### PR TITLE
fix tls integration test

### DIFF
--- a/tests/integration/ha/test_ha_on_rolling_restart.py
+++ b/tests/integration/ha/test_ha_on_rolling_restart.py
@@ -38,7 +38,7 @@ async def test_deploy_with_peer_tls(ops_test: OpsTest) -> None:
     """Deploy a cluster with three units and peer-certificates."""
     # Deploy the TLS charm
     tls_config = {"ca-common-name": "etcd"}
-    await ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config)
+    await ops_test.model.deploy(TLS_NAME, channel="1/edge", config=tls_config)
 
     if await existing_app(ops_test):
         return

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -176,7 +176,7 @@ async def test_network_cut_on_raft_leader_with_ip_change(ops_test: OpsTest) -> N
 
     # Deploy the TLS charm
     tls_config = {"ca-common-name": "etcd"}
-    await ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config)
+    await ops_test.model.deploy(TLS_NAME, channel="1/edge", config=tls_config)
 
     # make sure we have at least two units so we can stop one of them
     if len(ops_test.model.applications[app].units) < 2:

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -44,7 +44,7 @@ async def test_build_and_deploy_with_tls(ops_test: OpsTest) -> None:
     """
     # Deploy the TLS charm
     tls_config = {"ca-common-name": "etcd"}
-    await ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config)
+    await ops_test.model.deploy(TLS_NAME, channel="1/edge", config=tls_config)
 
     # Deploy the charm and wait for active/idle status
     logger.info("Deploying the charm")

--- a/tests/integration/tls/test_private_key_rotation.py
+++ b/tests/integration/tls/test_private_key_rotation.py
@@ -54,7 +54,7 @@ async def test_build_and_deploy_with_tls(ops_test: OpsTest) -> None:
     assert ops_test.model is not None, "Model is not set"
     # Deploy the TLS charm
     tls_config = {"ca-common-name": "etcd"}
-    await ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config)
+    await ops_test.model.deploy(TLS_NAME, channel="1/edge", config=tls_config)
     # Deploy the charm and wait for active/idle status
     logger.info("Deploying the charm")
     await ops_test.model.deploy(CHARM_PATH, num_units=NUM_UNITS)

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -45,7 +45,7 @@ async def test_build_and_deploy_with_tls(ops_test: OpsTest) -> None:
     assert ops_test.model is not None, "Model is not set"
     # Deploy the TLS charm
     tls_config = {"ca-common-name": "etcd"}
-    await ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config)
+    await ops_test.model.deploy(TLS_NAME, channel="1/edge", config=tls_config)
 
     # Deploy the charm and wait for active/idle status
     logger.info("Deploying the charm")


### PR DESCRIPTION
# Issue
The integration test `test_tls` fails with: `test_certificate_expiration - juju.errors.JujuError: ['parsing settings for application: option "certificate-validity" expected int, got "3m"']`

# Solution
switch to channel `1/edge` for deployment of self-signed-certificates operator, as recommended by the team in [this chat message](https://matrix.to/#/!yAkGlrYcBFYzYRvOlQ:ubuntu.com/$VDo9U_k0FAgDc7pET6S1ZZPxgirSoHtI3FF5IXoVcm4?via=ubuntu.com&via=matrix.org&via=laquadrature.net).