### PR TITLE
Ignore docs folder in charm workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ concurrency:
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
   schedule:
     - cron: "53 0 * * *" # Daily at 00:53 UTC
   # Triggered on push to default branch by .github/workflows/release.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - 3.5/edge
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   ci-tests:


### PR DESCRIPTION
## Issue

Tests designed for charm code currently run unnecessarily on doc-related PRs.

## Solution

Add a `paths-ignore` directive to `release.yaml` and `ci.yaml`. 