### PR TITLE
adjust release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
   pull_request:
   schedule:
     - cron: '53 0 * * *'  # Daily at 00:53 UTC
-  # Triggered on push to branch "main" by .github/workflows/release.yaml
+  # Triggered on push to default branch by .github/workflows/release.yaml
   workflow_call:
     outputs:
       artifact-prefix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ name: Release to Charmhub
 on:
   push:
     branches:
-      - main
+      - 3.5/edge
 
 jobs:
   ci-tests:


### PR DESCRIPTION
PR to change the release workflow; it will now run on pushes to branch `3.5/edge` after main is no longer the default branch.