### PR TITLE
[DPE-6700] stabilization and add test for forcefull restart with deleted data

### DIFF
--- a/src/common/client.py
+++ b/src/common/client.py
@@ -260,6 +260,7 @@ class EtcdClient:
             if use_input:
                 args.append("--interactive=False")
             # we append the TLS params whenever we find a client certificate
+            # todo: this is not substrate-agnostic
             if os.path.exists(f"{TLS_ROOT_DIR}/client.pem"):
                 args.append(f"--cert={TLS_ROOT_DIR}/client.pem")
                 args.append(f"--key={TLS_ROOT_DIR}/client.key")

--- a/src/common/client.py
+++ b/src/common/client.py
@@ -6,6 +6,7 @@
 
 import json
 import logging
+import os
 import subprocess
 from typing import Tuple
 
@@ -258,7 +259,8 @@ class EtcdClient:
                 args.append(f"-w={output_format}")
             if use_input:
                 args.append("--interactive=False")
-            if "https" in endpoints:
+            # we append the TLS params whenever we find a client certificate
+            if os.path.exists(f"{TLS_ROOT_DIR}/client.pem"):
                 args.append(f"--cert={TLS_ROOT_DIR}/client.pem")
                 args.append(f"--key={TLS_ROOT_DIR}/client.key")
                 args.append(f"--cacert={TLS_ROOT_DIR}/client_ca.pem")

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -132,8 +132,8 @@ class EtcdEvents(Object):
         ):
             # this unit has been added to the etcd cluster
             if not self.charm.state.cluster.auth_enabled:
+                # failed start hooks on cluster initialization will go here on retry
                 if self.charm.unit.is_leader():
-                    # if enabling auth failed on first cluster startup, we want to retry now
                     try:
                         self.charm.cluster_manager.enable_authentication()
                         self.charm.state.cluster.update({"authentication": "enabled"})
@@ -143,19 +143,21 @@ class EtcdEvents(Object):
                 else:
                     raise EtcdAuthNotEnabledError("Authentication not enabled.")
 
-            if self.charm.workload.exists(DATABASE_DIR):
-                logger.warning(f"Existing database file detected in {DATABASE_DIR}.")
-                # storage cannot be reused on non-leader members
-                try:
-                    self.charm.workload.remove_directory(DATABASE_DIR)
-                    logger.warning(
-                        f"Removed database file from {DATABASE_DIR} to join existing cluster."
-                    )
-                except OSError:
-                    # if removing fails, we cannot start the workload or the member would crash
-                    raise
+            if not self.charm.state.unit_server.is_started:
+                # database files should not be deleted on running units
+                if self.charm.workload.exists(DATABASE_DIR):
+                    logger.warning(f"Existing database file detected in {DATABASE_DIR}.")
+                    # storage cannot be reused on non-leader members
+                    try:
+                        self.charm.workload.remove_directory(DATABASE_DIR)
+                        logger.warning(
+                            f"Removed database file from {DATABASE_DIR} to join existing cluster."
+                        )
+                    except OSError:
+                        # if removing fails, we cannot start the workload or the member would crash
+                        raise
 
-            self.charm.cluster_manager.start_member()
+                self.charm.cluster_manager.start_member()
         else:
             # this unit that has not yet been added to the cluster
             # wait for leader to process `relation_joined` event and add the member to the cluster

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -232,13 +232,16 @@ class EtcdEvents(Object):
         if not self.charm.unit.is_leader():
             return
 
