### PR TITLE
[DPE-5950] fix charm name

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,7 +4,7 @@
 # This file is still required due to data-platform-workflows not supporting unified
 # charmcraft.yaml syntax. Details see:
 # https://github.com/canonical/data-platform-workflows/issues/169
-name: charmed-etcd-operator
+name: charmed-etcd
 title: Charmed etcd VM operator
 summary: Operator for etcd databases in VM environments.
 description: |


### PR DESCRIPTION
This PR updates the charm name in `metadata.yaml` according to the Charmhub registration: `charmed-etcd`.