### PR TITLE
[DPE-6430] Add basic status handling

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -18,7 +18,6 @@ from literals import (
     RESTART_RELATION,
     SUBSTRATE,
     DebugLevel,
-    EtcdClusterState,
     Status,
     TLSCARotationState,
     TLSState,
@@ -217,12 +216,8 @@ class EtcdOperatorCharm(ops.CharmBase):
         Component statuses should be computed in their respective priority.
         """
         # compute cluster status
-        if self.state.unit_server.is_started:
-            if not self.state.cluster.cluster_state == EtcdClusterState.EXISTING.value:
-                event.add_status(Status.CLUSTER_NOT_INITIALIZED.value.status)
-
-            if not self.state.cluster.auth_enabled:
-                event.add_status(Status.AUTHENTICATION_NOT_ENABLED.value.status)
+        for status in self.cluster_manager.compute_component_status():
+            event.add_status(status.value.status)
 
         # compute TLS status
         # todo: add compute logic here

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,6 +18,7 @@ from literals import (
     RESTART_RELATION,
     SUBSTRATE,
     DebugLevel,
+    EtcdClusterState,
     Status,
     TLSCARotationState,
     TLSState,
@@ -208,7 +209,28 @@ class EtcdOperatorCharm(ops.CharmBase):
 
         self._restart(None)
 
-    def _on_collect_status(self, event: ops.CollectStatusEvent):
+    def _on_collect_status(self, event: ops.CollectStatusEvent) -> None:
+        """Compute the current status for this unit.
+
+        Ops framework will choose the highest-priority status and set that as the status.
+        If there are multiple statuses with the same priority, the first one added wins.
+        Component statuses should be computed in their respective priority.
+        """
+        # compute cluster status
+        if self.state.unit_server.is_started:
+            if not self.state.cluster.cluster_state == EtcdClusterState.EXISTING.value:
+                event.add_status(Status.CLUSTER_NOT_INITIALIZED.value.status)
+
+            if not self.state.cluster.auth_enabled:
+                event.add_status(Status.AUTHENTICATION_NOT_ENABLED.value.status)
+
+        # compute TLS status
+        # todo: add compute logic here
+
+        # compute backup or other component's  status
+        # todo: add compute logic here
+
+        # add all other statuses collected during the current hook
         for status in self.pending_inactive_statuses + [Status.ACTIVE]:
             event.add_status(status.value.status)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -72,7 +72,6 @@ class EtcdOperatorCharm(ops.CharmBase):
 
         self.config_manager.set_config_properties()
         if not self.cluster_manager.restart_member():
-            self.set_status(Status.HEALTH_CHECK_FAILED)
             raise HealthCheckFailedError("Failed to check health of the member after restart")
 
     def rolling_restart(self, callback_override: str | None = None) -> None:
@@ -102,7 +101,6 @@ class EtcdOperatorCharm(ops.CharmBase):
         # write config and restart workload
         self.config_manager.set_config_properties()
         if not self.cluster_manager.restart_member():
-            self.set_status(Status.TLS_CLIENT_TRANSITION_FAILED)
             raise HealthCheckFailedError("Failed to check health of the member after restart")
 
     def _restart_enable_peer_tls(self, _) -> None:
@@ -128,7 +126,6 @@ class EtcdOperatorCharm(ops.CharmBase):
         # write config and restart workload
         self.config_manager.set_config_properties()
         if not self.cluster_manager.restart_member(move_leader=False):
-            self.set_status(Status.TLS_PEER_TRANSITION_FAILED)
             raise HealthCheckFailedError("Failed to check health of the member after restart")
 
     def _restart_disable_client_tls(self, _) -> None:
@@ -154,7 +151,6 @@ class EtcdOperatorCharm(ops.CharmBase):
         # write config and restart workload
         self.config_manager.set_config_properties()
         if not self.cluster_manager.restart_member(move_leader=False):
-            self.set_status(Status.TLS_CLIENT_TRANSITION_FAILED)
             raise HealthCheckFailedError("Failed to check health of the member after restart")
 
     def _restart_disable_peer_tls(self, _) -> None:
@@ -184,7 +180,6 @@ class EtcdOperatorCharm(ops.CharmBase):
         # write config and restart workload
         self.config_manager.set_config_properties()
         if not self.cluster_manager.restart_member(move_leader=False):
-            self.set_status(Status.TLS_PEER_TRANSITION_FAILED)
             raise HealthCheckFailedError("Failed to check health of the member after restart")
 
     def _restart_ca_rotation(self, _) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -38,6 +38,7 @@ class EtcdOperatorCharm(ops.CharmBase):
         super().__init__(*args)
         self.workload = EtcdWorkload()
         self.state = ClusterState(self, substrate=SUBSTRATE)
+        self.pending_inactive_statuses: list[Status] = []
 
         # --- MANAGERS ---
         self.cluster_manager = ClusterManager(state=self.state, workload=self.workload)
@@ -53,13 +54,16 @@ class EtcdOperatorCharm(ops.CharmBase):
         # --- LIB EVENT HANDLERS ---
         self.restart = RollingOpsManager(self, relation=RESTART_RELATION, callback=self._restart)
 
+        self.framework.observe(self.on.collect_unit_status, self._on_collect_status)
+        self.framework.observe(self.on.collect_app_status, self._on_collect_status)
+
     def set_status(self, key: Status) -> None:
         """Set charm status."""
         status: StatusBase = key.value.status
         log_level: DebugLevel = key.value.log_level
 
         getattr(logger, log_level.lower())(status.message)
-        self.unit.status = status
+        self.pending_inactive_statuses.append(key)
 
     def _restart(self, _) -> None:
         """Restart callback for the rolling ips lib."""
@@ -208,6 +212,10 @@ class EtcdOperatorCharm(ops.CharmBase):
             self.tls_manager.set_ca_rotation_state(TLSType.CLIENT, TLSCARotationState.NO_ROTATION)
 
         self._restart(None)
+
+    def _on_collect_status(self, event: ops.CollectStatusEvent):
+        for status in self.pending_inactive_statuses + [Status.ACTIVE]:
+            event.add_status(status.value.status)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/charm.py
+++ b/src/charm.py
@@ -220,7 +220,8 @@ class EtcdOperatorCharm(ops.CharmBase):
             event.add_status(status.value.status)
 
         # compute TLS status
-        # todo: add compute logic here
+        for status in self.tls_manager.compute_component_status():
+            event.add_status(status.value.status)
 
         # compute backup or other component's  status
         # todo: add compute logic here

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -103,6 +103,7 @@ class EtcdEvents(Object):
             logger.info(
                 f"Deferring start because TLS is not ready for {self.charm.state.unit_server.member_name}."
             )
+            self.charm.set_status(Status.TLS_NOT_READY)
             event.defer()
             return
 
@@ -222,6 +223,7 @@ class EtcdEvents(Object):
                     self.charm.cluster_manager.promote_learning_member()
                 except EtcdClusterManagementError as e:
                     logger.warning(e)
+                    self.charm.set_status(Status.CLUSTER_MEMBER_NOT_PROMOTED)
                     event.defer()
                     return
 

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -163,12 +163,11 @@ class EtcdEvents(Object):
         else:
             # this unit that has not yet been added to the cluster
             # wait for leader to process `relation_joined` event and add the member to the cluster
+            self.charm.set_status(Status.CLUSTER_NOT_JOINED)
             event.defer()
             return
 
-        if self.charm.workload.alive():
-            self.charm.set_status(Status.ACTIVE)
-        else:
+        if not self.charm.workload.alive():
             self.charm.set_status(Status.SERVICE_NOT_RUNNING)
 
     def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:
@@ -284,8 +283,6 @@ class EtcdEvents(Object):
             if not self.charm.cluster_manager.restart_member():
                 self.charm.set_status(Status.SERVICE_NOT_RUNNING)
                 return
-
-        self.charm.set_status(Status.ACTIVE)
 
     def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
         """Handle the secret_changed event."""

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -103,7 +103,6 @@ class EtcdEvents(Object):
             logger.info(
                 f"Deferring start because TLS is not ready for {self.charm.state.unit_server.member_name}."
             )
-            self.charm.set_status(Status.TLS_NOT_READY)
             event.defer()
             return
 

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -345,8 +345,13 @@ class EtcdEvents(Object):
                         )
                     except EtcdUserManagementError as e:
                         logger.error(e)
+                        self.charm.set_status(Status.PASSWORD_UPDATE_FAILED)
+            else:
+                logger.error(f"Invalid username in secret {admin_secret_id}.")
+                self.charm.set_status(Status.PASSWORD_UPDATE_FAILED)
         except (ModelError, SecretNotFoundError) as e:
             logger.error(e)
+            self.charm.set_status(Status.PASSWORD_UPDATE_FAILED)
 
     def update_private_key(self, private_key_id: str) -> None:
         """Update the private key in etcd."""

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -156,10 +156,8 @@ class TLSEvents(Object):
         """
         if event.relation.name == PEER_TLS_RELATION_NAME:
             self.charm.tls_manager.set_tls_state(state=TLSState.TO_TLS, tls_type=TLSType.PEER)
-            self.charm.set_status(Status.TLS_ENABLING_PEER_TLS)
         else:
             self.charm.tls_manager.set_tls_state(state=TLSState.TO_TLS, tls_type=TLSType.CLIENT)
-            self.charm.set_status(Status.TLS_ENABLING_CLIENT_TLS)
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Handle the `certificates-available` event.

--- a/src/literals.py
+++ b/src/literals.py
@@ -83,7 +83,9 @@ class Status(Enum):
         BlockedStatus("The private key provided is not valid. Please provide a valid private key"),
         "ERROR",
     )