-        logger.debug(f"Removing {event.unit.name} from cluster state in peer relation.")
-        cluster_members = self.charm.state.cluster.cluster_members.split(",")
-        # re-assemble the string without the departing unit
-        updated_cluster_members = ",".join(
-            m for m in cluster_members if event.unit.name.replace("/", "") not in m
-        )
-        self.charm.state.cluster.update({"cluster_members": updated_cluster_members})
+        if self.charm.state.unit_server.is_started:
+            # this must not overwrite already cleaned up application databag
+            # it should only happen if at least this unit's workload is still running
+            logger.debug(f"Removing {event.unit.name} from cluster state in peer relation.")
+            cluster_members = self.charm.state.cluster.cluster_members.split(",")
+            # re-assemble the string without the departing unit
+            updated_cluster_members = ",".join(
+                m for m in cluster_members if event.unit.name.replace("/", "") not in m
+            )
+            self.charm.state.cluster.update({"cluster_members": updated_cluster_members})
 
     def _on_peer_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Handle event received by all units when a new unit joins the cluster relation."""

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -275,6 +275,9 @@ class EtcdEvents(Object):
 
             self.charm.state.cluster.update({f"{INTERNAL_USER}-password": password})
 
+        # reflect membership updates in the cluster state
+        self.charm.cluster_manager.update_cluster_member_state()
+
     def _on_update_status(self, event: ops.UpdateStatusEvent) -> None:
         """Handle update_status event."""
         if not self.charm.workload.alive():

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -108,16 +108,18 @@ class EtcdEvents(Object):
 
         self.charm.config_manager.set_config_properties()
 
-        if not self.charm.state.cluster.cluster_state and self.charm.workload.exists(DATABASE_DIR):
-            # this is a new application but storage is reused
-            self.charm.cluster_manager.start_member()
-            self.charm.state.cluster.update({"authentication": "enabled"})
-            # update cluster membership configuration after recovering existing data
-            self.charm.cluster_manager.broadcast_peer_url(self.charm.state.unit_server.peer_url)
-        elif not self.charm.state.cluster.cluster_state and self.charm.unit.is_leader():
+        if not self.charm.state.cluster.cluster_state and self.charm.unit.is_leader():
             # this is the very first cluster start, this unit starts without being added as member
             # all subsequent units will have to be added as member before starting the workload
             self.charm.cluster_manager.start_member()
+
+            if self.charm.workload.exists(DATABASE_DIR):
+                # this is a new application but storage is reused
+                self.charm.state.cluster.update({"authentication": "enabled"})
+                # update cluster membership configuration after recovering existing data
+                self.charm.cluster_manager.broadcast_peer_url(
+                    self.charm.state.unit_server.peer_url
+                )
 
             if not self.charm.state.cluster.auth_enabled:
                 try:

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -193,7 +193,7 @@ class ClusterManager:
                 client = EtcdClient(
                     username=self.admin_user,
                     password=self.admin_password,
-                    client_url=self.state.unit_server.client_url,
+                    client_url=",".join(e for e in self.cluster_endpoints),
                 )
                 cluster_members, member_id = client.add_member_as_learner(
                     server.member_name, peer_url
@@ -230,7 +230,7 @@ class ClusterManager:
             client = EtcdClient(
                 username=self.admin_user,
                 password=self.admin_password,
-                client_url=self.state.unit_server.client_url,
+                client_url=",".join(e for e in self.cluster_endpoints),
             )
             client.promote_member(member_id=member_id)
         except EtcdClusterManagementError:
@@ -253,10 +253,7 @@ class ClusterManager:
                 password=self.admin_password,
                 client_url=",".join(e for e in self.cluster_endpoints),
             )
-            if self.is_healthy(cluster=True):
-                client.remove_member(self.member.id)
-            else:
-                raise EtcdClusterManagementError("Cluster not healthy.")
+            client.remove_member(self.member.id)
         except (EtcdClusterManagementError, RaftLeaderNotFoundError):
             raise
         except ValueError:

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -193,7 +193,7 @@ class ClusterManager:
                 client = EtcdClient(
                     username=self.admin_user,
                     password=self.admin_password,
-                    client_url=",".join(e for e in self.cluster_endpoints),
+                    client_url=self.state.unit_server.client_url,
                 )
                 cluster_members, member_id = client.add_member_as_learner(
                     server.member_name, peer_url
@@ -230,7 +230,7 @@ class ClusterManager:
             client = EtcdClient(
                 username=self.admin_user,
                 password=self.admin_password,
-                client_url=",".join(e for e in self.cluster_endpoints),
+                client_url=self.state.unit_server.client_url,
             )
             client.promote_member(member_id=member_id)
         except EtcdClusterManagementError:

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -300,16 +300,17 @@ class ClusterManager:
 
     def update_cluster_member_state(self) -> None:
         """Get up-to-date member information and store in cluster state."""
-        client = EtcdClient(
-            username=self.admin_user,
-            password=self.admin_password,
-            client_url=self.state.unit_server.client_url,
-        )
+        if self.state.cluster.cluster_state:
+            client = EtcdClient(
+                username=self.admin_user,
+                password=self.admin_password,
+                client_url=self.state.unit_server.client_url,
+            )
 
-        try:
-            member_list = client.member_list()
-            cluster_members = ",".join(f"{k}={v.peer_urls[0]}" for k, v in member_list.items())
-            self.state.cluster.update({"cluster_members": cluster_members})
-        except Exception as e:
-            # we should not have errors here, but if we do, we don't want the error to raise
-            logger.warning(f"Error updating the cluster member state: {e}")
+            try:
+                member_list = client.member_list()
+                cluster_members = ",".join(f"{k}={v.peer_urls[0]}" for k, v in member_list.items())
+                self.state.cluster.update({"cluster_members": cluster_members})
+            except Exception as e:
+                # we should not have errors here, but if we do, we don't want the error to raise
+                logger.warning(f"Error updating the cluster member state: {e}")

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -300,17 +300,19 @@ class ClusterManager:
 
     def update_cluster_member_state(self) -> None:
         """Get up-to-date member information and store in cluster state."""
-        if self.state.cluster.cluster_state:
-            client = EtcdClient(
-                username=self.admin_user,
-                password=self.admin_password,
-                client_url=self.state.unit_server.client_url,
-            )
+        if not self.state.cluster.cluster_state:
+            return
 
-            try:
-                member_list = client.member_list()
-                cluster_members = ",".join(f"{k}={v.peer_urls[0]}" for k, v in member_list.items())
-                self.state.cluster.update({"cluster_members": cluster_members})
-            except Exception as e:
-                # we should not have errors here, but if we do, we don't want the error to raise
-                logger.warning(f"Error updating the cluster member state: {e}")
+        client = EtcdClient(
+            username=self.admin_user,
+            password=self.admin_password,
+            client_url=self.state.unit_server.client_url,
+        )
+
+        try:
+            member_list = client.member_list()
+            cluster_members = ",".join(f"{k}={v.peer_urls[0]}" for k, v in member_list.items())
+            self.state.cluster.update({"cluster_members": cluster_members})
+        except Exception as e:
+            # we should not have errors here, but if we do, we don't want the error to raise
+            logger.warning(f"Error updating the cluster member state: {e}")

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -43,7 +43,7 @@ def continuous_writes(endpoints: str, user: str, password: str):
             for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(1)):
                 with attempt:
                     result = subprocess.getoutput(etcd_command).split("\n")
-                    if result != ["OK"]:
+                    if not result[0] == "OK":
                         raise ValueError
             with open(LOG_FILE_PATH, "a") as log_file:
                 log_file.write(f"{result}\n")

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 import time
 
+from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
+
 logger = logging.getLogger(__name__)
 
 WRITES_LAST_WRITTEN_VAL_PATH = "last_written_value"
@@ -38,10 +40,14 @@ def continuous_writes(endpoints: str, user: str, password: str):
                         """
 
         try:
