### PR TITLE
[DPE-6790] - TLS Status Handling

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -221,6 +221,8 @@ class EtcdOperatorCharm(ops.CharmBase):
 
         # compute TLS status
         # todo: add compute logic here
+        for status in self.tls_manager.compute_component_status():
+            event.add_status(status.value.status)
 
         # compute backup or other component's  status
         # todo: add compute logic here

--- a/src/charm.py
+++ b/src/charm.py
@@ -220,7 +220,6 @@ class EtcdOperatorCharm(ops.CharmBase):
             event.add_status(status.value.status)
 
         # compute TLS status
-        # todo: add compute logic here
         for status in self.tls_manager.compute_component_status():
             event.add_status(status.value.status)
 

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -359,7 +359,7 @@ class EtcdEvents(Object):
         logger.debug("Updating TLS private key.")
 
         if self.charm.tls_events.read_and_validate_private_key(private_key_id) is None:
-            self.charm.tls_manager.add_component_status(Status.TLS_INVALID_PRIVATE_KEY)
+            self.charm.set_status(Status.TLS_INVALID_PRIVATE_KEY)
             return
 
         self.charm.tls_events.refresh_tls_certificates_event.emit()

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -103,7 +103,6 @@ class EtcdEvents(Object):
             logger.info(
                 f"Deferring start because TLS is not ready for {self.charm.state.unit_server.member_name}."
             )
-            self.charm.set_status(Status.TLS_NOT_READY)
             event.defer()
             return
 
@@ -360,7 +359,7 @@ class EtcdEvents(Object):
         logger.debug("Updating TLS private key.")
 
         if self.charm.tls_events.read_and_validate_private_key(private_key_id) is None:
-            self.charm.set_status(Status.TLS_INVALID_PRIVATE_KEY)
+            self.charm.tls_manager.add_component_status(Status.TLS_INVALID_PRIVATE_KEY)
             return
 
         self.charm.tls_events.refresh_tls_certificates_event.emit()

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -96,13 +96,13 @@ class TLSEvents(Object):
             if (
                 peer_private_key := self.read_and_validate_private_key(peer_private_key_id)
             ) is None:
-                self.charm.set_status(Status.TLS_INVALID_PRIVATE_KEY)
+                self.charm.tls_manager.add_component_status(Status.TLS_INVALID_PRIVATE_KEY)
 
         if client_private_key_id := self.charm.config.get(TLS_CLIENT_PRIVATE_KEY_CONFIG):
             if (
                 client_private_key := self.read_and_validate_private_key(client_private_key_id)
             ) is None:
