### PR TITLE
fix(DPE-7106): fix double mtls changed event being emitted

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2200,4 +2200,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "1e8c18c780b7915383a9e92b67d8fef6912a2ffbbb47fe483bb11bd9f979875d"
+content-hash = "b8574cb963ea5d18610a4d6bc1065d9a979fd5e56585e086c900b19f853d11bb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ ops = ">=2.0.0"
 poetry-core = "*"
 # tls_certificates_interface/v4/tls_certificates.py
 cryptography = "==44.0.2"
-pydantic = "==2.9.1"
+pydantic = ">= 1.0"
 cosl = ">= 0.0.50"
 
 [tool.poetry.requires-plugins]
@@ -59,7 +59,7 @@ juju = "==3.6.0"
 allure-pytest = "*"
 allure-pytest-collection-report = { git = "https://github.com/canonical/data-platform-workflows", tag = "v29.0.0", subdirectory = "python/pytest_plugins/allure_pytest_collection_report" }
 tenacity = "*"
-pydantic = "==2.9.1"
+pydantic = ">= 1.0"
 
 [tool.coverage.run]
 branch = true

--- a/src/events/external_clients.py
+++ b/src/events/external_clients.py
@@ -125,13 +125,12 @@ class ExternalClientsEvents(Object):
                     )
                 )
                 if self.charm.cluster_manager.get_user(common_name) is not None:
-                    if common_name != relation_managed_user:
-                        logger.error("User already exists")
-                        self.charm.set_status(Status.EC_USERNAME_EXISTS)
-                        return
                     if common_name == relation_managed_user:
                         logger.debug("User is already being added for this relation")
-                        return
+                    else:
+                        logger.error("User already exists")
+                        self.charm.set_status(Status.EC_USERNAME_EXISTS)
+                    return
 
                 if relation_managed_user is None:
                     logger.info(f"Creating new user: {common_name}")

--- a/src/events/external_clients.py
+++ b/src/events/external_clients.py
@@ -105,9 +105,6 @@ class ExternalClientsEvents(Object):
                 return
             return
 
-        relation_managed_user = self.charm.external_clients_manager.get_relation_managed_user(
-            event.relation.id
-        )
         # if leader then create/update user
         if self.charm.unit.is_leader():
             if old_common_name != common_name:
@@ -121,6 +118,12 @@ class ExternalClientsEvents(Object):
                     except EtcdUserManagementError as e:
                         logger.error(f"Failed to remove old user from etcd: {e}")
                     self.charm.external_clients_manager.remove_managed_user(event.relation.id)
+
+                relation_managed_user = (
+                    self.charm.external_clients_manager.get_relation_managed_user(
+                        event.relation.id
+                    )
+                )
                 if self.charm.cluster_manager.get_user(common_name) is not None:
                     if common_name != relation_managed_user:
                         logger.error("User already exists")

--- a/src/events/external_clients.py
+++ b/src/events/external_clients.py
@@ -105,6 +105,9 @@ class ExternalClientsEvents(Object):
                 return
             return
 
+        relation_managed_user = self.charm.external_clients_manager.get_relation_managed_user(
+            event.relation.id
+        )
         # if leader then create/update user
         if self.charm.unit.is_leader():
             if old_common_name != common_name:
@@ -118,21 +121,25 @@ class ExternalClientsEvents(Object):
                     except EtcdUserManagementError as e:
                         logger.error(f"Failed to remove old user from etcd: {e}")
                     self.charm.external_clients_manager.remove_managed_user(event.relation.id)
-
                 if self.charm.cluster_manager.get_user(common_name) is not None:
-                    logger.error("User already exists")
-                    self.charm.set_status(Status.EC_USERNAME_EXISTS)
-                    return
+                    if common_name != relation_managed_user:
+                        logger.error("User already exists")
+                        self.charm.set_status(Status.EC_USERNAME_EXISTS)
+                        return
+                    if common_name == relation_managed_user:
+                        logger.debug("User is already being added for this relation")
+                        return
 
-                logger.info("Creating new user")
-                self.charm.cluster_manager.add_managed_user(common_name, event.prefix)
-                self.charm.external_clients_manager.add_managed_user(
-                    event.relation.id, common_name
-                )
-                self.etcd_provides.set_credentials(event.relation.id, common_name, "")
-                self.charm.external_clients_manager.update_client_relations_data(
-                    etcd_version=self.charm.cluster_manager.get_version()
-                )
+                if relation_managed_user is None:
+                    logger.info(f"Creating new user: {common_name}")
+                    self.charm.cluster_manager.add_managed_user(common_name, event.prefix)
+                    self.charm.external_clients_manager.add_managed_user(
+                        event.relation.id, common_name
+                    )
+                    self.etcd_provides.set_credentials(event.relation.id, common_name, "")
+                    self.charm.external_clients_manager.update_client_relations_data(
+                        etcd_version=self.charm.cluster_manager.get_version()
+                    )
 
         relation_managed_user = self.charm.external_clients_manager.get_relation_managed_user(
             event.relation.id


### PR DESCRIPTION
fixes #73 

## Context
The `mtls_cert_updated` is fired twice because relation changed is being fired twice:
- Once when requirer updates the data on `relation_created`.
- [2nd time right after `relation_joined`](https://arc.net/l/quote/hcevgqfy)

## Fix
Add conditions to detect when user is already being created and return