-            result = subprocess.getoutput(etcd_command).split("\n")
+            for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(1)):
+                with attempt:
+                    result = subprocess.getoutput(etcd_command).split("\n")
+                    if result != ["OK"]:
+                        raise ValueError
             with open(LOG_FILE_PATH, "a") as log_file:
                 log_file.write(f"{result}\n")
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        except RetryError:
             pass
 
         time.sleep(1)

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -40,7 +40,7 @@ def continuous_writes(endpoints: str, user: str, password: str):
                         """
 
         try:
-            for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(1)):
+            for attempt in Retrying(stop=stop_after_attempt(2), wait=wait_fixed(1)):
                 with attempt:
                     result = subprocess.getoutput(etcd_command).split("\n")
                     with open(LOG_FILE_PATH, "a") as log_file:

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -43,10 +43,10 @@ def continuous_writes(endpoints: str, user: str, password: str):
             for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(1)):
                 with attempt:
                     result = subprocess.getoutput(etcd_command).split("\n")
-                    if not result[0] == "OK":
+                    with open(LOG_FILE_PATH, "a") as log_file:
+                        log_file.write(f"{result}\n")
+                    if not any(r == "OK" for r in result):
                         raise ValueError
-            with open(LOG_FILE_PATH, "a") as log_file:
-                log_file.write(f"{result}\n")
         except RetryError:
             pass
 

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -12,7 +12,7 @@ from typing import Tuple
 from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_attempt, wait_fixed
 
-from literals import SNAP_NAME, SNAP_REVISION
+from literals import DATABASE_DIR, SNAP_NAME, SNAP_REVISION
 
 logger = logging.getLogger(__name__)
 
@@ -147,3 +147,14 @@ async def patch_restart_delay(ops_test: OpsTest, unit_name: str, delay: int) -> 
     # reload the daemon for systemd to reflect changes
     reload_cmd = f"exec --unit {unit_name} -- sudo systemctl daemon-reload"
     await ops_test.juju(*reload_cmd.split(), check=True)
+
+
+async def remove_database_file(ops_test: OpsTest, unit_name: str) -> None:
+    """Delete the database file of etcd on a unit."""
+    delete_db_cmd = f"exec --unit {unit_name} -- rm {DATABASE_DIR}/snap/db"
+    # we can delete the database file containing the data content
+    # but never the write-ahead-log file, which contains the committed Raft information
+    # otherwise the member would not be functional anymore
+    # see: https://etcd.io/docs/v3.5/learning/persistent-storage-files/#logical-content
+    await ops_test.juju(*delete_db_cmd.split(), check=True)
+    logger.info(f"etcd database file deleted on {unit_name}.")

--- a/tests/integration/ha/helpers_network.py
+++ b/tests/integration/ha/helpers_network.py
@@ -104,7 +104,7 @@ def restore_network_for_unit_without_ip_change(machine_name: str) -> None:
 def is_unit_reachable(from_host: str, to_host: str) -> bool:
     """Test network reachability between hosts."""
     try:
-        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(5)):
+        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(10)):
             with attempt:
                 ping = subprocess.call(
                     f"lxc exec {from_host} -- ping -c 5 {to_host}".split(),

--- a/tests/integration/ha/helpers_network.py
+++ b/tests/integration/ha/helpers_network.py
@@ -80,6 +80,8 @@ def cut_network_from_unit_without_ip_change(machine_name: str) -> None:
     subprocess.check_call(limit_set_command.split())
     limit_set_command = f"lxc config device set {machine_name} eth0 limits.ingress=1kbit"
     subprocess.check_call(limit_set_command.split())
+    limit_set_command = f"lxc config device set {machine_name} eth0 limits.priority=10"
+    subprocess.check_call(limit_set_command.split())
 
 
 def restore_network_for_unit_with_ip_change(machine_name: str) -> None:
@@ -101,7 +103,7 @@ def restore_network_for_unit_without_ip_change(machine_name: str) -> None:
 def is_unit_reachable(from_host: str, to_host: str) -> bool:
     """Test network reachability between hosts."""
     ping = subprocess.call(
-        f"lxc exec {from_host} -- ping -c 5 {to_host}".split(),
+        f"lxc exec {from_host} -- ping -c 15 {to_host}".split(),
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )

--- a/tests/integration/ha/helpers_network.py
+++ b/tests/integration/ha/helpers_network.py
@@ -80,8 +80,6 @@ def cut_network_from_unit_without_ip_change(machine_name: str) -> None:
     subprocess.check_call(limit_set_command.split())
     limit_set_command = f"lxc config device set {machine_name} eth0 limits.ingress=1kbit"
     subprocess.check_call(limit_set_command.split())
-    limit_set_command = f"lxc config device set {machine_name} eth0 limits.priority=10"
-    subprocess.check_call(limit_set_command.split())
 
 
 def restore_network_for_unit_with_ip_change(machine_name: str) -> None:

--- a/tests/integration/ha/helpers_network.py
+++ b/tests/integration/ha/helpers_network.py
@@ -12,6 +12,7 @@ import subprocess
 
 import yaml
 from pytest_operator.plugin import OpsTest
+from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
 logger = logging.getLogger(__name__)
 
@@ -102,9 +103,17 @@ def restore_network_for_unit_without_ip_change(machine_name: str) -> None:
 
 def is_unit_reachable(from_host: str, to_host: str) -> bool:
     """Test network reachability between hosts."""
-    ping = subprocess.call(
-        f"lxc exec {from_host} -- ping -c 15 {to_host}".split(),
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-    return ping == 0
+    try:
+        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(5)):
+            with attempt:
+                ping = subprocess.call(
+                    f"lxc exec {from_host} -- ping -c 5 {to_host}".split(),
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                if ping == 0:
+                    return True
+                else:
+                    raise ValueError
+    except RetryError:
+        return False

--- a/tests/integration/ha/test_failover.py
+++ b/tests/integration/ha/test_failover.py
@@ -27,6 +27,7 @@ from .helpers import (
     assert_continuous_writes_increasing,
     existing_app,
     patch_restart_delay,
+    remove_database_file,
     send_process_control_signal,
     start_continuous_writes,
     stop_continuous_writes,
@@ -422,3 +423,85 @@ async def test_full_cluster_crash(ops_test: OpsTest) -> None:
     # reset the restart delay to the original value
     for unit in ops_test.model.applications[app].units:
         await patch_restart_delay(ops_test, unit_name=unit.name, delay=RESTART_DELAY_DEFAULT)
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_restart_raft_leader_after_deleting_database_file(ops_test: OpsTest) -> None:
+    """Make sure the cluster can self-heal when the leader's data is deleted."""
+    app = (await existing_app(ops_test)) or APP_NAME
+
+    # make sure we have at least two units so we can kill one of them
+    if len(ops_test.model.applications[app].units) < 2:
+        await ops_test.model.applications[app].add_unit(count=1)
+        await wait_until(
+            ops_test,
+            apps=[app],
+            apps_statuses=["active"],
+            units_statuses=["active"],
+            wait_for_exact_units=2,
+        )
+
+    init_units_count = len(ops_test.model.applications[app].units)
+    endpoints = get_cluster_endpoints(ops_test, app)
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{app}.app")
+    password = secret.get(f"{INTERNAL_USER}-password")
+
+    # start writing data to the cluster
+    start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    time.sleep(10)
+
+    # get details for the current raft leader in the cluster
+    initial_raft_leader = get_raft_leader(endpoints=endpoints)
+    logger.info(f"initial raft leader: {initial_raft_leader}")
+    leader_unit = initial_raft_leader.replace(app, f"{app}/")
+
+    # stop the etcd process of the cluster/raft leader
+    await patch_restart_delay(ops_test, unit_name=leader_unit, delay=RESTART_DELAY_PATCHED)
+    send_process_control_signal(
+        unit_name=leader_unit, model_full_name=ops_test.model_full_name, signal="SIGTERM"
+    )
+
+    # make sure the process is stopped
+    unit_endpoint = get_unit_endpoint(ops_test, unit_name=leader_unit, app_name=app)
+    assert not is_endpoint_up(unit_endpoint, user=INTERNAL_USER, password=password)
+
+    # forcefully remove database file on the unit
+    await remove_database_file(ops_test, unit_name=leader_unit)
+
+    # as the stopped member is unresponsive, only query the endpoints still available
+    remaining_endpoints = get_remaining_endpoints(endpoints, unit_endpoint)
+
+    # ensure a new leader was assigned after waiting for the `election timeout`
+    time.sleep(3)
+    new_raft_leader = get_raft_leader(endpoints=remaining_endpoints)
+    logger.info(f"new raft leader: {new_raft_leader}")
+    assert new_raft_leader != initial_raft_leader, (
+        "raft leadership not transferred after freeze of leader"
+    )
+
+    # ensure data is written in the cluster
+    assert_continuous_writes_increasing(
+        endpoints=remaining_endpoints, user=INTERNAL_USER, password=password
+    )
+
+    # ensure the stopped unit was restarted
+    time.sleep(RESTART_DELAY_DEFAULT)
+    assert is_endpoint_up(unit_endpoint, user=INTERNAL_USER, password=password)
+    logger.info(f"{leader_unit} is available again.")
+
+    cluster_members = get_cluster_members(endpoints)
+    assert len(cluster_members) == init_units_count, (
+        f"expected {init_units_count} cluster members, got {len(cluster_members)}"
+    )
+    logger.info(f"Cluster fully formed again with {len(cluster_members)} members.")
+
+    # ensure data is written in the cluster
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    stop_continuous_writes()
+    # By default, etcd uses a 1s election timeout before attempting to replace a lost leader
+    # that's why we will miss writes here, and therefore ignore the revision of the key
+    assert_continuous_writes_consistent(
+        endpoints=endpoints, user=INTERNAL_USER, password=password, ignore_revision=True
+    )

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -61,6 +61,10 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000)
 
 
+# known-issue with self-hosted runners: `lxc config device set ... eth0 limits.priority=10`
+# command fails because of wrong kernel version
+# details see: https://warthogs.atlassian.net/browse/ISD-3026
+@pytest.mark.skip()
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -102,11 +102,10 @@ async def test_network_cut_on_raft_leader_without_ip_change(ops_test: OpsTest) -
     cut_network_from_unit_without_ip_change(leader_hostname)
 
     # make sure the unit is not reachable from the other units