-    TLS_NOT_READY = StatusLevel(BlockedStatus("Deferring start because TLS is not ready"), "ERROR")
+    TLS_NOT_READY = StatusLevel(MaintenanceStatus("Waiting for TLS to be ready"), "DEBUG")
+    TLS_PEER_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating peer CA..."), "DEBUG")
+    TLS_CLIENT_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating client CA..."), "DEBUG")
     SERVICE_NOT_INSTALLED = StatusLevel(BlockedStatus("unable to install etcd snap"), "ERROR")
     SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("etcd service not running"), "ERROR")
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -63,6 +63,9 @@ class Status(Enum):
         BlockedStatus("failed to enable authentication in etcd"), "ERROR"
     )
     CLUSTER_MANAGEMENT_ERROR = StatusLevel(BlockedStatus("cluster management error"), "ERROR")
+    CLUSTER_NOT_INITIALIZED = StatusLevel(
+        BlockedStatus("Waiting for cluster initialization"), "ERROR"
+    )
     CLUSTER_NOT_JOINED = StatusLevel(MaintenanceStatus("Waiting to join cluster"), "DEBUG")
     CLUSTER_MEMBER_NOT_PROMOTED = StatusLevel(
         MaintenanceStatus("Waiting to promote learning member"), "DEBUG"

--- a/src/literals.py
+++ b/src/literals.py
@@ -64,7 +64,9 @@ class Status(Enum):
     )
     CLUSTER_MANAGEMENT_ERROR = StatusLevel(BlockedStatus("cluster management error"), "ERROR")
     CLUSTER_NOT_JOINED = StatusLevel(MaintenanceStatus("Waiting to join cluster"), "DEBUG")
