### PR TITLE
[DPE-6160] block charm if password update fails

### DIFF
--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -172,7 +172,13 @@ class EtcdEvents(Object):
                         self.charm.state.cluster.update(
                             {f"{INTERNAL_USER}-password": new_password}
                         )
+                        self.charm.set_status(Status.ACTIVE)
                     except EtcdUserManagementError as e:
                         logger.error(e)
+                        self.charm.set_status(Status.PASSWORD_UPDATE_FAILED)
+            else:
+                logger.warning(f"Invalid username in secret {admin_secret_id}.")
+                self.charm.set_status(Status.PASSWORD_UPDATE_FAILED)
         except (ModelError, SecretNotFoundError) as e:
             logger.error(e)
+            self.charm.set_status(Status.PASSWORD_UPDATE_FAILED)

--- a/src/literals.py
+++ b/src/literals.py
@@ -45,6 +45,7 @@ class Status(Enum):
     AUTHENTICATION_NOT_ENABLED = StatusLevel(
         BlockedStatus("failed to enable authentication in etcd"), "ERROR"
     )
+    PASSWORD_UPDATE_FAILED = StatusLevel(BlockedStatus("failed to update password"), "ERROR")
     SERVICE_NOT_INSTALLED = StatusLevel(BlockedStatus("unable to install etcd snap"), "ERROR")
     SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("etcd service not running"), "ERROR")
     NO_PEER_RELATION = StatusLevel(MaintenanceStatus("no peer relation available"), "DEBUG")


### PR DESCRIPTION
This PR adds functionality to the charmed etcd operator to give feedback to users in case a password update fails. It will set the app and unit status to blocked status if:
- the password cannot be updated in etcd
- the secret has not been granted to the charmed etcd application
- the content of the secret is invalid (username other than `root`)