-    remaining_unit_names = (
-        unit.name for unit in ops_test.model.applications[app].units if unit.name != leader_unit
-    )
-    for unit_name in remaining_unit_names:
-        hostname = await hostname_from_unit(ops_test, unit_name)
+    for unit in ops_test.model.applications[app].units:
+        if unit.name == leader_unit:
+            continue
+        hostname = await hostname_from_unit(ops_test, unit.name)
         assert not is_unit_reachable(hostname, leader_hostname), (
             f"{leader_hostname} is reachable from {hostname}"
         )
@@ -220,11 +219,10 @@ async def test_network_cut_on_raft_leader_with_ip_change(ops_test: OpsTest) -> N
     cut_network_from_unit_with_ip_change(leader_hostname)
 
     # make sure the unit is not reachable from the other units
-    remaining_unit_names = (
-        unit.name for unit in ops_test.model.applications[app].units if unit.name != leader_unit
-    )
-    for unit_name in remaining_unit_names:
-        hostname = await hostname_from_unit(ops_test, unit_name)
+    for unit in ops_test.model.applications[app].units:
+        if unit.name == leader_unit:
+            continue
+        hostname = await hostname_from_unit(ops_test, unit.name)
         assert not is_unit_reachable(hostname, leader_hostname), (
             f"{leader_hostname} is reachable from {hostname}"
         )

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -98,9 +98,14 @@ async def test_network_cut_on_raft_leader_without_ip_change(ops_test: OpsTest) -
     cut_network_from_unit_without_ip_change(leader_hostname)
 
     # make sure the unit is not reachable from the other units
