### PR TITLE
[DPE-5964] - TLS certificate renewal

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -59,7 +59,7 @@ version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
 python-versions = ">=3.8"
-groups = ["charm-libs"]
+groups = ["charm-libs", "integration"]
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
@@ -1185,7 +1185,7 @@ version = "2.9.1"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
-groups = ["charm-libs"]
+groups = ["charm-libs", "integration"]
 files = [
     {file = "pydantic-2.9.1-py3-none-any.whl", hash = "sha256:7aff4db5fdf3cf573d4b3c30926a510a10e19a0774d38fc4967f78beb6deb612"},
     {file = "pydantic-2.9.1.tar.gz", hash = "sha256:1363c7d975c7036df0db2b4a61f2e062fbc0aa5ab5f2772e0ffc7191a4f4bce2"},
@@ -1209,7 +1209,7 @@ version = "2.23.3"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.8"
-groups = ["charm-libs"]
+groups = ["charm-libs", "integration"]
 files = [
     {file = "pydantic_core-2.23.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:7f10a5d1b9281392f1bf507d16ac720e78285dfd635b05737c3911637601bae6"},
     {file = "pydantic_core-2.23.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3c09a7885dd33ee8c65266e5aa7fb7e2f23d49d8043f089989726391dd7350c5"},
@@ -1967,4 +1967,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "7410a4ffbbca2c3501909375b1ae1fa8a35d279e4186c9ea82a05a8403a775d4"
+content-hash = "950ca6d67c1b3933b04d651e6d885840ef2460a5f117e87c37b9cdc0dc232e99"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ allure-pytest-collection-report = {git = "https://github.com/canonical/data-plat
 # see also: https://github.com/juju/python-libjuju/issues/1184
 websockets = "<14.0"
 tenacity = "*"
+pydantic = "==2.9.1"
 
 [tool.coverage.run]
 branch = true

--- a/src/literals.py
+++ b/src/literals.py
@@ -55,7 +55,7 @@ class Status(Enum):
     NO_PEER_RELATION = StatusLevel(MaintenanceStatus("no peer relation available"), "DEBUG")
     MISSING_TLS_RELATION = StatusLevel(BlockedStatus("missing tls relation"), "DEBUG")
     MISSING_CERTIFICATES = StatusLevel(MaintenanceStatus("missing certificates"), "DEBUG")
-    TLS_NOT_READY = StatusLevel(MaintenanceStatus("tls not ready"), "DEBUG")
+    TLS_NOT_READY = StatusLevel(MaintenanceStatus("enabling/disabling TLS"), "DEBUG")
     PEER_URL_NOT_SET = StatusLevel(MaintenanceStatus("peer-url not set"), "DEBUG")
     CLIENT_TLS_MISSING = StatusLevel(BlockedStatus("client tls relation missing"), "DEBUG")
     PEER_TLS_MISSING = StatusLevel(BlockedStatus("peer tls relation missing"), "DEBUG")

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -112,7 +112,7 @@ async def test_turning_off_tls(ops_test: OpsTest) -> None:
     assert model is not None
 
     # disable TLS and check if the cluster is still accessible
-    logger.info("Disbaling TLS by removing the TLS certificates")
+    logger.info("Disabling TLS by removing the TLS certificates")
     etcd_app: Application = ops_test.model.applications[APP_NAME]  # type: ignore
     await etcd_app.remove_relation("peer-certificates", f"{TLS_NAME}:certificates")
     await etcd_app.remove_relation("client-certificates", f"{TLS_NAME}:certificates")


### PR DESCRIPTION
This PR handeled the TLS certificate renewal.


### Enhancements to TLS Handling:
* Modified the `Status` enum in `src/literals.py` to update the message for `TLS_NOT_READY` to "enabling/disabling TLS" for better clarity.
* Updated the `_on_certificate_available` method in `src/events/tls.py` to only write the certificates to disk if TLS has already been enabled.

### Improvements to Tests:
* Added assertions to several test functions in `tests/integration/test_tls.py` to ensure that the leader unit and secrets are correctly retrieved. [[1]](diffhunk://#diff-d0fbf30f9fc8d4e2b961cdc1adf45385c53e4e091c3de0cdd2a1f882366ac444R61) [[2]](diffhunk://#diff-d0fbf30f9fc8d4e2b961cdc1adf45385c53e4e091c3de0cdd2a1f882366ac444R71) [[3]](diffhunk://#diff-d0fbf30f9fc8d4e2b961cdc1adf45385c53e4e091c3de0cdd2a1f882366ac444R118) [[4]](diffhunk://#diff-d0fbf30f9fc8d4e2b961cdc1adf45385c53e4e091c3de0cdd2a1f882366ac444R158) [[5]](diffhunk://#diff-d0fbf30f9fc8d4e2b961cdc1adf45385c53e4e091c3de0cdd2a1f882366ac444R167)
* Introduced a new test case `test_certificate_expiration` in `tests/integration/test_tls.py` to verify that the system correctly handles certificate expiration and renewal.

### Code Refinements:
* Added type hints to functions in `tests/integration/helpers.py` to improve code readability and maintainability. [[1]](diffhunk://#diff-e9349e06331f9876f984bcf05671235cfbe546046bccab6ad1abb0b183982b30L96-R104) [[2]](diffhunk://#diff-e9349e06331f9876f984bcf05671235cfbe546046bccab6ad1abb0b183982b30R118-R127)
* Imported `CertType` from `managers/tls` in `tests/integration/helpers.py` and `tests/integration/test_tls.py` to support the new test case and helper function. [[1]](diffhunk://#diff-e9349e06331f9876f984bcf05671235cfbe546046bccab6ad1abb0b183982b30R15) [[2]](diffhunk://#diff-d0fbf30f9fc8d4e2b961cdc1adf45385c53e4e091c3de0cdd2a1f882366ac444R6-R17)

### Dependency Update:
* Added `pydantic` version 2.9.1 to integration dependencies.