### PR TITLE
[DPE-6850] improve UX with status messages

### DIFF
--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -95,6 +95,9 @@ class EtcdEvents(Object):
 
     def _on_start(self, event: ops.StartEvent) -> None:  # noqa: C901
         """Handle start event."""
+        # check if data exists before doing any operation
+        storage_reuse = self.charm.workload.exists(DATABASE_DIR)
+
         tls_transition_states = [TLSState.TO_TLS, TLSState.TO_NO_TLS]
         if (
             self.charm.state.unit_server.tls_client_state in tls_transition_states
@@ -113,13 +116,18 @@ class EtcdEvents(Object):
             # all subsequent units will have to be added as member before starting the workload
             self.charm.cluster_manager.start_member()
 
-            if self.charm.workload.exists(DATABASE_DIR):
+            if storage_reuse:
                 # this is a new application but storage is reused
-                self.charm.state.cluster.update({"authentication": "enabled"})
                 # update cluster membership configuration after recovering existing data
-                self.charm.cluster_manager.broadcast_peer_url(
-                    self.charm.state.unit_server.peer_url
-                )
+                try:
+                    self.charm.cluster_manager.broadcast_peer_url(
+                        self.charm.state.unit_server.peer_url
+                    )
+                    self.charm.state.cluster.update({"authentication": "enabled"})
+                except ValueError:
+                    logger.error("Failed to update member configuration")
+                    event.defer()
+                    return
 
             if not self.charm.state.cluster.auth_enabled:
                 try:
@@ -141,13 +149,16 @@ class EtcdEvents(Object):
                         self.charm.state.cluster.update({"authentication": "enabled"})
                     except (EtcdAuthNotEnabledError, EtcdUserManagementError) as e:
                         logger.error(e)
-                        raise
+                        event.defer()
+                        return
                 else:
-                    raise EtcdAuthNotEnabledError("Authentication not enabled.")
+                    logger.error("Authentication not enabled.")
+                    event.defer()
+                    return
 
             if not self.charm.state.unit_server.is_started:
                 # database files should not be deleted on running units
-                if self.charm.workload.exists(DATABASE_DIR):
+                if storage_reuse:
                     logger.warning(f"Existing database file detected in {DATABASE_DIR}.")
                     # storage cannot be reused on non-leader members
                     try:

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -170,6 +170,7 @@ class EtcdEvents(Object):
                         # if removing fails, we cannot start the workload or the member would crash
                         raise
 
+                self.charm.set_status(Status.SERVICE_STARTING)
                 self.charm.cluster_manager.start_member()
         else:
             # this unit that has not yet been added to the cluster

--- a/src/literals.py
+++ b/src/literals.py
@@ -89,6 +89,7 @@ class Status(Enum):
     TLS_PEER_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating peer CA..."), "DEBUG")
     TLS_CLIENT_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating client CA..."), "DEBUG")
     SERVICE_INSTALLING = StatusLevel(MaintenanceStatus("Installing etcd..."), "DEBUG")
+    SERVICE_STARTING = StatusLevel(MaintenanceStatus("Waiting for etcd to start..."), "DEBUG")
     SERVICE_NOT_INSTALLED = StatusLevel(BlockedStatus("unable to install etcd snap"), "ERROR")
     SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("etcd service not running"), "ERROR")
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -63,6 +63,7 @@ class Status(Enum):
     AUTHENTICATION_NOT_ENABLED = StatusLevel(
         BlockedStatus("failed to enable authentication in etcd"), "ERROR"
     )