-    for unit in ops_test.model.applications[app].units:
-        hostname = await hostname_from_unit(ops_test, unit.name)
-        assert not is_unit_reachable(hostname, leader_hostname)
+    remaining_unit_names = (
+        unit.name for unit in ops_test.model.applications[app].units if unit.name != leader_unit
+    )
+    for unit_name in remaining_unit_names:
+        hostname = await hostname_from_unit(ops_test, unit_name)
+        assert not is_unit_reachable(hostname, leader_hostname), (
+            f"{leader_hostname} is reachable from {hostname}"
+        )
 
     # make sure the unit is not reachable from the controller
     controller_hostname = await get_controller_hostname(ops_test)
@@ -211,9 +216,14 @@ async def test_network_cut_on_raft_leader_with_ip_change(ops_test: OpsTest) -> N
     cut_network_from_unit_with_ip_change(leader_hostname)
 
     # make sure the unit is not reachable from the other units
-    for unit in ops_test.model.applications[app].units:
-        hostname = await hostname_from_unit(ops_test, unit.name)
-        assert not is_unit_reachable(hostname, leader_hostname)
+    remaining_unit_names = (
+        unit.name for unit in ops_test.model.applications[app].units if unit.name != leader_unit
+    )
+    for unit_name in remaining_unit_names:
+        hostname = await hostname_from_unit(ops_test, unit_name)
+        assert not is_unit_reachable(hostname, leader_hostname), (
+            f"{leader_hostname} is reachable from {hostname}"
+        )
 
     # make sure the unit is not reachable from the controller
     controller_hostname = await get_controller_hostname(ops_test)