-    CLUSTER_MEMBER_NOT_PROMOTED = StatusLevel(MaintenanceStatus("Waiting to promote learning member"), "DEBUG")
+    CLUSTER_MEMBER_NOT_PROMOTED = StatusLevel(
+        MaintenanceStatus("Waiting to promote learning member"), "DEBUG"
+    )
     HEALTH_CHECK_FAILED = StatusLevel(MaintenanceStatus("health check failed"), "DEBUG")
     NO_PEER_RELATION = StatusLevel(MaintenanceStatus("no peer relation available"), "DEBUG")
     PASSWORD_UPDATE_FAILED = StatusLevel(BlockedStatus("failed to update password"), "ERROR")

--- a/src/literals.py
+++ b/src/literals.py
@@ -62,14 +62,13 @@ class Status(Enum):
     AUTHENTICATION_NOT_ENABLED = StatusLevel(
         BlockedStatus("failed to enable authentication in etcd"), "ERROR"
     )
-    SERVICE_NOT_INSTALLED = StatusLevel(BlockedStatus("unable to install etcd snap"), "ERROR")
-    SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("etcd service not running"), "ERROR")
-    NO_PEER_RELATION = StatusLevel(MaintenanceStatus("no peer relation available"), "DEBUG")
     CLUSTER_MANAGEMENT_ERROR = StatusLevel(BlockedStatus("cluster management error"), "ERROR")
     CLUSTER_NOT_JOINED = StatusLevel(MaintenanceStatus("Waiting to join cluster"), "DEBUG")
