### PR TITLE
[DPE-6421] Add storage for data and logs

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,8 +24,6 @@ storage:
     minimum-size: 1G
   logs:
     type: filesystem
-    # location to be adjusted when adding file logging to etcd
-    # for now, we use the default
     location: /var/snap/charmed-etcd/common/var/log/etcd
     description: storage for logfiles of etcd server
     minimum-size: 1G

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,3 +15,17 @@ description: |
 peers:
   etcd-peers:
     interface: etcd_peers
+
+storage:
+  data:
+    type: filesystem
+    location: /var/snap/charmed-etcd/common/var/lib/etcd
+    description: storage for etcd data
+    minimum-size: 1G
+  logs:
+    type: filesystem
+    # location to be adjusted when adding file logging to etcd
+    # for now, we use the default
+    location: /var/snap/charmed-etcd/common/var/log/etcd
+    description: storage for logfiles of etcd server
+    minimum-size: 1G

--- a/src/managers/config/etcd.conf.yml
+++ b/src/managers/config/etcd.conf.yml
@@ -1,4 +1,7 @@
 data-dir: "/var/snap/charmed-etcd/common/var/lib/etcd"
+log-outputs: ["/var/snap/charmed-etcd/common/var/log/etcd/etcd.log"]
+enable-log-rotation: true
+log-rotation-config-json: '{"maxsize": 100, "maxage": 0, "maxbackups": 0, "localtime": false, "compress": false}'
 initial-cluster-token: 'etcd-cluster'
 snapshot-count: 10000
 heartbeat-interval: 100

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -117,6 +117,25 @@ def test_update_status():
         state_out = ctx.run(ctx.on.update_status(), state_in)
         assert state_out.unit_status == ops.BlockedStatus("etcd service not running")
 
+    # test data storage
+    # Set up storage with some content:
+    data_storage = testing.Storage("data")
+    (data_storage.get_filesystem(ctx) / "myfile.data").write_text("helloworld")
+
+    with patch("workload.EtcdWorkload.alive", return_value=True):
+        with ctx(ctx.on.update_status(), testing.State(storages=[data_storage])) as context:
+            data = context.charm.model.storages["data"][0]
+            data_loc = data.location
+            data_path = data_loc / "myfile.data"
+            assert data_path.exists()
+            assert data_path.read_text() == "helloworld"
+
+            test_file = data_loc / "test.txt"
+            test_file.write_text("test_line")
+
+    # Verify that writing the file did work as expected.
+    assert (data_storage.get_filesystem(ctx) / "test.txt").read_text() == "test_line"
+
 
 def test_peer_relation_created():
     test_data = {"hostname": "my_hostname", "ip": "my_ip"}


### PR DESCRIPTION
This PR adds a storage configuration to the charmed etcd operator.

We will have two storage mounts:
- for data in `/var/snap/charmed-etcd/common/var/lib/etcd`
- for log files in `/var/snap/charmed-etcd/common/var/log/etcd`

In addition we enable logfile output and logfile rotation in etcd.