--- a/tests/integration/ha/test_storage_reuse.py
+++ b/tests/integration/ha/test_storage_reuse.py
@@ -88,7 +88,7 @@ async def test_attach_storage_after_scale_down(ops_test: OpsTest) -> None:
     new_unit = ops_test.model.applications[app].units[-1]
     await wait_until(ops_test, apps=[app], wait_for_exact_units=init_units_count, idle_period=60)
 
-    # ensure data can be written on the new unit
+    # ensure the newly added endpoint is healthy
     unit_endpoint = get_unit_endpoint(ops_test, unit_name=new_unit.name, app_name=app)
     assert is_endpoint_up(unit_endpoint, user=INTERNAL_USER, password=password)
     logger.info(f"{new_unit.name} is available again.")

--- a/tests/integration/ha/test_storage_reuse.py
+++ b/tests/integration/ha/test_storage_reuse.py
@@ -37,7 +37,7 @@ TEST_KEY = "test_key"
 TEST_VALUE = "42"
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
@@ -54,7 +54,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     assert len(ops_test.model.applications[APP_NAME].units) == NUM_UNITS
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_attach_storage_after_scale_down(ops_test: OpsTest) -> None:
@@ -122,7 +122,7 @@ async def test_attach_storage_after_scale_down(ops_test: OpsTest) -> None:
     )
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_attach_storage_after_scale_to_zero(ops_test: OpsTest) -> None:
@@ -190,7 +190,7 @@ async def test_attach_storage_after_scale_to_zero(ops_test: OpsTest) -> None:
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_attach_storage_after_removing_application(ops_test: OpsTest) -> None:

--- a/tests/integration/ha/test_storage_reuse.py
+++ b/tests/integration/ha/test_storage_reuse.py
@@ -19,6 +19,7 @@ from ..helpers import (
     get_secret_by_label,
     get_storage_id,
     get_unit_endpoint,
+    is_endpoint_up,
     put_key,
 )
 from ..helpers_deployment import wait_until
@@ -89,16 +90,7 @@ async def test_attach_storage_after_scale_down(ops_test: OpsTest) -> None:
 
     # ensure data can be written on the new unit
     unit_endpoint = get_unit_endpoint(ops_test, unit_name=new_unit.name, app_name=app)
-    assert (
-        put_key(
-            unit_endpoint,
-            user=INTERNAL_USER,
-            password=password,
-            key=TEST_KEY,
-            value=TEST_VALUE,
-        )
-        == "OK"
-    )
+    assert is_endpoint_up(unit_endpoint, user=INTERNAL_USER, password=password)
     logger.info(f"{new_unit.name} is available again.")
 
     # check cluster formation after unit with existing storage was added

--- a/tests/integration/ha/test_storage_reuse.py
+++ b/tests/integration/ha/test_storage_reuse.py
@@ -38,7 +38,7 @@ TEST_KEY = "test_key"
 TEST_VALUE = "42"
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
@@ -55,7 +55,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     assert len(ops_test.model.applications[APP_NAME].units) == NUM_UNITS
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_attach_storage_after_scale_down(ops_test: OpsTest) -> None:
@@ -114,7 +114,7 @@ async def test_attach_storage_after_scale_down(ops_test: OpsTest) -> None:
     )
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_attach_storage_after_scale_to_zero(ops_test: OpsTest) -> None:
@@ -182,7 +182,7 @@ async def test_attach_storage_after_scale_to_zero(ops_test: OpsTest) -> None:
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_attach_storage_after_removing_application(ops_test: OpsTest) -> None:

