### PR TITLE
Increase external clients relation stability

### DIFF
--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -124,6 +124,10 @@ class ExternalClientsManager:
         if not self.state.etcd_provides.relations:
             return
 
+        if not self.state.cluster.cluster_state:
+            logger.debug("Cluster not yet initialized, cannot update client relation data.")
+            return
+
         cluster_server_names = {
             uri.split("=")[0] for uri in self.state.cluster.cluster_members.split(",")
         }


### PR DESCRIPTION
# Issue
If the cluster has not been started/initialized yet, event processing of `peer_relation_changed` could fail on updating the external client relation data with information from the cluster. Can be seen in some integration test runs on data-integrator, such as [here](https://github.com/canonical/data-integrator/actions/runs/14692645787/job/41230176204#step:29:253).

# Solution
Only update external clients relation data if the cluster has already been initialized.