-    REMOVED = StatusLevel(BlockedStatus("unit removed from cluster"), "INFO")
     HEALTH_CHECK_FAILED = StatusLevel(MaintenanceStatus("health check failed"), "DEBUG")
+    NO_PEER_RELATION = StatusLevel(MaintenanceStatus("no peer relation available"), "DEBUG")
+    PASSWORD_UPDATE_FAILED = StatusLevel(BlockedStatus("failed to update password"), "ERROR")
     PEER_URL_NOT_SET = StatusLevel(MaintenanceStatus("peer-url not set"), "DEBUG")
+    REMOVED = StatusLevel(BlockedStatus("unit removed from cluster"), "INFO")
     TLS_ENABLING_PEER_TLS = StatusLevel(MaintenanceStatus("Enabling peer TLS..."), "DEBUG")
     TLS_ENABLING_CLIENT_TLS = StatusLevel(MaintenanceStatus("Enabling client TLS..."), "DEBUG")
     TLS_DISABLING_PEER_TLS = StatusLevel(MaintenanceStatus("Disabling peer TLS..."), "DEBUG")
@@ -84,6 +83,8 @@ class Status(Enum):
         BlockedStatus("The private key provided is not valid. Please provide a valid private key"),
         "ERROR",
     )
+    SERVICE_NOT_INSTALLED = StatusLevel(BlockedStatus("unable to install etcd snap"), "ERROR")
+    SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("etcd service not running"), "ERROR")
 
 
 # enum for TLS state

--- a/src/literals.py
+++ b/src/literals.py
@@ -64,25 +64,21 @@ class Status(Enum):
     )
     CLUSTER_MANAGEMENT_ERROR = StatusLevel(BlockedStatus("cluster management error"), "ERROR")
     CLUSTER_NOT_JOINED = StatusLevel(MaintenanceStatus("Waiting to join cluster"), "DEBUG")
+    CLUSTER_MEMBER_NOT_PROMOTED = StatusLevel(MaintenanceStatus("Waiting to promote learning member"), "DEBUG")
     HEALTH_CHECK_FAILED = StatusLevel(MaintenanceStatus("health check failed"), "DEBUG")
     NO_PEER_RELATION = StatusLevel(MaintenanceStatus("no peer relation available"), "DEBUG")
     PASSWORD_UPDATE_FAILED = StatusLevel(BlockedStatus("failed to update password"), "ERROR")
     PEER_URL_NOT_SET = StatusLevel(MaintenanceStatus("peer-url not set"), "DEBUG")
     REMOVED = StatusLevel(BlockedStatus("unit removed from cluster"), "INFO")