--- a/tests/integration/ha/test_storage_reuse.py
+++ b/tests/integration/ha/test_storage_reuse.py
@@ -158,7 +158,7 @@ async def test_attach_storage_after_scale_to_zero(ops_test: OpsTest) -> None:
         return_code, _, _ = await ops_test.juju(*add_unit_cmd.split())
         assert return_code == 0, f"Failed to add unit with storage {storage_id}"
 
-    await wait_until(ops_test, apps=[app], wait_for_exact_units=len(storage_ids), idle_period=60)
+    await wait_until(ops_test, apps=[app], wait_for_exact_units=len(storage_ids), idle_period=120)
 
     # check cluster formation after new cluster was forced
     endpoints = get_cluster_endpoints(ops_test, app)
@@ -260,7 +260,7 @@ async def test_attach_storage_after_removing_application(ops_test: OpsTest) -> N
 
     # scale up
     await ops_test.model.applications[APP_NAME].add_unit(count=2)
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS, idle_period=60)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS, idle_period=120)
 
     # check cluster formation
     endpoints = get_cluster_endpoints(ops_test, APP_NAME)

--- a/tests/integration/ha/test_storage_reuse.py
+++ b/tests/integration/ha/test_storage_reuse.py
@@ -168,7 +168,7 @@ async def test_attach_storage_after_scale_to_zero(ops_test: OpsTest) -> None:
     cluster_members = get_cluster_members(endpoints)
 
     for unit in ops_test.model.applications[app].units:
-        assert unit.name.replace("/", "") in (member["name"] for member in cluster_members), (
+        assert any(unit.name.replace("/", "") == member["name"] for member in cluster_members), (
             f"{unit.name} is not in {cluster_members}"
         )
 
@@ -270,8 +270,8 @@ async def test_attach_storage_after_removing_application(ops_test: OpsTest) -> N
     cluster_members = get_cluster_members(endpoints)
 
     for unit in ops_test.model.applications[app].units:
-        assert unit.name.replace("/", "") in (member["name"] for member in cluster_members), (
-            f"{unit.name} is not a cluster member"
+        assert any(unit.name.replace("/", "") == member["name"] for member in cluster_members), (
+            f"{unit.name} is not in {cluster_members}"
         )
 
     assert len(cluster_members) == NUM_UNITS, (

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -107,7 +107,7 @@ def get_cluster_id(endpoints: str, tls_enabled: bool = False) -> str:
         except (TypeError, KeyError) as e:
             logger.warning(e)
 
-    return ""
+    raise KeyError("cluster_id not found")
 
 
 def get_cluster_endpoints(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -99,12 +99,15 @@ def get_cluster_id(endpoints: str, tls_enabled: bool = False) -> str:
             --cert client.pem \
             --key client.key"
 
-    try:
-        result = subprocess.getoutput(etcd_command).split("\n")[0]
-        members = json.loads(result)
-        return members[0]["Status"]["header"]["cluster_id"]
-    except KeyError:
-        raise
+    result = subprocess.getoutput(etcd_command).split("\n")
+    for r in result:
+        member = json.loads(r)
+        try:
+            return member["Status"]["header"]["cluster_id"]
+        except (TypeError, KeyError) as e:
+            logger.warning(e)
+
+    return ""
 
 
 def get_cluster_endpoints(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -103,7 +103,7 @@ def get_cluster_id(endpoints: str, tls_enabled: bool = False) -> str:
     for r in result:
         member = json.loads(r)
         try:
-            return member["Status"]["header"]["cluster_id"]
+            return member[0]["Status"]["header"]["cluster_id"]
         except (TypeError, KeyError) as e:
             logger.warning(e)
 

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -54,7 +54,7 @@ async def test_build_and_deploy_with_tls(ops_test: OpsTest) -> None:
     logger.info("Integrating peer-certificates and client-certificates relations")
     await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", TLS_NAME)
     await ops_test.model.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
-    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME], timeout=1000)
+    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME], timeout=1000, idle_period=60)
 
     endpoints = get_cluster_endpoints(ops_test, APP_NAME, tls_enabled=True)
     await download_client_certificate_from_unit(ops_test, APP_NAME)

--- a/tests/integration/tls/test_private_key_rotation.py
+++ b/tests/integration/tls/test_private_key_rotation.py
@@ -63,7 +63,7 @@ async def test_build_and_deploy_with_tls(ops_test: OpsTest) -> None:
     logger.info("Integrating peer-certificates and client-certificates relations")
     await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", TLS_NAME)
     await ops_test.model.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
-    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])
+    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME], idle_period=60)
 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -55,7 +55,7 @@ async def test_build_and_deploy_with_tls(ops_test: OpsTest) -> None:
     logger.info("Integrating peer-certificates and client-certificates relations")
     await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", TLS_NAME)
     await ops_test.model.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
-    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])
+    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME], idle_period=60)
 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -183,7 +183,7 @@ def test_start():
             "cluster_state": "existing",
             "cluster_members": "charmed-etcd0=http://ip0:2380",
         },
