### PR TITLE
Clean tox etcd install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ last_written_value
 client.pem
 client.key
 client_ca.pem
+coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -78,10 +78,10 @@ commands_pre =
     # workaround to install etcdctl from release archive
     # in 22.04 only etcdctl v3.3.25 is included, which is incompatible to v3.4.x
     # this workaround will be removed once we can run on "noble" runners
-    sudo apt-get install wget
-    wget https://github.com/etcd-io/etcd/releases/download/v3.4.35/etcd-v3.4.35-linux-amd64.tar.gz
-    tar xvf etcd-v3.4.35-linux-amd64.tar.gz
-    sudo mv etcd-v3.4.35-linux-amd64/etcdctl /usr/local/bin
+    sudo apt install wget -y
+    wget https://github.com/etcd-io/etcd/releases/download/v3.4.35/etcd-v3.4.35-linux-amd64.tar.gz -P /tmp/etcd_install/
+    tar -xvf /tmp/etcd_install/etcd-v3.4.35-linux-amd64.tar.gz -C /tmp/etcd_install/
+    sudo mv /tmp/etcd_install/etcd-v3.4.35-linux-amd64/etcdctl /usr/local/bin
 commands =
     # https://github.com/canonical/data-platform-workflows/blob/main/python/pytest_plugins/pytest_operator_cache/deprecation_notice.md
     sh -c "if [ -z "$CI" ]; then charmcraft pack; fi;"


### PR DESCRIPTION
This pull request includes changes to the `tox.ini` file to improve the installation process of `etcdctl` by using a temporary directory for downloads and extraction. This change enhances the script's reliability and cleanliness.

Improvements to the installation process:

* [`tox.ini`](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L81-R84): Changed the installation commands for `etcdctl` to use a temporary directory for downloading and extracting the archive, ensuring a cleaner and more reliable installation process.