-    TLS_ENABLING_PEER_TLS = StatusLevel(MaintenanceStatus("Enabling peer TLS..."), "DEBUG")
-    TLS_ENABLING_CLIENT_TLS = StatusLevel(MaintenanceStatus("Enabling client TLS..."), "DEBUG")
     TLS_DISABLING_PEER_TLS = StatusLevel(MaintenanceStatus("Disabling peer TLS..."), "DEBUG")
     TLS_DISABLING_CLIENT_TLS = StatusLevel(MaintenanceStatus("Disabling client TLS..."), "DEBUG")
-    TLS_CLIENT_TRANSITION_FAILED = StatusLevel(
-        BlockedStatus("Failed to transition to/from client tls"), "ERROR"
-    )
-    TLS_PEER_TRANSITION_FAILED = StatusLevel(
-        BlockedStatus("Failed to transition to/from peer tls"), "ERROR"
-    )
+    TLS_ENABLING_PEER_TLS = StatusLevel(MaintenanceStatus("Enabling peer TLS..."), "DEBUG")
+    TLS_ENABLING_CLIENT_TLS = StatusLevel(MaintenanceStatus("Enabling client TLS..."), "DEBUG")
     TLS_INVALID_PRIVATE_KEY = StatusLevel(
         BlockedStatus("The private key provided is not valid. Please provide a valid private key"),
         "ERROR",
     )
+    TLS_NOT_READY = StatusLevel(BlockedStatus("Deferring start because TLS is not ready"), "ERROR")
     SERVICE_NOT_INSTALLED = StatusLevel(BlockedStatus("unable to install etcd snap"), "ERROR")
     SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("etcd service not running"), "ERROR")
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -66,6 +66,7 @@ class Status(Enum):
     SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("etcd service not running"), "ERROR")
     NO_PEER_RELATION = StatusLevel(MaintenanceStatus("no peer relation available"), "DEBUG")
     CLUSTER_MANAGEMENT_ERROR = StatusLevel(BlockedStatus("cluster management error"), "ERROR")
+    CLUSTER_NOT_JOINED = StatusLevel(MaintenanceStatus("Waiting to join cluster"), "DEBUG")
     REMOVED = StatusLevel(BlockedStatus("unit removed from cluster"), "INFO")
     HEALTH_CHECK_FAILED = StatusLevel(MaintenanceStatus("health check failed"), "DEBUG")
     PEER_URL_NOT_SET = StatusLevel(MaintenanceStatus("peer-url not set"), "DEBUG")

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -7,6 +7,7 @@
 import logging
 import socket
 from json import JSONDecodeError
+from typing import List
 
 from tenacity import retry, stop_after_attempt, wait_fixed, wait_random_exponential
 
@@ -20,7 +21,7 @@ from common.exceptions import (
 from core.cluster import ClusterState
 from core.models import Member
 from core.workload import WorkloadBase
-from literals import INTERNAL_USER, EtcdClusterState, TLSState
+from literals import INTERNAL_USER, EtcdClusterState, Status, TLSState
 
 logger = logging.getLogger(__name__)
 
@@ -316,3 +317,16 @@ class ClusterManager:
         except Exception as e:
             # we should not have errors here, but if we do, we don't want the error to raise
             logger.warning(f"Error updating the cluster member state: {e}")
+
+    def compute_component_status(self) -> List[Status]:
+        """Compute the Cluster manager's statuses."""
+        status_list = []
+
+        if self.state.unit_server.is_started:
+            if not self.state.cluster.cluster_state == EtcdClusterState.EXISTING.value:
+                status_list.append(Status.CLUSTER_NOT_INITIALIZED)
+
+            if not self.state.cluster.auth_enabled:
+                status_list.append(Status.AUTHENTICATION_NOT_ENABLED)
+
+        return status_list

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -323,7 +323,7 @@ class ClusterManager:
         status_list = []
 
         if self.state.unit_server.is_started:
-            if not self.state.cluster.cluster_state == EtcdClusterState.EXISTING.value:
+            if self.state.cluster.cluster_state != EtcdClusterState.EXISTING.value:
                 status_list.append(Status.CLUSTER_NOT_INITIALIZED)
 
             if not self.state.cluster.auth_enabled:

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -14,7 +14,7 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
 
 from core.cluster import ClusterState
 from core.workload import WorkloadBase
-from literals import SUBSTRATES, TLSCARotationState, TLSState, TLSType
+from literals import SUBSTRATES, Status, TLSCARotationState, TLSState, TLSType
 
 logger = logging.getLogger(__name__)
 
@@ -201,3 +201,27 @@ class TLSManager:
             ]:
                 return False
         return True