-        local_unit_data={"hostname": "charmed-etcd0", "ip": "ip0"},
+        local_unit_data={"hostname": "charmed-etcd0", "ip": "ip0", "state": "started"},
     )
     state_in = testing.State(relations={relation}, leader=True)
     with (
@@ -193,7 +193,7 @@ def test_start():
     ):
         with raises(testing.errors.UncaughtCharmError) as e:
             state_out = ctx.run(ctx.on.start(), state_in)
-            assert not state_out.get_relation(1).local_unit_data.get("state") == "started"
+            assert not state_out.get_relation(1).local_app_data.get("authentication") == "enabled"
 
         start.assert_not_called()
         assert isinstance(e.value.__cause__, EtcdUserManagementError)
@@ -206,7 +206,7 @@ def test_start():
             "cluster_state": "existing",
             "cluster_members": "charmed-etcd0=http://ip0:2380",
         },
-        local_unit_data={"hostname": "charmed-etcd0", "ip": "ip0"},
+        local_unit_data={"hostname": "charmed-etcd0", "ip": "ip0", "state": "started"},
     )
     state_in = testing.State(relations={relation}, leader=True)
     with (
@@ -218,7 +218,7 @@ def test_start():
         state_out = ctx.run(ctx.on.start(), state_in)
         assert state_out.unit_status == ops.ActiveStatus()
         assert state_out.get_relation(1).local_app_data.get("authentication") == "enabled"
-        start.assert_called_once()
+        start.assert_not_called()
 
     # non leader must not start if auth not enabled
     relation = testing.PeerRelation(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -463,7 +463,10 @@ def test_peer_relation_changed():
         assert run_etcdctl_args["command"] == "member"
         assert run_etcdctl_args["subcommand"] == "promote"
         assert run_etcdctl_args["member"] == "4477466968462020105"
-        assert run_etcdctl_args["endpoints"] == "http://ip0:2379"
+        assert (
+            run_etcdctl_args["endpoints"] == "http://ip0:2379,http://ip1:2379"
+            or run_etcdctl_args["endpoints"] == "http://ip1:2379,http://ip0:2379"
+        )
 
 
 def test_unit_removal():

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -463,10 +463,7 @@ def test_peer_relation_changed():
         assert run_etcdctl_args["command"] == "member"
         assert run_etcdctl_args["subcommand"] == "promote"
         assert run_etcdctl_args["member"] == "4477466968462020105"
-        assert (
-            run_etcdctl_args["endpoints"] == "http://ip0:2379,http://ip1:2379"
-            or run_etcdctl_args["endpoints"] == "http://ip1:2379,http://ip0:2379"
-        )
+        assert run_etcdctl_args["endpoints"] == "http://ip0:2379"
 
 
 def test_unit_removal():


### PR DESCRIPTION
This PR brings fixes for a couple of edge cases, adjustments to some existing integration tests and a new integration test.

The main changes are the following:

**EtcdClient:**
- Only append client TLS file parameters to the `etcdctl` commands if the files actually exist. When transitioning to/from TLS, it can happen that some cluster members already have `https` endpoints, but a unit does not yet/not anymore have the client TLS files available. In these cases, the `etcdctl` commands failed with `Error: open /var/snap/charmed-etcd/common/tls/client.pem: no such file or directory`.

**EtcdEvents:**
- `on_start`: When reusing storage, a previously existing database file should only be deleted if the workload has not been started yet.
- `on_start`: Eliminate an edge case for storage reuse, when multiple units are started at exactly the same time. This could create a race condition where all of them try to initialize the cluster, which can happen only once. This is now prevented by only allowing the juju leader to initialize the cluster.
- `on_peer_relation_departed`: only allow updating the cluster members in the application databag if the leaders workload is still running. This mitigates an edge case where concurring unit removals bring juju leadership changes (even in the state of removal), which can lead to updates on already cleaned up data.
- `on_leader_elected`: run `update_cluster_member_state()` to reflect changes to the cluster membership due to unit removal

**ClusterManager:**
- remove a duplicate check for cluster availability in the `remove_member` logic
- only `update_cluster_member_state()` if the cluster has already been initialized

**Integration tests:**
- add a one-time retry to the `continuous writes` if the result was not `OK`. This eliminates flickering test results when a write can not be committed during raft leadership change. The retry is limited to one attempt after one second.
- add a retry to the `is_unit_reachable()` helper, which eliminates failing tests if the network disconnect takes longer than 5 `ping` executions
- add a new failover test `test_restart_raft_leader_after_deleting_database_file`
- temporarily skip `test_network_cut_on_raft_leader_without_ip_change` due to the issue with github runners causing frequent failures of the `lxc config` changes for the network cut (also added a comment with ticket reference)
- some other small fixes to make the integration test runs on CI more stable