### PR TITLE
[DPE-6568] Raise error if enabling auth fails

### DIFF
--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -92,7 +92,7 @@ class EtcdEvents(Object):
             self.charm.set_status(Status.SERVICE_NOT_INSTALLED)
             return
 
-    def _on_start(self, event: ops.StartEvent) -> None:
+    def _on_start(self, event: ops.StartEvent) -> None:  # noqa: C901
         """Handle start event."""
         tls_transition_states = [TLSState.TO_TLS, TLSState.TO_NO_TLS]
         if (
@@ -130,6 +130,9 @@ class EtcdEvents(Object):
             in self.charm.state.cluster.cluster_members
         ):
             # this unit has been added to the etcd cluster
+            if not self.charm.state.cluster.auth_enabled:
+                raise EtcdAuthNotEnabledError("Authentication not enabled.")
+
             if self.charm.workload.exists(DATABASE_DIR):
                 logger.warning(f"Existing database file detected in {DATABASE_DIR}.")
                 # storage cannot be reused on non-leader members

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -124,8 +124,7 @@ class EtcdEvents(Object):
                     self.charm.state.cluster.update({"authentication": "enabled"})
                 except (EtcdAuthNotEnabledError, EtcdUserManagementError) as e:
                     logger.error(e)
-                    self.charm.set_status(Status.AUTHENTICATION_NOT_ENABLED)
-                    return
+                    raise
         elif (
             self.charm.state.unit_server.member_endpoint
             in self.charm.state.cluster.cluster_members

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -8,7 +8,7 @@ import logging
 import socket
 from json import JSONDecodeError
 
-from tenacity import retry, stop_after_attempt, wait_random_exponential
+from tenacity import retry, stop_after_attempt, wait_random_exponential, wait_fixed
 
 from common.client import EtcdClient
 from common.exceptions import (
@@ -67,6 +67,11 @@ class ClusterManager:
         except (KeyError, JSONDecodeError) as e:
             raise RaftLeaderNotFoundError(f"No raft leader found: {e}")
 
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(1),
+        reraise=True,
+    )
     def enable_authentication(self) -> None:
         """Enable the etcd admin user and authentication."""
         try:

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -8,7 +8,7 @@ import logging
 import socket
 from json import JSONDecodeError
 
-from tenacity import retry, stop_after_attempt, wait_random_exponential, wait_fixed
+from tenacity import retry, stop_after_attempt, wait_fixed, wait_random_exponential
 
 from common.client import EtcdClient
 from common.exceptions import (

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -189,11 +189,9 @@ def test_start():
     with (
         patch("workload.EtcdWorkload.start") as start,
         patch("workload.EtcdWorkload.write_file"),
-        patch("workload.EtcdWorkload.alive", return_value=True),
     ):
         with raises(testing.errors.UncaughtCharmError) as e:
             state_out = ctx.run(ctx.on.start(), state_in)
-            assert state_out.unit_status == ops.ActiveStatus()
             assert not state_out.get_relation(1).local_unit_data.get("state") == "started"
             start.assert_not_called()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,7 +13,11 @@ from ops import testing
 from pytest import raises
 
 from charm import EtcdOperatorCharm
-from common.exceptions import EtcdAuthNotEnabledError, EtcdClusterManagementError, EtcdUserManagementError
+from common.exceptions import (
+    EtcdAuthNotEnabledError,
+    EtcdClusterManagementError,
+    EtcdUserManagementError,
+)
 from core.models import Member
 from literals import CLIENT_PORT, INTERNAL_USER, INTERNAL_USER_PASSWORD_CONFIG, PEER_RELATION
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -193,8 +193,8 @@ def test_start():
         with raises(testing.errors.UncaughtCharmError) as e:
             state_out = ctx.run(ctx.on.start(), state_in)
             assert not state_out.get_relation(1).local_unit_data.get("state") == "started"
-            start.assert_not_called()
 
+        start.assert_not_called()
         assert isinstance(e.value.__cause__, EtcdAuthNotEnabledError)
 
 


### PR DESCRIPTION
Currently the etcd operator does not raise an error if enabling authentication on cluster startup fails. This could happen for example if the `etcdctl` command times out because of high load on the machine.

To make sure we do not start an unprotected cluster, the `on_start` hook should fail if authentication can not be enabled.

The changes in this PR include:

**EtcdEvents:**
- fail the `on_start` hook for the first unit in the cluster, if the admin user can not be created or authentication can not be enabled in the cluster
- fail the `on_start` hook for subsequent units if authentication is not enabled

**Unit tests:**
- add new test cases for unhappy path (when enabling authentication fails) on startup