### PR TITLE
Minor fixes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -243,6 +243,7 @@ class EtcdOperatorCharm(ops.CharmBase):
         """
         if self.app.planned_units() == 0:
             event.add_status(Status.REMOVED.value.status)
+            return
 
         # compute cluster status
         for status in self.cluster_manager.compute_component_status():

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -300,7 +300,12 @@ class ClusterManager:
                 # wait for leadership to be moved before continuing operation
                 if self.is_healthy(cluster=True):
                     logger.debug(f"Successfully moved leader to {new_leader_id}.")
-        except (EtcdClusterManagementError, RaftLeaderNotFoundError, ValueError) as e:
+        except (
+            EtcdClusterManagementError,
+            RaftLeaderNotFoundError,
+            ValueError,
+            StopIteration,
+        ) as e:
             logger.warning(f"Could not transfer cluster leadership: {e}")
             return
 


### PR DESCRIPTION
This PR fixes some minor issues that were found when testing:
- Do not add any other status when removing all units (can only be seen in the debug log).
- Handle cases when raft leadership cannot be transferred because there is no other cluster member. This raises a `StopIteration` exception that was not handled yet.