### PR TITLE
[DPE-6265] - Add poetry plugin export to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ pydantic = "^1.10, <2"
 cryptography = ">=42.0.5"
 jsonschema = "*"
 
+[tool.poetry.requires-plugins]
+poetry-plugin-export = ">=1.8"
+
 [tool.poetry.group.format]
 optional = true
 


### PR DESCRIPTION
This pull request includes a change to the `pyproject.toml` file. The change adds a new plugin requirement for `poetry-plugin-export`. The plugin is no longer installed by default starting in poetry 2.

Changes to dependencies:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R24-R26): Added the `poetry-plugin-export` plugin with a version requirement of ">=1.8".