+    CLUSTER_INITIALIZING = StatusLevel(MaintenanceStatus("Initializing etcd cluster..."), "DEBUG")
     CLUSTER_MANAGEMENT_ERROR = StatusLevel(BlockedStatus("cluster management error"), "ERROR")
     CLUSTER_NOT_INITIALIZED = StatusLevel(
         BlockedStatus("Waiting for cluster initialization"), "ERROR"
@@ -87,6 +88,7 @@ class Status(Enum):
     TLS_NOT_READY = StatusLevel(MaintenanceStatus("Waiting for TLS to be ready"), "DEBUG")
     TLS_PEER_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating peer CA..."), "DEBUG")
     TLS_CLIENT_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating client CA..."), "DEBUG")
+    SERVICE_INSTALLING = StatusLevel(MaintenanceStatus("Installing etcd..."), "DEBUG")
     SERVICE_NOT_INSTALLED = StatusLevel(BlockedStatus("unable to install etcd snap"), "ERROR")
     SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("etcd service not running"), "ERROR")
 

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -126,6 +126,11 @@ class ClusterManager:
         logger.debug(f"Member: {member_list[self.state.unit_server.member_name].id}")
         return member_list[self.state.unit_server.member_name]
 
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(2),
+        reraise=True,
+    )
     def broadcast_peer_url(self, peer_urls: str) -> None:
         """Broadcast the peer URL to all units in the cluster.
 

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -329,4 +329,10 @@ class ClusterManager:
             if not self.state.cluster.auth_enabled:
                 status_list.append(Status.AUTHENTICATION_NOT_ENABLED)
 
+        if not self.state.peer_relation:
+            status_list.append(Status.SERVICE_INSTALLING)
+
+        if not self.state.cluster.cluster_state:
+            status_list.append(Status.CLUSTER_INITIALIZING)
+
         return status_list

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -183,7 +183,7 @@ def test_start():
         patch("workload.EtcdWorkload.alive", return_value=True),
     ):
         state_out = ctx.run(ctx.on.start(), state_in)
-        assert state_out.unit_status == ops.ActiveStatus()
+        assert state_out.unit_status == ops.MaintenanceStatus("Waiting for etcd to start...")
         assert state_out.get_relation(1).local_unit_data.get("state") == "started"
         start.assert_called_once()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -14,7 +14,6 @@ from pytest import raises
 
 from charm import EtcdOperatorCharm
 from common.exceptions import (
-    EtcdAuthNotEnabledError,
     EtcdClusterManagementError,
     EtcdUserManagementError,
 )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -63,7 +63,7 @@ def test_internal_user_creation():
 def test_start():
     ctx = testing.Context(EtcdOperatorCharm)
     relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
-    state_in = testing.State(leader=True)
+    state_in = testing.State(leader=True, relations={relation})
 
     with (
         patch("workload.EtcdWorkload.alive", return_value=True),
@@ -75,7 +75,15 @@ def test_start():
         assert state_out.unit_status == ops.ActiveStatus()
 
     # non-leader units should not start directly
-    state_in = testing.State(leader=False)
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={
+            "authentication": "enabled",
+            "cluster_state": "existing",
+        },
+    )
+    state_in = testing.State(leader=False, relations={relation})
     with (
         patch("workload.EtcdWorkload.alive", return_value=False),
         patch("workload.EtcdWorkload.write_file"),
@@ -87,6 +95,10 @@ def test_start():
         start.assert_not_called()
 
     # if authentication cannot be enabled, the charm should error out
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+    )
     state_in = testing.State(relations={relation}, leader=True)
     with (
         patch("workload.EtcdWorkload.alive", return_value=True),
@@ -246,7 +258,15 @@ def test_start():
 
 def test_update_status():
     ctx = testing.Context(EtcdOperatorCharm)
-    state_in = testing.State()
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={
+            "authentication": "enabled",
+            "cluster_state": "existing",
+        },
+    )
+    state_in = testing.State(relations={relation})
 
     # restart workload if not running
     with (

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -204,12 +204,10 @@ def test_start():
         patch("workload.EtcdWorkload.write_file"),
         patch("subprocess.run", side_effect=CalledProcessError(returncode=1, cmd="test")),
     ):
-        with raises(testing.errors.UncaughtCharmError) as e:
-            state_out = ctx.run(ctx.on.start(), state_in)
-            assert not state_out.get_relation(1).local_app_data.get("authentication") == "enabled"
+        state_out = ctx.run(ctx.on.start(), state_in)
+        assert not state_out.get_relation(1).local_app_data.get("authentication") == "enabled"
 
         start.assert_not_called()
-        assert isinstance(e.value.__cause__, EtcdUserManagementError)
 
     # leader started but auth not enabled -> retry -> success
     relation = testing.PeerRelation(
@@ -248,12 +246,10 @@ def test_start():
         patch("workload.EtcdWorkload.start") as start,
         patch("workload.EtcdWorkload.write_file"),
     ):
-        with raises(testing.errors.UncaughtCharmError) as e:
-            state_out = ctx.run(ctx.on.start(), state_in)
-            assert not state_out.get_relation(1).local_unit_data.get("state") == "started"
+        state_out = ctx.run(ctx.on.start(), state_in)
+        assert not state_out.get_relation(1).local_unit_data.get("state") == "started"
 
         start.assert_not_called()
-        assert isinstance(e.value.__cause__, EtcdAuthNotEnabledError)
 
 
 def test_update_status():

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -211,6 +211,10 @@ def test_enable_tls_on_start():
                 "ip": "localhost",
                 "tls_peer_state": TLSState.TO_TLS.value,
             },
+            local_app_data={
+                "authentication": "enabled",
+                "cluster_state": "existing",
+            },
         )
         peer_tls_relation = testing.Relation(id=2, endpoint=PEER_TLS_RELATION_NAME)
         client_tls_relation = testing.Relation(id=3, endpoint=CLIENT_TLS_RELATION_NAME)
@@ -228,6 +232,10 @@ def test_enable_tls_on_start():
             local_unit_data={
                 "ip": "localhost",
                 "tls_client_state": TLSState.TO_TLS.value,
+            },
+            local_app_data={
+                "authentication": "enabled",
+                "cluster_state": "existing",
             },
         )
         peer_tls_relation = testing.Relation(id=2, endpoint=PEER_TLS_RELATION_NAME)
@@ -610,7 +618,14 @@ def test_enabling_tls_one_restart(certificate_available_context):
 def test_certificates_relation_created():
     """Test TLS certificates relation created."""
     ctx = testing.Context(EtcdOperatorCharm)
-    peer_relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
+    peer_relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={
+            "authentication": "enabled",
+            "cluster_state": "existing",
+        },
+    )
     peer_tls_relation = testing.Relation(id=2, endpoint=PEER_TLS_RELATION_NAME)
 
     state_in = testing.State(
@@ -625,7 +640,14 @@ def test_certificates_relation_created():
             == TLSState.TO_TLS.value
         )
 
-    peer_relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
+    peer_relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={
+            "authentication": "enabled",
+            "cluster_state": "existing",
+        },
+    )
     client_tls_relation = testing.Relation(id=2, endpoint=CLIENT_TLS_RELATION_NAME)
 
     state_in = testing.State(


### PR DESCRIPTION
This PR improves the UX with better status messages for the following cases:
- on installation
- on cluster initialization by the leader
- when reusing storage, if authentication fails because the credentials were not provided by the user

It also adds a retry to the `ClusterManager`'s `broadcast_peer_url()` method to account for failures when the etcd service has just been started and may take a few seconds to be available for updating the member configuration.