+
+    def compute_component_status(self) -> list[Status]:
+        """Compute the component status."""
+        status_list = []
+
+        if self.state.unit_server.tls_peer_state == TLSState.TO_TLS:
+            status_list.append(Status.TLS_ENABLING_PEER_TLS)
+
+        if self.state.unit_server.tls_client_state == TLSState.TO_TLS:
+            status_list.append(Status.TLS_ENABLING_CLIENT_TLS)
+
+        if self.state.unit_server.tls_peer_state == TLSState.TO_NO_TLS:
+            status_list.append(Status.TLS_DISABLING_PEER_TLS)
+
+        if self.state.unit_server.tls_client_state == TLSState.TO_NO_TLS:
+            status_list.append(Status.TLS_DISABLING_CLIENT_TLS)
+
+        if self.state.unit_server.tls_peer_ca_rotation_state != TLSCARotationState.NO_ROTATION:
+            status_list.append(Status.TLS_PEER_CA_ROTATING)
+
+        if self.state.unit_server.tls_client_ca_rotation_state != TLSCARotationState.NO_ROTATION:
+            status_list.append(Status.TLS_CLIENT_CA_ROTATING)
+
+        return status_list

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -83,7 +83,7 @@ def test_start():
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.start(), state_in)
-        assert state_out.unit_status != ops.ActiveStatus()
+        assert state_out.unit_status == ops.MaintenanceStatus("Waiting to join cluster")
         start.assert_not_called()
 
     # if authentication cannot be enabled, the charm should error out

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -348,6 +348,48 @@ def test_config_changed():
         assert secret_out.latest_content.get(f"{INTERNAL_USER}-password") == secret_value
 
 
+def test_secret_changed():
+    secret_key = "root"
+    secret_value = "123"
+    secret_content = {secret_key: secret_value}
+    secret = ops.testing.Secret(tracked_content=secret_content, remote_grants=APP_NAME)
+    relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
+
+    # test the happy path
+    ctx = testing.Context(EtcdOperatorCharm)
+    state_in = testing.State(
+        secrets=[secret],
+        config={INTERNAL_USER_PASSWORD_CONFIG: secret.id},
+        relations={relation},
+        leader=True,
+    )
+    with patch("subprocess.run"):
+        state_out = ctx.run(ctx.on.secret_changed(secret=secret), state_in)
+        secret_out = state_out.get_secret(label=f"{PEER_RELATION}.{APP_NAME}.app")
+        assert secret_out.latest_content.get(f"{INTERNAL_USER}-password") == secret_value
+
+    # unhappy path: if the password update fails in etcd, charm status has to be blocked
+    with patch("subprocess.run", side_effect=CalledProcessError(returncode=1, cmd="failed")):
+        state_out = ctx.run(ctx.on.secret_changed(secret=secret), state_in)
+
+        assert state_out.unit_status == ops.BlockedStatus("failed to update password")
+
+    # no update should happen if the user-name is invalid, charm status has to be blocked
+    secret_key = "invalid-user-name"
+    secret_content = {secret_key: secret_value}
+    secret = ops.testing.Secret(tracked_content=secret_content, remote_grants=APP_NAME)
+    state_in = testing.State(
+        secrets=[secret],
+        config={INTERNAL_USER_PASSWORD_CONFIG: secret.id},
+        relations={relation},
+        leader=True,
+    )
+    with patch("subprocess.run") as run:
+        state_out = ctx.run(ctx.on.secret_changed(secret=secret), state_in)
+        run.assert_not_called()
+        assert state_out.unit_status == ops.BlockedStatus("failed to update password")
+
+
 def test_peer_relation_joined():
     ctx = testing.Context(EtcdOperatorCharm)
     relation = testing.PeerRelation(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -77,13 +77,14 @@ def test_start():
     # non-leader units should not start directly
     state_in = testing.State(leader=False)
     with (
-        patch("workload.EtcdWorkload.alive", return_value=True),
+        patch("workload.EtcdWorkload.alive", return_value=False),
         patch("workload.EtcdWorkload.write_file"),
-        patch("workload.EtcdWorkload.start"),
+        patch("workload.EtcdWorkload.start") as start,
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.start(), state_in)
         assert state_out.unit_status != ops.ActiveStatus()
+        start.assert_not_called()
 
     # if authentication cannot be enabled, the charm should error out
     state_in = testing.State(relations={relation}, leader=True)

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -707,6 +707,10 @@ def test_set_tls_private_key():
             "tls_peer_state": "tls",
             "state": "started",
         },
