### PR TITLE
connect to all cluster endpoints when broadcasting peer URL

### DIFF
--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -132,7 +132,7 @@ class ClusterManager:
         client = EtcdClient(
             username=self.admin_user,
             password=self.admin_password,
-            client_url=self.state.unit_server.client_url,
+            client_url=",".join(e for e in self.cluster_endpoints),
         )
         client.broadcast_peer_url(self.state.unit_server.client_url, self.member.id, peer_urls)
 


### PR DESCRIPTION
When broadcasting an updated peer URL during the peer TLS transition, it could happen that connection errors appear when connecting to the local instance with TLS (because client cert files have been removed by the separate client TLS disabling hook).  This has been observed [here](https://github.com/canonical/charmed-etcd-operator/actions/runs/13258167474/job/37008789433?pr=36).

To work around that, we could connect to all endpoints instead of just the local one.