### PR TITLE
Switch to charmed-etcd snap and publish to Charmhub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,16 +39,16 @@ jobs:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23.0.4
 
-#  release:
-#    name: Release charm
-#    needs:
-#      - ci-tests
-#      - build
-#    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v23.0.4
-#    with:
-#      channel: 3.5/edge
-#      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
-#    secrets:
-#      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
-#    permissions:
-#      contents: write  # Needed to create GitHub release
+  release:
+    name: Release charm
+    needs:
+      - ci-tests
+      - build
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v23.0.4
+    with:
+      channel: 3.5/edge
+      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
+    secrets:
+      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
+    permissions:
+      contents: write  # Needed to create GitHub release

--- a/src/common/client.py
+++ b/src/common/client.py
@@ -8,6 +8,8 @@ import json
 import logging
 import subprocess
 
+from literals import SNAP_NAME
+
 logger = logging.getLogger(__name__)
 
 
@@ -62,7 +64,7 @@ class EtcdClient:
         try:
             result = subprocess.run(
                 args=[
-                    "etcdctl",
+                    f"{SNAP_NAME}.etcdctl",
                     command,
                     subcommand,
                     f"--endpoints={endpoints}",

--- a/src/literals.py
+++ b/src/literals.py
@@ -10,12 +10,12 @@ from typing import Literal
 
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, StatusBase
 
-SNAP_NAME = "etcd"
-SNAP_REVISION = 233
+SNAP_NAME = "charmed-etcd"
+SNAP_REVISION = 1
 SNAP_SERVICE = "etcd"
 # this path will be updated when we switch to charmed-etcd snap
 # it's the current config path for the legacy-etcd snap
-CONFIG_FILE = "/var/snap/etcd/common/etcd.conf.yml"
+CONFIG_FILE = "/var/snap/charmed-etcd/current/etcd.conf.yml"
 
 PEER_RELATION = "etcd-peers"
 CLIENT_PORT = 2379

--- a/src/managers/config/etcd.conf.yml
+++ b/src/managers/config/etcd.conf.yml
@@ -1,3 +1,4 @@
+data-dir: "/var/snap/charmed-etcd/common/var/lib/etcd"
 initial-cluster-token: 'etcd-cluster'
 snapshot-count: 10000
 heartbeat-interval: 100

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import yaml
 from pytest_operator.plugin import OpsTest
 
-from literals import CLIENT_PORT
+from literals import CLIENT_PORT, SNAP_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ APP_NAME = METADATA["name"]
 
 def put_key(model: str, unit: str, endpoints: str, key: str, value: str) -> str:
     """Write data to etcd using `etcdctl` via `juju ssh`."""
-    etcd_command = f"etcdctl put {key} {value} --endpoints={endpoints}"
+    etcd_command = f"{SNAP_NAME}.etcdctl put {key} {value} --endpoints={endpoints}"
     juju_command = f"juju ssh --model={model} {unit} {etcd_command}"
 
     return subprocess.getoutput(juju_command).split("\n")[0]
@@ -28,7 +28,7 @@ def put_key(model: str, unit: str, endpoints: str, key: str, value: str) -> str:
 
 def get_key(model: str, unit: str, endpoints: str, key: str) -> str:
     """Read data from etcd using `etcdctl` via `juju ssh`."""
-    etcd_command = f"etcdctl get {key} --endpoints={endpoints}"
+    etcd_command = f"{SNAP_NAME}.etcdctl get {key} --endpoints={endpoints}"
     juju_command = f"juju ssh --model={model} {unit} {etcd_command}"
 
     return subprocess.getoutput(juju_command).split("\n")[1]
@@ -36,7 +36,7 @@ def get_key(model: str, unit: str, endpoints: str, key: str) -> str:
 
 def get_cluster_members(model: str, unit: str, endpoints: str) -> list[dict]:
     """Query all cluster members from etcd using `etcdctl` via `juju ssh`."""
-    etcd_command = f"etcdctl member list --endpoints={endpoints} -w=json"
+    etcd_command = f"{SNAP_NAME}.etcdctl member list --endpoints={endpoints} -w=json"
     juju_command = f"juju ssh --model={model} {unit} {etcd_command}"
 
     result = subprocess.getoutput(juju_command).split("\n")[0]


### PR DESCRIPTION
With this PR, we use revision 1 of the `charmed-etcd` snap instead of legacy `etcd` snap. Furthermore the PR enables the release-workflow for publishing to Charmhub `3.5/edge` on pushes to main.