+        local_app_data={
+            "cluster_state": "existing",
+            "authentication": "enabled",
+        },
     )
     restart_peer_relation = testing.PeerRelation(id=4, endpoint=RESTART_RELATION)
     peer_tls_relation = testing.Relation(id=2, endpoint=PEER_TLS_RELATION_NAME)

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -220,6 +220,7 @@ def test_enable_tls_on_start():
         )
         state_out = ctx.run(ctx.on.start(), state_in)
         assert "start" in [event.name for event in state_out.deferred]
+        assert state_out.app_status == Status.TLS_ENABLING_PEER_TLS.value.status
 
         peer_relation = testing.PeerRelation(
             id=1,
@@ -237,6 +238,7 @@ def test_enable_tls_on_start():
         )
         state_out = ctx.run(ctx.on.start(), state_in)
         assert "start" in [event.name for event in state_out.deferred]
+        assert state_out.app_status == Status.TLS_ENABLING_CLIENT_TLS.value.status
 
         peer_relation = testing.PeerRelation(
             id=1,
@@ -257,6 +259,7 @@ def test_enable_tls_on_start():
         assert state_out.unit_status == Status.ACTIVE.value.status
         assert peer_relation.local_unit_data["state"] == "started"
         assert peer_relation.local_app_data["cluster_state"] == "existing"
+        assert state_out.app_status == Status.ACTIVE.value.status
 
 
 def test_certificates_broken():


### PR DESCRIPTION
With this PR, we add basic status handling for units and application. The implementation adheres to the guidelines provided in [Evaluating charm status across multiple components](https://discourse.charmhub.io/t/how-to-set-a-charms-status/11771#heading--evaluate-charm-status-across-multiple-components).

The changed behaviour can be nicely been seen in the integration test runs on CI, for example [this one](https://github.com/canonical/charmed-etcd-operator/actions/runs/13721304582/job/38377439306?pr=50#step:29:786) from line 785 onwards.

The main changes are:

**charm.py:**
- keeping a list of `pending_inactive_statuses`
- observing the `collect_unit_status` and `collect_app_status` events
- do not set status (`TLS_TRANSITION_FAILED`) if we raise an error in the event handler

**EtcdEvents:**
- do not set `ActiveStatus` as this is now part of `CollectStatusEvent` handler
- set status if deferring `on_start` because TLS is not ready or the unit did not join the cluster yet
- set status when encountering errors in `update_admin_password()`

**ClusterManager:**
- new method `compute_cluster_status()`

unrelated changes:
- `literals.py` re-arrange `Status` class in alphabetical order for better readability
- update `tls_certificates` lib from version `4.9` to `4.11`