-                self.charm.set_status(Status.TLS_INVALID_PRIVATE_KEY)
+                self.charm.tls_manager.add_component_status(Status.TLS_INVALID_PRIVATE_KEY)
 
         self.peer_certificate = TLSCertificatesRequiresV4(
             self.charm,
@@ -156,10 +156,8 @@ class TLSEvents(Object):
         """
         if event.relation.name == PEER_TLS_RELATION_NAME:
             self.charm.tls_manager.set_tls_state(state=TLSState.TO_TLS, tls_type=TLSType.PEER)
-            self.charm.set_status(Status.TLS_ENABLING_PEER_TLS)
         else:
             self.charm.tls_manager.set_tls_state(state=TLSState.TO_TLS, tls_type=TLSType.CLIENT)
-            self.charm.set_status(Status.TLS_ENABLING_CLIENT_TLS)
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Handle the `certificates-available` event.

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -96,13 +96,13 @@ class TLSEvents(Object):
             if (
                 peer_private_key := self.read_and_validate_private_key(peer_private_key_id)
             ) is None:
-                self.charm.tls_manager.add_component_status(Status.TLS_INVALID_PRIVATE_KEY)
+                self.charm.set_status(Status.TLS_INVALID_PRIVATE_KEY)
 
         if client_private_key_id := self.charm.config.get(TLS_CLIENT_PRIVATE_KEY_CONFIG):
             if (
                 client_private_key := self.read_and_validate_private_key(client_private_key_id)
             ) is None:
-                self.charm.tls_manager.add_component_status(Status.TLS_INVALID_PRIVATE_KEY)
+                self.charm.set_status(Status.TLS_INVALID_PRIVATE_KEY)
 
         self.peer_certificate = TLSCertificatesRequiresV4(
             self.charm,

--- a/src/literals.py
+++ b/src/literals.py
@@ -83,9 +83,7 @@ class Status(Enum):
         BlockedStatus("The private key provided is not valid. Please provide a valid private key"),
         "ERROR",
     )
-    TLS_NOT_READY = StatusLevel(
-        MaintenanceStatus("Deferring start because TLS is not ready"), "DEBUG"
-    )
+    TLS_NOT_READY = StatusLevel(MaintenanceStatus("Waiting for TLS to be ready"), "DEBUG")
     TLS_PEER_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating peer CA..."), "DEBUG")
     TLS_CLIENT_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating client CA..."), "DEBUG")
     SERVICE_NOT_INSTALLED = StatusLevel(BlockedStatus("unable to install etcd snap"), "ERROR")

--- a/src/literals.py
+++ b/src/literals.py
@@ -83,7 +83,11 @@ class Status(Enum):
         BlockedStatus("The private key provided is not valid. Please provide a valid private key"),
         "ERROR",
     )
-    TLS_NOT_READY = StatusLevel(BlockedStatus("Deferring start because TLS is not ready"), "ERROR")
+    TLS_NOT_READY = StatusLevel(
+        MaintenanceStatus("Deferring start because TLS is not ready"), "DEBUG"
+    )
+    TLS_PEER_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating peer CA..."), "DEBUG")
+    TLS_CLIENT_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating client CA..."), "DEBUG")
     SERVICE_NOT_INSTALLED = StatusLevel(BlockedStatus("unable to install etcd snap"), "ERROR")
     SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("etcd service not running"), "ERROR")
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -26,7 +26,6 @@ class TLSManager:
         self.state = state
         self.workload = workload
         self.substrate = substrate
-        self._component_status_list: list[Status] = []
 
     def set_tls_state(self, state: TLSState, tls_type: TLSType) -> None:
         """Set the TLS state.
@@ -205,7 +204,7 @@ class TLSManager:
 
     def compute_component_status(self) -> list[Status]:
         """Compute the component status."""
-        status_list = list(self._component_status_list)
+        status_list = []
 
         if self.state.unit_server.tls_peer_state == TLSState.TO_TLS:
             status_list.append(Status.TLS_ENABLING_PEER_TLS)
@@ -226,11 +225,3 @@ class TLSManager:
             status_list.append(Status.TLS_CLIENT_CA_ROTATING)
 
         return status_list
-
-    def add_component_status(self, status: Status) -> None:
-        """Add a component status.
-
-        Args:
-            status (Status): The status to add.
-        """
-        self._component_status_list.append(status)

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -14,7 +14,7 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
 
 from core.cluster import ClusterState
 from core.workload import WorkloadBase
-from literals import SUBSTRATES, TLSCARotationState, TLSState, TLSType
+from literals import SUBSTRATES, Status, TLSCARotationState, TLSState, TLSType
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +26,7 @@ class TLSManager:
         self.state = state
         self.workload = workload
         self.substrate = substrate
+        self._component_status_list: list[Status] = []
 
     def set_tls_state(self, state: TLSState, tls_type: TLSType) -> None:
         """Set the TLS state.
@@ -201,3 +202,35 @@ class TLSManager:
             ]:
                 return False
         return True
+
+    def compute_component_status(self) -> list[Status]:
+        """Compute the component status."""
+        status_list = list(self._component_status_list)
+
+        if self.state.unit_server.tls_peer_state == TLSState.TO_TLS:
+            status_list.append(Status.TLS_ENABLING_PEER_TLS)
+
+        if self.state.unit_server.tls_client_state == TLSState.TO_TLS:
+            status_list.append(Status.TLS_ENABLING_CLIENT_TLS)
+
+        if self.state.unit_server.tls_peer_state == TLSState.TO_NO_TLS:
+            status_list.append(Status.TLS_DISABLING_PEER_TLS)
+
+        if self.state.unit_server.tls_client_state == TLSState.TO_NO_TLS:
+            status_list.append(Status.TLS_DISABLING_CLIENT_TLS)
+
+        if self.state.unit_server.tls_peer_ca_rotation_state != TLSCARotationState.NO_ROTATION:
+            status_list.append(Status.TLS_PEER_CA_ROTATING)
+
+        if self.state.unit_server.tls_client_ca_rotation_state != TLSCARotationState.NO_ROTATION:
+            status_list.append(Status.TLS_CLIENT_CA_ROTATING)
+
+        return status_list
+
+    def add_component_status(self, status: Status) -> None:
+        """Add a component status.
+
+        Args:
+            status (Status): The status to add.
+        """
+        self._component_status_list.append(status)

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -220,6 +220,7 @@ def test_enable_tls_on_start():
         )
         state_out = ctx.run(ctx.on.start(), state_in)
         assert "start" in [event.name for event in state_out.deferred]
+        assert state_out.app_status == Status.TLS_ENABLING_PEER_TLS.value.status
 
         peer_relation = testing.PeerRelation(
             id=1,
@@ -237,6 +238,7 @@ def test_enable_tls_on_start():
         )
         state_out = ctx.run(ctx.on.start(), state_in)
         assert "start" in [event.name for event in state_out.deferred]
+        assert state_out.app_status == Status.TLS_ENABLING_CLIENT_TLS.value.status
 
         peer_relation = testing.PeerRelation(
             id=1,
@@ -257,6 +259,7 @@ def test_enable_tls_on_start():
         assert state_out.unit_status == Status.ACTIVE.value.status
         assert peer_relation.local_unit_data["state"] == "started"
         assert peer_relation.local_app_data["cluster_state"] == "existing"
+        assert state_out.app_status == Status.ACTIVE.value.status
 
 
 def test_certificates_broken():


### PR DESCRIPTION
This pull request includes several changes focused on improving the handling and computation of TLS statuses within the `etcd` charm. The changes involve updating the methods for setting and computing TLS statuses, as well as modifying the status levels and their logging levels.

Improvements to TLS status handling:

* [`src/charm.py`](diffhunk://#diff-b9ed39bbc9c0387bd3e07da31d13373745534a1cd723d3e292c73496b12e307cR224-R225): Added logic to compute and add TLS component statuses in the `_on_collect_status` method.
* [`src/events/etcd.py`](diffhunk://#diff-4d4b45129d72bf79a08e70009a59f4ebe0a016b4727117155249c864ae4a1b49L106): Removed the direct setting of TLS status and replaced it with deferring events and adding component statuses through the `tls_manager`. [[1]](diffhunk://#diff-4d4b45129d72bf79a08e70009a59f4ebe0a016b4727117155249c864ae4a1b49L106) [[2]](diffhunk://#diff-4d4b45129d72bf79a08e70009a59f4ebe0a016b4727117155249c864ae4a1b49L363-R362)
* [`src/events/tls.py`](diffhunk://#diff-3dfb4a104b407f7d4b2e07795a63745a09cde228a8dbe86602e7b72ea600fbe4L99-R105): Updated the initialization and event handling methods to use the `tls_manager` for adding component statuses instead of directly setting the status. [[1]](diffhunk://#diff-3dfb4a104b407f7d4b2e07795a63745a09cde228a8dbe86602e7b72ea600fbe4L99-R105) [[2]](diffhunk://#diff-3dfb4a104b407f7d4b2e07795a63745a09cde228a8dbe86602e7b72ea600fbe4L159-L162)

Status level modifications:

* [`src/literals.py`](diffhunk://#diff-959ba637043ab4ac88c6f9f9109022f78a7df1b9a2ab3a0407bff4f124c2db64L86-R90): Changed the status level for `TLS_NOT_READY` to `MaintenanceStatus` with a "DEBUG" log level and added new statuses for peer and client CA rotations.

Enhancements to `tls_manager`:

* [`src/managers/tls.py`](diffhunk://#diff-a2c036f44ae9bbab595aad84b23bc3106a342c5ab12f7b0cf3d26268b51cdc83L17-R17): Introduced a list to track component statuses, and added methods to compute component statuses and add new statuses to the list. [[1]](diffhunk://#diff-a2c036f44ae9bbab595aad84b23bc3106a342c5ab12f7b0cf3d26268b51cdc83L17-R17) [[2]](diffhunk://#diff-a2c036f44ae9bbab595aad84b23bc3106a342c5ab12f7b0cf3d26268b51cdc83R29) [[3]](diffhunk://#diff-a2c036f44ae9bbab595aad84b23bc3106a342c5ab12f7b0cf3d26268b51cdc83R205-R236)