### PR TITLE
[DPE-6568] add self-healing for network cuts

### DIFF
--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -63,13 +63,14 @@ the CLI:
 juju run-action some-charm/0 some-charm/1 <... some-charm/n> restart
 ```
 
-Note that all units that plan to restart must receive the action and emit the aquire
+Note that all units that plan to restart must receive the action and emit the acquire
 event. Any units that do not run their acquire handler will be left out of the rolling
 restart. (An operator might take advantage of this fact to recover from a failed rolling
 operation without restarting workloads that were able to successfully restart -- simply
 omit the successful units from a subsequent run-action call.)
 
 """
+
 import logging
 from enum import Enum
 from typing import AnyStr, Callable, Optional
@@ -88,7 +89,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 class LockNoRelationError(Exception):
@@ -149,7 +150,6 @@ class Lock:
     """
 
     def __init__(self, manager, unit=None):
-
         self.relation = manager.model.relations[manager.name][0]
         if not self.relation:
             # TODO: defer caller in this case (probably just fired too soon).
@@ -246,7 +246,7 @@ class Locks:
 
         # Gather all the units.
         relation = manager.model.relations[manager.name][0]
-        units = [unit for unit in relation.units]
+        units = list(relation.units)
 
         # Plus our unit ...
         units.append(manager.model.unit)

--- a/src/common/client.py
+++ b/src/common/client.py
@@ -359,7 +359,7 @@ class EtcdClient:
         logger.debug("Health check passed.")
         return True
 
-    def broadcast_peer_url(self, endpoints: str, member_id: str, peer_urls: str) -> None:
+    def broadcast_peer_url(self, member_id: str, peer_urls: str) -> None:
         """Broadcast the peer URL to all units in the cluster.
 
         Args:
@@ -370,7 +370,7 @@ class EtcdClient:
         self._run_etcdctl(
             command="member",
             subcommand="update",
-            endpoints=endpoints,
+            endpoints=self.client_url,
             auth_username=self.user,
             auth_password=self.password,
             member=member_id,

--- a/src/common/client.py
+++ b/src/common/client.py
@@ -363,7 +363,6 @@ class EtcdClient:
         """Broadcast the peer URL to all units in the cluster.
 
         Args:
-            endpoints (str): The endpoints to run the command against.
             member_id (str): The member ID to broadcast the peer URL for.
             peer_urls (str): The peer URLs to broadcast.
         """

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -142,6 +142,9 @@ class EtcdEvents(Object):
             if not self.charm.cluster_manager.restart_member(move_leader=False):
                 raise HealthCheckFailedError("Failed to check health of the member after restart")
 
+            if self.charm.unit.is_leader():
+                self.charm.cluster_manager.update_cluster_member_state()
+
             # update tls certificates with new ip address
             if self.charm.state.unit_server.tls_client_state in (
                 TLSState.TO_TLS,

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -108,7 +108,7 @@ class ClusterManager:
         client = EtcdClient(
             username=self.admin_user,
             password=self.admin_password,
-            client_url=self.state.unit_server.client_url,
+            client_url=",".join(e for e in self.cluster_endpoints),
         )
 
         member_list = client.member_list()
@@ -134,7 +134,7 @@ class ClusterManager:
             password=self.admin_password,
             client_url=",".join(e for e in self.cluster_endpoints),
         )
-        client.broadcast_peer_url(self.state.unit_server.client_url, self.member.id, peer_urls)
+        client.broadcast_peer_url(self.member.id, peer_urls)
 
     def is_healthy(self, cluster: bool = True) -> bool:
         """Run the `endpoint health` command and return True if healthy.

--- a/tests/integration/ha/helpers_network.py
+++ b/tests/integration/ha/helpers_network.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""This helpers-file could be replaced by the `data_platform_helpers`.
+
+Prerequisite: PR https://github.com/canonical/data-platform-helpers/pull/12 has been merged
+"""
+
+import logging
+import subprocess
+
+import yaml
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+async def hostname_from_unit(ops_test: OpsTest, unit_name: str) -> str:
+    """Get the machine hostname from a specific unit.
+
+    Args:
+        ops_test: The ops test framework instance
+        unit_name: The name of the unit to get the machine
+
+    Returns:
+        The hostname of the machine.
+    """
+    run_command = ["exec", "--unit", unit_name, "--", "hostname"]
+    _, hostname, _ = await ops_test.juju(*run_command)
+
+    return hostname.strip()
+
+
+async def get_controller_hostname(ops_test: OpsTest) -> str:
+    """Return controller machine hostname."""
+    _, raw_controller, _ = await ops_test.juju("show-controller")
+
+    controller = yaml.safe_load(raw_controller.strip())
+
+    return [
+        machine.get("instance-id")
+        for machine in controller[ops_test.controller_name]["controller-machines"].values()
+    ][0]
+
+
+def cut_network_from_unit_with_ip_change(machine_name: str) -> None:
+    """Cut network from a lxc container in a way the changes the IP."""
+    # apply a mask (device type `none`)
+    cut_network_command = f"lxc config device add {machine_name} eth0 none"
+    subprocess.check_call(cut_network_command.split())
+
+
+def cut_network_from_unit_without_ip_change(machine_name: str) -> None:
+    """Cut network from a lxc container (without causing the change of the unit IP address)."""
+    override_command = f"lxc config device override {machine_name} eth0"
+    try:
+        subprocess.check_call(override_command.split())
+    except subprocess.CalledProcessError:
+        # Ignore if the interface was already overridden.
+        pass
+
+    limit_set_command = f"lxc config device set {machine_name} eth0 limits.egress=0kbit"
+    subprocess.check_call(limit_set_command.split())
+    limit_set_command = f"lxc config device set {machine_name} eth0 limits.ingress=1kbit"
+    subprocess.check_call(limit_set_command.split())
+    limit_set_command = f"lxc config device set {machine_name} eth0 limits.priority=10"
+    subprocess.check_call(limit_set_command.split())
+
+
+def restore_network_for_unit_with_ip_change(machine_name: str) -> None:
+    """Restore network from a lxc container by removing mask from eth0."""
+    restore_network_command = f"lxc config device remove {machine_name} eth0"
+    subprocess.check_call(restore_network_command.split())
+
+
+def restore_network_for_unit_without_ip_change(machine_name: str) -> None:
+    """Restore network from a lxc container (without causing the change of the unit IP address)."""
+    limit_set_command = f"lxc config device set {machine_name} eth0 limits.egress="
+    subprocess.check_call(limit_set_command.split())
+    limit_set_command = f"lxc config device set {machine_name} eth0 limits.ingress="
+    subprocess.check_call(limit_set_command.split())
+    limit_set_command = f"lxc config device set {machine_name} eth0 limits.priority="
+    subprocess.check_call(limit_set_command.split())
+
+
+def is_unit_reachable(from_host: str, to_host: str) -> bool:
+    """Test network reachability between hosts."""
+    ping = subprocess.call(
+        f"lxc exec {from_host} -- ping -c 5 {to_host}".split(),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return ping == 0

--- a/tests/integration/ha/helpers_network.py
+++ b/tests/integration/ha/helpers_network.py
@@ -32,6 +32,22 @@ async def hostname_from_unit(ops_test: OpsTest, unit_name: str) -> str:
     return hostname.strip()
 
 
+async def ip_address_from_unit(ops_test: OpsTest, unit_name: str) -> str:
+    """Get the machine ip address from a specific unit.
+
+    Args:
+        ops_test: The ops test framework instance
+        unit_name: The name of the unit to get the machine
+
+    Returns:
+        The ip address of the machine.
+    """
+    run_command = ["exec", "--unit", unit_name, "--", "hostname", "-i"]
+    _, ip_address, _ = await ops_test.juju(*run_command)
+
+    return ip_address.strip()
+
+
 async def get_controller_hostname(ops_test: OpsTest) -> str:
     """Return controller machine hostname."""
     _, raw_controller, _ = await ops_test.juju("show-controller")

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -30,10 +30,12 @@ from .helpers import (
     stop_continuous_writes,
 )
 from .helpers_network import (
+    cut_network_from_unit_with_ip_change,
     cut_network_from_unit_without_ip_change,
     get_controller_hostname,
     hostname_from_unit,
     is_unit_reachable,
+    restore_network_for_unit_with_ip_change,
     restore_network_for_unit_without_ip_change,
 )
 
@@ -56,6 +58,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000)
 
 
+@pytest.mark.skip()
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -124,6 +127,104 @@ async def test_network_cut_on_raft_leader_without_ip_change(ops_test: OpsTest) -
 
     # reconnect the network for the disconnected unit
     restore_network_for_unit_without_ip_change(leader_hostname)
+    logger.info(f"Network restored for {leader_unit}")
+
+    await wait_until(
+        ops_test,
+        apps=[app],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units=init_units_count,
+    )
+
+    # ensure the member is up again
+    assert is_endpoint_up(unit_endpoint, user=INTERNAL_USER, password=password)
+    logger.info(f"{leader_unit} is available again.")
+
+    cluster_members = get_cluster_members(endpoints)
+    assert len(cluster_members) == init_units_count, (
+        f"expected {init_units_count} cluster members, got {len(cluster_members)}"
+    )
+    logger.info(f"Cluster fully formed again with {len(cluster_members)} members.")
+
+    # ensure data is written in the cluster
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    stop_continuous_writes()
+    # By default, etcd uses a 1s election timeout before attempting to replace a lost leader
+    # that's why we will miss writes here, and therefore ignore the revision of the key
+    assert_continuous_writes_consistent(
+        endpoints=endpoints, user=INTERNAL_USER, password=password, ignore_revision=True
+    )
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_network_cut_on_raft_leader_with_ip_change(ops_test: OpsTest) -> None:
+    """Make sure the cluster can self-heal and the unit reconfigures after network disconnect."""
+    app = (await existing_app(ops_test)) or APP_NAME
+
+    # make sure we have at least two units so we can stop one of them
+    if len(ops_test.model.applications[app].units) < 2:
+        await ops_test.model.applications[app].add_unit(count=1)
+        await wait_until(
+            ops_test,
+            apps=[app],
+            apps_statuses=["active"],
+            units_statuses=["active"],
+            wait_for_exact_units=2,
+        )
+
+    init_units_count = len(ops_test.model.applications[app].units)
+    endpoints = get_cluster_endpoints(ops_test, app)
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{app}.app")
+    password = secret.get(f"{INTERNAL_USER}-password")
+
+    # start writing data to the cluster
+    start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    time.sleep(10)
+
+    # get details for the current raft leader in the cluster
+    initial_raft_leader = get_raft_leader(endpoints=endpoints)
+    logger.info(f"initial raft leader: {initial_raft_leader}")
+    leader_unit = initial_raft_leader.replace(app, f"{app}/")
+
+    # cut network from the current cluster/raft leader
+    leader_hostname = await hostname_from_unit(ops_test, unit_name=leader_unit)
+    cut_network_from_unit_with_ip_change(leader_hostname)
+
+    # make sure the unit is not reachable from the other units
+    for unit in ops_test.model.applications[app].units:
+        hostname = await hostname_from_unit(ops_test, unit.name)
+        assert not is_unit_reachable(hostname, leader_hostname)
+
+    # make sure the unit is not reachable from the controller
+    controller_hostname = await get_controller_hostname(ops_test)
+    assert not is_unit_reachable(controller_hostname, leader_hostname)
+    logger.info(f"{leader_unit} is not reachable via network.")
+
+    # verify the cluster member is not up anymore
+    unit_endpoint = get_unit_endpoint(ops_test, unit_name=leader_unit, app_name=app)
+    assert not is_endpoint_up(unit_endpoint, user=INTERNAL_USER, password=password)
+    logger.info(f"etcd endpoint on {leader_unit} is not available.")
+
+    # as the stopped member is unresponsive, only query the endpoints still available
+    remaining_endpoints = get_remaining_endpoints(endpoints, unit_endpoint)
+
+    # ensure a new leader was assigned after waiting for the `election timeout`
+    new_raft_leader = get_raft_leader(endpoints=remaining_endpoints)
+    logger.info(f"new raft leader: {new_raft_leader}")
+    assert new_raft_leader != initial_raft_leader, (
+        "raft leadership not transferred after network disconnect of the leader"
+    )
+
+    # ensure data is continuing to be written in the cluster
+    assert_continuous_writes_increasing(
+        endpoints=remaining_endpoints, user=INTERNAL_USER, password=password
+    )
+
+    # reconnect the network for the disconnected unit
+    restore_network_for_unit_with_ip_change(leader_hostname)
     logger.info(f"Network restored for {leader_unit}")
 
     await wait_until(

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -47,7 +47,7 @@ NUM_UNITS = 3
 TLS_NAME = "self-signed-certificates"
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
@@ -61,7 +61,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000)
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_network_cut_on_raft_leader_without_ip_change(ops_test: OpsTest) -> None:
@@ -159,7 +159,7 @@ async def test_network_cut_on_raft_leader_without_ip_change(ops_test: OpsTest) -
     )
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_network_cut_on_raft_leader_with_ip_change(ops_test: OpsTest) -> None:

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -236,20 +236,22 @@ async def test_network_cut_on_raft_leader_with_ip_change(ops_test: OpsTest) -> N
     )
 
     # ensure the member is up again
-    assert is_endpoint_up(unit_endpoint, user=INTERNAL_USER, password=password)
+    unit_endpoint_updated = get_unit_endpoint(ops_test, unit_name=leader_unit, app_name=app)
+    assert is_endpoint_up(unit_endpoint_updated, user=INTERNAL_USER, password=password)
     logger.info(f"{leader_unit} is available again.")
 
-    cluster_members = get_cluster_members(endpoints)
+    endpoints_updated = get_cluster_endpoints(ops_test, app)
+    cluster_members = get_cluster_members(endpoints_updated)
     assert len(cluster_members) == init_units_count, (
         f"expected {init_units_count} cluster members, got {len(cluster_members)}"
     )
     logger.info(f"Cluster fully formed again with {len(cluster_members)} members.")
 
     # ensure data is written in the cluster
-    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    assert_continuous_writes_increasing(endpoints=endpoints_updated, user=INTERNAL_USER, password=password)
     stop_continuous_writes()
     # By default, etcd uses a 1s election timeout before attempting to replace a lost leader
     # that's why we will miss writes here, and therefore ignore the revision of the key
     assert_continuous_writes_consistent(
-        endpoints=endpoints, user=INTERNAL_USER, password=password, ignore_revision=True
+        endpoints=endpoints_updated, user=INTERNAL_USER, password=password, ignore_revision=True
     )

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import time
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from literals import INTERNAL_USER, PEER_RELATION
+
+from ..helpers import (
+    APP_NAME,
+    CHARM_PATH,
+    get_cluster_endpoints,
+    get_cluster_members,
+    get_raft_leader,
+    get_remaining_endpoints,
+    get_secret_by_label,
+    get_unit_endpoint,
+    is_endpoint_up,
+)
+from ..helpers_deployment import wait_until
+from .helpers import (
+    assert_continuous_writes_consistent,
+    assert_continuous_writes_increasing,
+    existing_app,
+    start_continuous_writes,
+    stop_continuous_writes,
+)
+from .helpers_network import (
+    cut_network_from_unit_without_ip_change,
+    get_controller_hostname,
+    hostname_from_unit,
+    is_unit_reachable,
+    restore_network_for_unit_without_ip_change,
+)
+
+logger = logging.getLogger(__name__)
+
+NUM_UNITS = 3
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest) -> None:
+    """Build and deploy the charm, allowing for skipping if already deployed."""
+    # it is possible for users to provide their own cluster for HA testing.
+    if await existing_app(ops_test):
+        return
+
+    # Deploy the charm and wait for active/idle status
+    await ops_test.model.deploy(CHARM_PATH, num_units=NUM_UNITS)
+    await wait_until(ops_test, apps=[APP_NAME], timeout=1000)
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_network_cut_on_raft_leader_without_ip_change(ops_test: OpsTest) -> None:
+    """Make sure the cluster can self-heal and the unit reconfigures after network disconnect."""
+    app = (await existing_app(ops_test)) or APP_NAME
+
+    # make sure we have at least two units so we can stop one of them
+    if len(ops_test.model.applications[app].units) < 2:
+        await ops_test.model.applications[app].add_unit(count=1)
+        await wait_until(
+            ops_test,
+            apps=[app],
+            apps_statuses=["active"],
+            units_statuses=["active"],
+            wait_for_exact_units=2,
+        )
+
+    init_units_count = len(ops_test.model.applications[app].units)
+    endpoints = get_cluster_endpoints(ops_test, app)
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{app}.app")
+    password = secret.get(f"{INTERNAL_USER}-password")
+
+    # start writing data to the cluster
+    start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    time.sleep(10)
+
+    # get details for the current raft leader in the cluster
+    initial_raft_leader = get_raft_leader(endpoints=endpoints)
+    logger.info(f"initial raft leader: {initial_raft_leader}")
+    leader_unit = initial_raft_leader.replace(app, f"{app}/")
+
+    # cut network from the current cluster/raft leader
+    leader_hostname = await hostname_from_unit(ops_test, unit_name=leader_unit)
+    cut_network_from_unit_without_ip_change(leader_hostname)
+
+    # make sure the unit is not reachable from the other units
+    for unit in ops_test.model.applications[app].units:
+        hostname = await hostname_from_unit(ops_test, unit.name)
+        assert not is_unit_reachable(hostname, leader_hostname)
+
+    # make sure the unit is not reachable from the controller
+    controller_hostname = await get_controller_hostname(ops_test)
+    assert not is_unit_reachable(controller_hostname, leader_hostname)
+    logger.info(f"{leader_unit} is not reachable via network.")
+
+    # verify the cluster member is not up anymore
+    unit_endpoint = get_unit_endpoint(ops_test, unit_name=leader_unit, app_name=app)
+    assert not is_endpoint_up(unit_endpoint, user=INTERNAL_USER, password=password)
+    logger.info(f"etcd endpoint on {leader_unit} is not available.")
+
+    # as the stopped member is unresponsive, only query the endpoints still available
+    remaining_endpoints = get_remaining_endpoints(endpoints, unit_endpoint)
+
+    # ensure a new leader was assigned after waiting for the `election timeout`
+    new_raft_leader = get_raft_leader(endpoints=remaining_endpoints)
+    logger.info(f"new raft leader: {new_raft_leader}")
+    assert new_raft_leader != initial_raft_leader, (
+        "raft leadership not transferred after network disconnect of the leader"
+    )
+
+    # ensure data is continuing to be written in the cluster
+    assert_continuous_writes_increasing(
+        endpoints=remaining_endpoints, user=INTERNAL_USER, password=password
+    )
+
+    # reconnect the network for the disconnected unit
+    restore_network_for_unit_without_ip_change(leader_hostname)
+    logger.info(f"Network restored for {leader_unit}")
+
+    await wait_until(
+        ops_test,
+        apps=[app],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units=init_units_count,
+    )
+
+    # ensure the member is up again
+    assert is_endpoint_up(unit_endpoint, user=INTERNAL_USER, password=password)
+    logger.info(f"{leader_unit} is available again.")
+
+    cluster_members = get_cluster_members(endpoints)
+    assert len(cluster_members) == init_units_count, (
+        f"expected {init_units_count} cluster members, got {len(cluster_members)}"
+    )
+    logger.info(f"Cluster fully formed again with {len(cluster_members)} members.")
+
+    # ensure data is written in the cluster
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    stop_continuous_writes()
+    # By default, etcd uses a 1s election timeout before attempting to replace a lost leader
+    # that's why we will miss writes here, and therefore ignore the revision of the key
+    assert_continuous_writes_consistent(
+        endpoints=endpoints, user=INTERNAL_USER, password=password, ignore_revision=True
+    )

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -248,7 +248,9 @@ async def test_network_cut_on_raft_leader_with_ip_change(ops_test: OpsTest) -> N
     logger.info(f"Cluster fully formed again with {len(cluster_members)} members.")
 
     # ensure data is written in the cluster
-    assert_continuous_writes_increasing(endpoints=endpoints_updated, user=INTERNAL_USER, password=password)
+    assert_continuous_writes_increasing(
+        endpoints=endpoints_updated, user=INTERNAL_USER, password=password
+    )
     stop_continuous_writes()
     # By default, etcd uses a 1s election timeout before attempting to replace a lost leader
     # that's why we will miss writes here, and therefore ignore the revision of the key

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -61,7 +61,6 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000)
 
 
-@pytest.mark.skip()
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -243,7 +243,13 @@ def test_config_changed():
         leader=True,
     )
 
-    with patch("subprocess.run"):
+    with (
+        patch("subprocess.run"),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("common.client.EtcdClient.broadcast_peer_url"),
+        patch("workload.EtcdWorkload.write_file"),
+        patch("managers.cluster.ClusterManager.restart_member", return_value=True),
+    ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
         secret_out = state_out.get_secret(label=f"{PEER_RELATION}.{APP_NAME}.app")
         assert secret_out.latest_content.get(f"{INTERNAL_USER}-password") == secret_value
@@ -351,14 +357,16 @@ def test_peer_relation_changed():
         promote_learning_member.assert_called_once()
         assert state_out.deferred[0].name == "etcd_peers_relation_changed"
 
-    with patch("common.client.EtcdClient._run_etcdctl") as run_etcdctl:
+    with (
+        patch("common.client.EtcdClient._run_etcdctl") as run_etcdctl,
+        patch("managers.cluster.ClusterManager.update_cluster_member_state"),
+    ):
         state_out = ctx.run(ctx.on.relation_changed(relation=relation), state_in)
         assert relation.local_app_data.get("learning_member") is None
         assert (
             relation.local_app_data.get("cluster_members")
             == "charmed-etcd0=http://ip0:2380,charmed-etcd1=http://ip1:2380"
         )
-        run_etcdctl.assert_called_once()
         run_etcdctl_args = run_etcdctl.call_args[1]
         assert run_etcdctl_args["command"] == "member"
         assert run_etcdctl_args["subcommand"] == "promote"

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -730,6 +730,10 @@ def test_set_tls_private_key():
         patch(
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4._find_available_certificates"
         ),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("common.client.EtcdClient.broadcast_peer_url"),
+        patch("workload.EtcdWorkload.write_file"),
+        patch("managers.cluster.ClusterManager.restart_member", return_value=True),
     ):
         # Configure peer private key configured
         state_in = testing.State(


### PR DESCRIPTION
With this PR we add self-healing functionality for network cuts with changed ip-address to the etcd-operator.

**EtcdEvents:**
- the `config_changed` handler will update the etcd cluster configuration and request new TLS certificates if it detects a change of ip address
- the `peer_relation_changed` handler on the Juju leader unit will by notified by an updated ip address in the peer unit databag and will update the cluster state information in the application databag

**Integration tests:**
added a new integration test file `test_network_cut.py` to conduct these tests:
- `test_network_cut_on_raft_leader_without_ip_change`
- `test_network_cut_on_raft_leader_with_ip_change`

added the following test helpers: 
- `hostname_from_unit`, 
- `ip_address_from_unit` 
- `get_controller_hostname`
- `cut_network_from_unit_with_ip_change`
- `cut_network_from_unit_without_ip_change`
- `restore_network_for_unit_with_ip_change`
- `restore_network_for_unit_without_ip_change`
- `is_unit_reachable`

**Notes and fixes:**
- updated the `rolling_ops` lib to v0.8
- updated `broadcast_peer_url()` in `EtcdClient` to use the client's url property instead of the `endpoints` parameter passed to the method (for consistency with all other methods)
- updated `member` property of the `ClusterManager` to query the member list from all cluster endpoints, not just the current unit