### PR TITLE
[DPE-7104] Bugfix: CA rotation fails if client certificates already expired

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,6 @@ jobs:
       - unit-test
       - build
     uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v29.0.0
-    timeout-minutes: 60
     with:
       juju-agent-version: ${{ matrix.juju.agent }}
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,7 @@ jobs:
       - unit-test
       - build
     uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v29.0.0
+    timeout-minutes: 60
     with:
       juju-agent-version: ${{ matrix.juju.agent }}
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,6 +5,7 @@
 """Charmed machine operator for etcd."""
 
 import logging
+from subprocess import CalledProcessError
 
 import ops
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
@@ -214,7 +215,11 @@ class EtcdOperatorCharm(ops.CharmBase):
         # this can happen if the client certificate has already expired
         # on CA-rotation the certs are only updated AFTER all cluster members updated the CA
         if not self.cluster_manager.restart_member():
-            logger.warning("Health check failed after ca rotation restart")
+            try:
+                self.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
+                raise HealthCheckFailedError("Failed to check health of the member after restart")
+            except CalledProcessError:
+                logger.warning("Health check failed, TLS client certificates expired")
 
         if self.state.unit_server.tls_peer_ca_rotation_state == TLSCARotationState.NEW_CA_DETECTED:
             self.tls_manager.set_ca_rotation_state(TLSType.PEER, TLSCARotationState.NEW_CA_ADDED)
@@ -244,7 +249,11 @@ class EtcdOperatorCharm(ops.CharmBase):
         # this can happen if the client certificate has already expired but was not renewed yet
         # in case the peer certificate came first
         if not self.cluster_manager.restart_member():
-            logger.warning("Health check failed after ca cleanup restart")
+            try:
+                self.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
+                raise HealthCheckFailedError("Failed to check health of the member after restart")
+            except CalledProcessError:
+                logger.warning("Health check failed, TLS client certificates expired")
 
     def _on_collect_status(self, event: ops.CollectStatusEvent) -> None:
         """Compute the current status for this unit.

--- a/src/charm.py
+++ b/src/charm.py
@@ -208,7 +208,14 @@ class EtcdOperatorCharm(ops.CharmBase):
     def _restart_ca_rotation(self, _) -> None:
         """Restart callback for CA rotation."""
         logger.debug("ca rotation restart")
-        self._restart(None)
+
+        self.config_manager.set_config_properties()
+        # do not raise in case health check fails
+        # this can happen if the client certificate has already expired
+        # on CA-rotation the certs are only updated AFTER all cluster members updated the CA
+        if not self.cluster_manager.restart_member():
+            logger.warning("Health check failed after ca rotation restart")
+
         if self.state.unit_server.tls_peer_ca_rotation_state == TLSCARotationState.NEW_CA_DETECTED:
             self.tls_manager.set_ca_rotation_state(TLSType.PEER, TLSCARotationState.NEW_CA_ADDED)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -239,7 +239,12 @@ class EtcdOperatorCharm(ops.CharmBase):
             self.tls_manager.update_cas(self.tls_events.collect_client_cas(), TLSType.CLIENT)
             self.tls_manager.set_ca_rotation_state(TLSType.CLIENT, TLSCARotationState.NO_ROTATION)
 
-        self._restart(None)
+        self.config_manager.set_config_properties()
+        # do not raise in case health check fails
+        # this can happen if the client certificate has already expired but was not renewed yet
+        # in case the peer certificate came first
+        if not self.cluster_manager.restart_member():
+            logger.warning("Health check failed after ca cleanup restart")
 
     def _on_collect_status(self, event: ops.CollectStatusEvent) -> None:
         """Compute the current status for this unit.

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -140,6 +140,11 @@ class EtcdServer(RelationState):
         return self.peer_cert_ready and self.client_cert_ready
 
     @property
+    def certs_expiring(self) -> bool:
+        """Check if any certificate is expiring."""
+        return self.relation_data.get("certificates_expiring", "") == "True"
+
+    @property
     def member_endpoint(self) -> str:
         """Concatenate member_name and peer_url."""
         return f"{self.member_name}={self.peer_url}"

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -140,9 +140,14 @@ class EtcdServer(RelationState):
         return self.peer_cert_ready and self.client_cert_ready
 
     @property
-    def certs_expiring(self) -> bool:
+    def tls_peer_certs_expiring(self) -> bool:
         """Check if any certificate is expiring."""
-        return self.relation_data.get("certificates_expiring", "") == "True"
+        return self.relation_data.get("tls_peer_certificates_expiring", "") == "True"
+
+    @property
+    def tls_client_certs_expiring(self) -> bool:
+        """Check if any certificate is expiring."""
+        return self.relation_data.get("tls_client_certificates_expiring", "") == "True"
 
     @property
     def member_endpoint(self) -> str:

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -241,9 +241,12 @@ class EtcdEvents(Object):
             # reflect membership updates in the cluster state, e.g. ip change or tls switchover
             self.charm.cluster_manager.update_cluster_member_state()
 
-            self.charm.external_clients_manager.update_client_relations_data(
-                etcd_version=self.charm.cluster_manager.get_version()
-            )
+            try:
+                self.charm.external_clients_manager.update_client_relations_data(
+                    etcd_version=self.charm.cluster_manager.get_version()
+                )
+            except KeyError as e:
+                logger.warning(f"Error updating client relations data: {e}")
 
     def _on_peer_relation_departed(self, event: RelationDepartedEvent) -> None:
         """Handle event received by all units when a unit leaves the cluster relation."""

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -250,17 +250,16 @@ class EtcdEvents(Object):
             except KeyError as e:
                 logger.warning(f"Error updating client relations data: {e}")
 
-        try:
-            self.charm.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
-            self.charm.state.unit_server.update({"tls_client_certificates_expiring": ""})
-        except CalledProcessError:
-            self.charm.state.unit_server.update({"tls_client_certificates_expiring": "True"})
-
-        try:
-            self.charm.tls_manager.check_certificate_validity(tls_type=TLSType.PEER)
-            self.charm.state.unit_server.update({"tls_peer_certificates_expiring": ""})
-        except CalledProcessError:
-            self.charm.state.unit_server.update({"tls_peer_certificates_expiring": "True"})
+        for tls_type in TLSType:
+            try:
+                self.charm.tls_manager.check_certificate_validity(tls_type)
+                self.charm.state.unit_server.update(
+                    {f"tls_{tls_type.value}_certificates_expiring": ""}
+                )
+            except CalledProcessError:
+                self.charm.state.unit_server.update(
+                    {f"tls_{tls_type.value}_certificates_expiring": "True"}
+                )
 
     def _on_peer_relation_departed(self, event: RelationDepartedEvent) -> None:
         """Handle event received by all units when a unit leaves the cluster relation."""
@@ -320,17 +319,16 @@ class EtcdEvents(Object):
 
         self.charm.cluster_manager.clean_users()
 
-        try:
-            self.charm.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
-            self.charm.state.unit_server.update({"tls_client_certificates_expiring": ""})
-        except CalledProcessError:
-            self.charm.state.unit_server.update({"tls_client_certificates_expiring": "True"})
-
-        try:
-            self.charm.tls_manager.check_certificate_validity(tls_type=TLSType.PEER)
-            self.charm.state.unit_server.update({"tls_peer_certificates_expiring": ""})
-        except CalledProcessError:
-            self.charm.state.unit_server.update({"tls_peer_certificates_expiring": "True"})
+        for tls_type in TLSType:
+            try:
+                self.charm.tls_manager.check_certificate_validity(tls_type)
+                self.charm.state.unit_server.update(
+                    {f"tls_{tls_type.value}_certificates_expiring": ""}
+                )
+            except CalledProcessError:
+                self.charm.state.unit_server.update(
+                    {f"tls_{tls_type.value}_certificates_expiring": "True"}
+                )
 
     def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
         """Handle the secret_changed event."""

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -249,6 +249,12 @@ class EtcdEvents(Object):
             except KeyError as e:
                 logger.warning(f"Error updating client relations data: {e}")
 
+        try:
+            self.charm.tls_manager.check_certificate_validity()
+            self.charm.state.unit_server.update({"certificates_expiring": ""})
+        except CalledProcessError:
+            self.charm.state.unit_server.update({"certificates_expiring": "True"})
+
     def _on_peer_relation_departed(self, event: RelationDepartedEvent) -> None:
         """Handle event received by all units when a unit leaves the cluster relation."""
         if not self.charm.unit.is_leader():

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -5,6 +5,7 @@
 """Etcd related and core event handlers."""
 
 import logging
+from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 
 import ops
@@ -305,6 +306,12 @@ class EtcdEvents(Object):
                 return
 
         self.charm.cluster_manager.clean_users()
+
+        try:
+            self.charm.tls_manager.check_certificate_validity()
+            self.charm.state.unit_server.update({"certificates_expiring": ""})
+        except CalledProcessError:
+            self.charm.state.unit_server.update({"certificates_expiring": "True"})
 
     def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
         """Handle the secret_changed event."""

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -40,6 +40,7 @@ from literals import (
     TLS_PEER_PRIVATE_KEY_CONFIG,
     Status,
     TLSState,
+    TLSType,
 )
 
 if TYPE_CHECKING:
@@ -250,10 +251,16 @@ class EtcdEvents(Object):
                 logger.warning(f"Error updating client relations data: {e}")
 
         try:
-            self.charm.tls_manager.check_certificate_validity()
-            self.charm.state.unit_server.update({"certificates_expiring": ""})
+            self.charm.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
+            self.charm.state.unit_server.update({"tls_client_certificates_expiring": ""})
         except CalledProcessError:
-            self.charm.state.unit_server.update({"certificates_expiring": "True"})
+            self.charm.state.unit_server.update({"tls_client_certificates_expiring": "True"})
+
+        try:
+            self.charm.tls_manager.check_certificate_validity(tls_type=TLSType.PEER)
+            self.charm.state.unit_server.update({"tls_peer_certificates_expiring": ""})
+        except CalledProcessError:
+            self.charm.state.unit_server.update({"tls_peer_certificates_expiring": "True"})
 
     def _on_peer_relation_departed(self, event: RelationDepartedEvent) -> None:
         """Handle event received by all units when a unit leaves the cluster relation."""
@@ -314,10 +321,16 @@ class EtcdEvents(Object):
         self.charm.cluster_manager.clean_users()
 
         try:
-            self.charm.tls_manager.check_certificate_validity()
-            self.charm.state.unit_server.update({"certificates_expiring": ""})
+            self.charm.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
+            self.charm.state.unit_server.update({"tls_client_certificates_expiring": ""})
         except CalledProcessError:
-            self.charm.state.unit_server.update({"certificates_expiring": "True"})
+            self.charm.state.unit_server.update({"tls_client_certificates_expiring": "True"})
+
+        try:
+            self.charm.tls_manager.check_certificate_validity(tls_type=TLSType.PEER)
+            self.charm.state.unit_server.update({"tls_peer_certificates_expiring": ""})
+        except CalledProcessError:
+            self.charm.state.unit_server.update({"tls_peer_certificates_expiring": "True"})
 
     def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
         """Handle the secret_changed event."""

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -215,9 +215,12 @@ class TLSEvents(Object):
             # Update the CA for external clients
             if cert_type == TLSType.CLIENT:
                 if self.charm.unit.is_leader():
-                    self.charm.external_clients_manager.update_client_relations_data(
-                        etcd_version=self.charm.cluster_manager.get_version()
-                    )
+                    try:
+                        self.charm.external_clients_manager.update_client_relations_data(
+                            etcd_version=self.charm.cluster_manager.get_version()
+                        )
+                    except KeyError as e:
+                        logger.warning(f"Error updating client relations data: {e}")
             self.clean_ca_event.emit(cert_type=cert_type)
             return
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -90,7 +90,12 @@ class Status(Enum):
     TLS_NOT_READY = StatusLevel(MaintenanceStatus("Waiting for TLS to be ready"), "DEBUG")
     TLS_PEER_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating peer CA..."), "DEBUG")
     TLS_CLIENT_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating client CA..."), "DEBUG")
-    TLS_CERTS_EXPIRING = StatusLevel(BlockedStatus("TLS certificates expiring soon..."), "INFO")
+    TLS_CERTS_EXPIRING = StatusLevel(
+        MaintenanceStatus(
+            "TLS certificates expiring soon. Please ensure new certificates are provided."
+        ),
+        "WARNING",
+    )
     SERVICE_INSTALLING = StatusLevel(MaintenanceStatus("Installing etcd..."), "DEBUG")
     SERVICE_STARTING = StatusLevel(MaintenanceStatus("Waiting for etcd to start..."), "DEBUG")
     SERVICE_NOT_INSTALLED = StatusLevel(BlockedStatus("unable to install etcd snap"), "ERROR")

--- a/src/literals.py
+++ b/src/literals.py
@@ -90,6 +90,7 @@ class Status(Enum):
     TLS_NOT_READY = StatusLevel(MaintenanceStatus("Waiting for TLS to be ready"), "DEBUG")
     TLS_PEER_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating peer CA..."), "DEBUG")
     TLS_CLIENT_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating client CA..."), "DEBUG")
+    TLS_CERTS_EXPIRING = StatusLevel(BlockedStatus("TLS certificates expiring soon..."), "INFO")
     SERVICE_INSTALLING = StatusLevel(MaintenanceStatus("Installing etcd..."), "DEBUG")
     SERVICE_STARTING = StatusLevel(MaintenanceStatus("Waiting for etcd to start..."), "DEBUG")
     SERVICE_NOT_INSTALLED = StatusLevel(BlockedStatus("unable to install etcd snap"), "ERROR")

--- a/src/literals.py
+++ b/src/literals.py
@@ -90,9 +90,15 @@ class Status(Enum):
     TLS_NOT_READY = StatusLevel(MaintenanceStatus("Waiting for TLS to be ready"), "DEBUG")
     TLS_PEER_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating peer CA..."), "DEBUG")
     TLS_CLIENT_CA_ROTATING = StatusLevel(MaintenanceStatus("Rotating client CA..."), "DEBUG")
-    TLS_CERTS_EXPIRING = StatusLevel(
+    TLS_CLIENT_CERTS_EXPIRING = StatusLevel(
         MaintenanceStatus(
-            "TLS certificates expiring soon. Please ensure new certificates are provided."
+            "TLS client certificates expiring soon. Please ensure new certificates are provided."
+        ),
+        "WARNING",
+    )
+    TLS_PEER_CERTS_EXPIRING = StatusLevel(
+        MaintenanceStatus(
+            "TLS peer certificates expiring soon. Please ensure new certificates are provided."
         ),
         "WARNING",
     )

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -207,14 +207,14 @@ class TLSManager:
             else self.workload.paths.tls.client_ca,
         )
 
-    def check_certificate_validity(self) -> None:
+    def check_certificate_validity(self, tls_type: TLSType) -> None:
         """Check if the certificates installed on the unit will soon expire."""
         cert_files = []
-        if self.state.unit_server.tls_client_state == TLSState.TLS:
+        if tls_type == TLSType.CLIENT and self.state.unit_server.tls_client_state == TLSState.TLS:
             cert_files.append(self.workload.paths.tls.client_cert)
             cert_files.append(self.workload.paths.tls.client_ca)
 
-        if self.state.unit_server.tls_peer_state == TLSState.TLS:
+        if tls_type == TLSType.PEER and self.state.unit_server.tls_peer_state == TLSState.TLS:
             cert_files.append(self.workload.paths.tls.peer_cert)
             cert_files.append(self.workload.paths.tls.peer_ca)
 
@@ -254,7 +254,10 @@ class TLSManager:
         if self.state.unit_server.tls_client_ca_rotation_state != TLSCARotationState.NO_ROTATION:
             status_list.append(Status.TLS_CLIENT_CA_ROTATING)
 
-        if self.state.unit_server.certs_expiring:
-            status_list.append(Status.TLS_CERTS_EXPIRING)
+        if self.state.unit_server.tls_client_certs_expiring:
+            status_list.append(Status.TLS_CLIENT_CERTS_EXPIRING)
+
+        if self.state.unit_server.tls_peer_certs_expiring:
+            status_list.append(Status.TLS_PEER_CERTS_EXPIRING)
 
         return status_list

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -208,13 +208,16 @@ class TLSManager:
         )
 
     def check_certificate_validity(self, tls_type: TLSType) -> None:
-        """Check if the certificates installed on the unit will soon expire."""
+        """Check if the certificates installed on the unit will soon expire.
+
+        Args:
+            tls_type (TLSType): The TLS type to check certificate validity for.
+        """
         cert_files = []
         if tls_type == TLSType.CLIENT and self.state.unit_server.tls_client_state == TLSState.TLS:
             cert_files.append(self.workload.paths.tls.client_cert)
             cert_files.append(self.workload.paths.tls.client_ca)
-
-        if tls_type == TLSType.PEER and self.state.unit_server.tls_peer_state == TLSState.TLS:
+        elif tls_type == TLSType.PEER and self.state.unit_server.tls_peer_state == TLSState.TLS:
             cert_files.append(self.workload.paths.tls.peer_cert)
             cert_files.append(self.workload.paths.tls.peer_ca)
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -207,6 +207,31 @@ class TLSManager:
             else self.workload.paths.tls.client_ca,
         )
 
+    def check_certificate_validity(self) -> None:
+        """Check if the certificates installed on the unit will soon expire."""
+        cert_files = []
+        if self.state.unit_server.tls_client_state == TLSState.TLS:
+            cert_files.append(self.workload.paths.tls.client_cert)
+            cert_files.append(self.workload.paths.tls.client_ca)
+
+        if self.state.unit_server.tls_peer_state == TLSState.TLS:
+            cert_files.append(self.workload.paths.tls.peer_cert)
+            cert_files.append(self.workload.paths.tls.peer_ca)
+
+        for cert_file in cert_files:
+            # will raise CalledProcessError if cert expires in less than 24h (=86400s)
+            self.workload.exec(
+                [
+                    "openssl",
+                    "x509",
+                    "-checkend",
+                    "86400",
+                    "-noout",
+                    "-in",
+                    cert_file,
+                ]
+            )
+
     def compute_component_status(self) -> list[Status]:
         """Compute the component status."""
         status_list = []
@@ -228,5 +253,8 @@ class TLSManager:
 
         if self.state.unit_server.tls_client_ca_rotation_state != TLSCARotationState.NO_ROTATION:
             status_list.append(Status.TLS_CLIENT_CA_ROTATING)
+
+        if self.state.unit_server.certs_expiring:
+            status_list.append(Status.TLS_CERTS_EXPIRING)
 
         return status_list

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -232,10 +232,8 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
         apps=[APP_NAME, TLS_NAME],
         apps_full_statuses={
             APP_NAME: {
-                "units": {
-                    "maintenance": [Status.TLS_CERTS_EXPIRING.value.status.message],
-                    "active": [],
-                }
+                "maintenance": [Status.TLS_CERTS_EXPIRING.value.status.message],
+                "active": [],
             },
             TLS_NAME: {"active": []},
         },

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -232,7 +232,7 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
         apps=[APP_NAME, TLS_NAME],
         apps_full_statuses={
             APP_NAME: {
-                "maintenance": [Status.TLS_CERTS_EXPIRING.value.status.message],
+                "maintenance": [Status.TLS_CLIENT_CERTS_EXPIRING.value.status.message],
                 "active": [],
             },
             TLS_NAME: {"active": []},
@@ -270,7 +270,7 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
         units_full_statuses={
             APP_NAME: {
                 "units": {
-                    "maintenance": [Status.TLS_CERTS_EXPIRING.value.status.message],
+                    "maintenance": [Status.TLS_CLIENT_CERTS_EXPIRING.value.status.message],
                     "active": [],
                 }
             },

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -221,7 +221,7 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
     """
     model = ops_test.model_full_name
 
-    logger.info("Adjusting validity of the CA certificate to 5 minutes")
+    logger.info("Adjusting validity of the CA certificate to 6 minutes")
     # CA validity should be 2x cert validity to make sure the cert is also expired at this time
     tls_config = {"root-ca-validity": "6m", "certificate-validity": "3m"}
     tls_app: Application = ops_test.model.applications[TLS_NAME]  # type: ignore

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -223,8 +223,9 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
 
     # cert validity should be enough time for the rotation to happen
     # even with health checks failing because of invalid certs
-    logger.info("Adjusting validity of the CA to 10 min and certificates to 6 min")
-    tls_config = {"root-ca-validity": "10m", "certificate-validity": "6m"}
+    # CA validity must be 2x cert validity to be considered valid
+    logger.info("Adjusting validity of the CA to 12 min and certificates to 6 min")
+    tls_config = {"root-ca-validity": "12m", "certificate-validity": "6m"}
     tls_app: Application = ops_test.model.applications[TLS_NAME]  # type: ignore
     await tls_app.set_config(tls_config)
     await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -219,7 +219,14 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
     The rotation is triggered by expiring certificates.
     """
     model = ops_test.model_full_name
-    # Rotate the CA certificate
+
+    logger.info("Adjusting validity of the CA certificate to 5 minutes")
+    # CA validity should be 2x cert validity to make sure the cert is also expired at this time
+    tls_config = {"root-ca-validity": "6m", "certificate-validity": "3m"}
+    tls_app: Application = ops_test.model.applications[TLS_NAME]  # type: ignore
+    await tls_app.set_config(tls_config)
+    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])
+
     logger.info("Getting the current CA certificates")
     leader_unit = await get_juju_leader_unit_name(ops_test, APP_NAME)
     current_peer_ca = get_certificate_from_unit(
@@ -242,13 +249,8 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
     )
     assert current_client_certificate, "Failed to get the current client certificate"
 
-    logger.info("Adjusting validity of the CA certificate to 2 minutes")
-    tls_config = {"root-ca-validity": "2m", "certificate-validity": "1m"}
-    tls_app: Application = ops_test.model.applications[TLS_NAME]  # type: ignore
-    await tls_app.set_config(tls_config)
-
-    logger.info("Waiting for expiration of CA certificate")
-    time.sleep(150)
+    logger.info("Waiting 6m for expiration of CA certificate")
+    time.sleep(360)
     await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])
 
     logger.info("Checking if the CA certificates are rotated")

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -223,8 +223,8 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
 
     # cert validity should be enough time for the rotation to happen
     # even with health checks failing because of invalid certs
-    logger.info("Adjusting validity of the CA to 1 hour and certificates to 6 minutes")
-    tls_config = {"root-ca-validity": "1h", "certificate-validity": "6m"}
+    logger.info("Adjusting validity of the CA to 10 min and certificates to 6 min")
+    tls_config = {"root-ca-validity": "10m", "certificate-validity": "6m"}
     tls_app: Application = ops_test.model.applications[TLS_NAME]  # type: ignore
     await tls_app.set_config(tls_config)
     await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -251,8 +251,9 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
     )
     assert current_client_certificate, "Failed to get the current client certificate"
 
-    logger.info("Waiting 6m for expiration of certificates - renewed certs will have a new CA")
-    time.sleep(360)
+    logger.info("Waiting ~6m for expiration of certificates - renewed certs will have a new CA")
+    # 6m + 30s for renewal to start
+    time.sleep(390)
     await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])
 
     logger.info("Checking if the CA certificates are rotated")

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -92,6 +92,7 @@ async def test_build_and_deploy_with_tls(ops_test: OpsTest) -> None:
     ), "Failed to read key"
 
 
+@pytest.mark.skip()
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -227,7 +227,14 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
     tls_config = {"root-ca-validity": "12m", "certificate-validity": "6m"}
     tls_app: Application = ops_test.model.applications[TLS_NAME]  # type: ignore
     await tls_app.set_config(tls_config)
-    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME, TLS_NAME],
+        apps_full_statuses={
+            APP_NAME: {"blocked": ["TLS certificates expiring soon..."], "active": []},
+            TLS_NAME: {"active": []},
+        },
+    )
 
     logger.info("Getting the current CA certificates")
     leader_unit = await get_juju_leader_unit_name(ops_test, APP_NAME)
@@ -254,7 +261,14 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
     logger.info("Waiting ~6m for expiration of certificates - renewed certs will have a new CA")
     # 6m + 30s for renewal to start
     time.sleep(390)
-    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME, TLS_NAME],
+        apps_full_statuses={
+            APP_NAME: {"blocked": ["TLS certificates expiring soon..."], "active": []},
+            TLS_NAME: {"active": []},
+        },
+    )
 
     logger.info("Checking if the CA certificates are rotated")
     new_peer_ca = get_certificate_from_unit(model, leader_unit, cert_type=TLSType.PEER, is_ca=True)

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -92,7 +92,6 @@ async def test_build_and_deploy_with_tls(ops_test: OpsTest) -> None:
     ), "Failed to read key"
 
 
-@pytest.mark.skip()
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -264,9 +264,9 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
     await wait_until(
         ops_test,
         apps=[APP_NAME, TLS_NAME],
-        apps_full_statuses={
-            APP_NAME: {"blocked": ["TLS certificates expiring soon..."], "active": []},
-            TLS_NAME: {"active": []},
+        units_full_statuses={
+            APP_NAME: {"units": {"blocked": ["TLS certificates expiring soon..."], "active": []}},
+            TLS_NAME: {"units": {"active": []}},
         },
     )
 

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -9,7 +9,7 @@ import pytest
 from juju.application import Application
 from pytest_operator.plugin import OpsTest
 
-from literals import INTERNAL_USER, PEER_RELATION, TLSType
+from literals import INTERNAL_USER, PEER_RELATION, Status, TLSType
 
 from ..helpers import (
     APP_NAME,
@@ -231,7 +231,12 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
         ops_test,
         apps=[APP_NAME, TLS_NAME],
         apps_full_statuses={
-            APP_NAME: {"blocked": ["TLS certificates expiring soon..."], "active": []},
+            APP_NAME: {
+                "units": {
+                    "maintenance": [Status.TLS_CERTS_EXPIRING.value.status.message],
+                    "active": [],
+                }
+            },
             TLS_NAME: {"active": []},
         },
     )
@@ -265,7 +270,12 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
         ops_test,
         apps=[APP_NAME, TLS_NAME],
         units_full_statuses={
-            APP_NAME: {"units": {"blocked": ["TLS certificates expiring soon..."], "active": []}},
+            APP_NAME: {
+                "units": {
+                    "maintenance": [Status.TLS_CERTS_EXPIRING.value.status.message],
+                    "active": [],
+                }
+            },
             TLS_NAME: {"units": {"active": []}},
         },
     )

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 
 import pytest
 from juju.application import Application
@@ -91,13 +92,15 @@ async def test_build_and_deploy_with_tls(ops_test: OpsTest) -> None:
     ), "Failed to read key"
 
 
+@pytest.mark.skip()
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_ca_rotation(ops_test: OpsTest) -> None:
+async def test_ca_rotation_by_config_change(ops_test: OpsTest) -> None:
     """Test the CA rotation.
 
     The CA certificate should be rotated and the cluster should still be accessible.
+    The rotation is triggered by updating the config for `ca-common-name` on the TLS provider side.
     """
     model = ops_test.model_full_name
     # Rotate the CA certificate
@@ -128,6 +131,125 @@ async def test_ca_rotation(ops_test: OpsTest) -> None:
     tls_app: Application = ops_test.model.applications[TLS_NAME]  # type: ignore
     await tls_app.set_config(tls_config)
 
+    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])
+
+    logger.info("Checking if the CA certificates are rotated")
+    new_peer_ca = get_certificate_from_unit(model, leader_unit, cert_type=TLSType.PEER, is_ca=True)
+    assert new_peer_ca, "Failed to get the new peer CA certificate"
+
+    new_client_ca = get_certificate_from_unit(
+        model, leader_unit, cert_type=TLSType.CLIENT, is_ca=True
+    )
+    assert new_client_ca, "Failed to get the new client CA certificate"
+
+    new_peer_certificate = get_certificate_from_unit(
+        model, leader_unit, cert_type=TLSType.PEER, is_ca=False
+    )
+    assert new_peer_certificate, "Failed to get the new peer certificate"
+
+    new_client_certificate = get_certificate_from_unit(
+        model, leader_unit, cert_type=TLSType.CLIENT, is_ca=False
+    )
+    assert new_client_certificate, "Failed to get the new client certificate"
+
+    assert current_peer_ca != new_peer_ca, "Peer CA certificate was not rotated"
+    assert current_client_ca != new_client_ca, "Client CA certificate was not rotated"
+
+    logger.info("Both CA certificates are rotated")
+
+    assert current_peer_certificate != new_peer_certificate, "Peer certificate was not rotated"
+    assert current_client_certificate != new_client_certificate, (
+        "Client certificate was not rotated"
+    )
+
+    logger.info("Both certificates are rotated")
+
+    await download_client_certificate_from_unit(ops_test, APP_NAME)
+    # Check if the cluster is still accessible
+    logger.info("Checking if the cluster is still accessible")
+    endpoints = get_cluster_endpoints(ops_test, APP_NAME, tls_enabled=True)
+
+    cluster_members = get_cluster_members(endpoints, tls_enabled=True)
+    assert len(cluster_members) == NUM_UNITS, f"Cluster members are not equal to {NUM_UNITS}"
+
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
+    assert secret, f"Secret is not set for {PEER_RELATION}.{APP_NAME}.app"
+
+    password = secret.get(f"{INTERNAL_USER}-password")
+
+    logger.info("Reading and writing keys with HTTP peerURLs and HTTPS clientURLs")
+    assert (
+        get_key(
+            endpoints,
+            user=INTERNAL_USER,
+            password=password,
+            key=TEST_KEY,
+            tls_enabled=True,
+        )
+        == TEST_VALUE
+    ), "Failed to read key"
+
+    assert put_key(
+        endpoints,
+        user=INTERNAL_USER,
+        password=password,
+        key=f"{TEST_KEY}_4",
+        value=TEST_VALUE,
+        tls_enabled=True,
+    ), "Failed to write new key"
+
+    assert (
+        get_key(
+            endpoints,
+            user=INTERNAL_USER,
+            password=password,
+            key=f"{TEST_KEY}_4",
+            tls_enabled=True,
+        )
+        == TEST_VALUE
+    ), "Failed to read new key"
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
+    """Test the CA rotation.
+
+    The CA certificate should be rotated and the cluster should still be accessible.
+    The rotation is triggered by expiring certificates.
+    """
+    model = ops_test.model_full_name
+    # Rotate the CA certificate
+    logger.info("Getting the current CA certificates")
+    leader_unit = await get_juju_leader_unit_name(ops_test, APP_NAME)
+    current_peer_ca = get_certificate_from_unit(
+        model, leader_unit, cert_type=TLSType.PEER, is_ca=True
+    )
+    assert current_peer_ca, "Failed to get the current peer CA certificate"
+
+    current_client_ca = get_certificate_from_unit(
+        model, leader_unit, cert_type=TLSType.CLIENT, is_ca=True
+    )
+    assert current_client_ca, "Failed to get the current client CA certificate"
+
+    current_peer_certificate = get_certificate_from_unit(
+        model, leader_unit, cert_type=TLSType.PEER, is_ca=False
+    )
+    assert current_peer_certificate, "Failed to get the current peer certificate"
+
+    current_client_certificate = get_certificate_from_unit(
+        model, leader_unit, cert_type=TLSType.CLIENT, is_ca=False
+    )
+    assert current_client_certificate, "Failed to get the current client certificate"
+
+    logger.info("Adjusting validity of the CA certificate to 2 minutes")
+    tls_config = {"root-ca-validity": "2m", "certificate-validity": "1m"}
+    tls_app: Application = ops_test.model.applications[TLS_NAME]  # type: ignore
+    await tls_app.set_config(tls_config)
+
+    logger.info("Waiting for expiration of CA certificate")
+    time.sleep(150)
     await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])
 
     logger.info("Checking if the CA certificates are rotated")

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -221,9 +221,10 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
     """
     model = ops_test.model_full_name
 
-    logger.info("Adjusting validity of the CA certificate to 6 minutes")
-    # CA validity should be 2x cert validity to make sure the cert is also expired at this time
-    tls_config = {"root-ca-validity": "6m", "certificate-validity": "3m"}
+    # cert validity should be enough time for the rotation to happen
+    # even with health checks failing because of invalid certs
+    logger.info("Adjusting validity of the CA to 1 hour and certificates to 6 minutes")
+    tls_config = {"root-ca-validity": "1h", "certificate-validity": "6m"}
     tls_app: Application = ops_test.model.applications[TLS_NAME]  # type: ignore
     await tls_app.set_config(tls_config)
     await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])
@@ -250,7 +251,7 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
     )
     assert current_client_certificate, "Failed to get the current client certificate"
 
-    logger.info("Waiting 6m for expiration of CA certificate")
+    logger.info("Waiting 6m for expiration of certificates - renewed certs will have a new CA")
     time.sleep(360)
     await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])
 

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -9,7 +9,7 @@ import pytest
 from juju.application import Application
 from pytest_operator.plugin import OpsTest
 
-from literals import INTERNAL_USER, PEER_RELATION, TLSType
+from literals import INTERNAL_USER, PEER_RELATION, Status, TLSType
 
 from ..helpers import (
     APP_NAME,
@@ -547,7 +547,19 @@ async def test_certificate_expiration(ops_test: OpsTest) -> None:
     await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", TLS_NAME)
     await ops_test.model.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
 
-    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME], idle_period=15)
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME, TLS_NAME],
+        units_full_statuses={
+            APP_NAME: {
+                "units": {
+                    "maintenance": [Status.TLS_CERTS_EXPIRING.value.status.message],
+                    "active": [],
+                }
+            },
+            TLS_NAME: {"units": {"active": []}},
+        },
+    )
 
     endpoints = get_cluster_endpoints(ops_test, APP_NAME, tls_enabled=True)
     leader_unit = await get_juju_leader_unit_name(ops_test, APP_NAME)

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -553,7 +553,7 @@ async def test_certificate_expiration(ops_test: OpsTest) -> None:
         units_full_statuses={
             APP_NAME: {
                 "units": {
-                    "maintenance": [Status.TLS_CERTS_EXPIRING.value.status.message],
+                    "maintenance": [Status.TLS_CLIENT_CERTS_EXPIRING.value.status.message],
                     "active": [],
                 }
             },

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -18,7 +18,13 @@ from common.exceptions import (
     EtcdUserManagementError,
 )
 from core.models import Member
-from literals import CLIENT_PORT, INTERNAL_USER, INTERNAL_USER_PASSWORD_CONFIG, PEER_RELATION
+from literals import (
+    CLIENT_PORT,
+    INTERNAL_USER,
+    INTERNAL_USER_PASSWORD_CONFIG,
+    PEER_RELATION,
+    TLSState,
+)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
@@ -302,6 +308,77 @@ def test_update_status():
 
     # Verify that writing the file did work as expected.
     assert (data_storage.get_filesystem(ctx) / "test.txt").read_text() == "test_line"
+
+    # test certificate expiry check fails
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={
+            "authentication": "enabled",
+            "cluster_state": "existing",
+        },
+        local_unit_data={
+            "tls_peer_state": TLSState.TLS.value,
+            "tls_client_state": TLSState.TLS.value,
+            "tls_client_certificates_expiring": "",
+            "tls_peer_certificates_expiring": "",
+        },
+    )
+
+    state_in = testing.State(relations={relation})
+
+    with (
+        patch("workload.EtcdWorkload.alive", return_value=True),
+        patch("managers.cluster.ClusterManager.clean_users"),
+        patch(
+            "workload.EtcdWorkload.exec",
+            side_effect=CalledProcessError(returncode=1, cmd="openssl -checkend"),
+        ),
+    ):
+        state_out = ctx.run(ctx.on.update_status(), state_in)
+        assert state_out.unit_status == ops.MaintenanceStatus(
+            "TLS client certificates expiring soon. Please ensure new certificates are provided."
+        )
+        assert (
+            state_out.get_relation(1).local_unit_data.get("tls_client_certificates_expiring")
+            == "True"
+        )
+        assert (
+            state_out.get_relation(1).local_unit_data.get("tls_peer_certificates_expiring")
+            == "True"
+        )
+
+    # test certificate expiry check successful
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={
+            "authentication": "enabled",
+            "cluster_state": "existing",
+        },
+        local_unit_data={
+            "tls_peer_state": TLSState.TLS.value,
+            "tls_client_state": TLSState.TLS.value,
+            "tls_client_certificates_expiring": "",
+            "tls_peer_certificates_expiring": "",
+        },
+    )
+
+    state_in = testing.State(relations={relation})
+
+    with (
+        patch("workload.EtcdWorkload.alive", return_value=True),
+        patch("managers.cluster.ClusterManager.clean_users"),
+        patch("workload.EtcdWorkload.exec", return_value=CompletedProcess(returncode=0, args=[])),
+    ):
+        state_out = ctx.run(ctx.on.update_status(), state_in)
+        assert state_out.unit_status == ops.ActiveStatus()
+        assert (
+            state_out.get_relation(1).local_unit_data.get("tls_client_certificates_expiring") == ""
+        )
+        assert (
+            state_out.get_relation(1).local_unit_data.get("tls_peer_certificates_expiring") == ""
+        )
 
 
 def test_peer_relation_created():


### PR DESCRIPTION
fixes https://github.com/canonical/charmed-etcd-operator/issues/70

**Root cause**
If a TLS CA rotation is happening when the TLS client certificates have expired, the operator is no longer able to communicate with the etcd cluster when restarting. Health checks fail and cause irrecoverable errors. This also impacts the `peer_relation_changed` events happening as part of the CA-rotation workflow.

**Fix**
The methods `_restart_ca_rotation()` and `_restart_clean_cas()` should ignore Health check errors when restarting etcd. This is safe and self-healing, as the following steps of the CA-rotation workflow will also check the health status of the cluster when the operator has updated the client certificates and can communicate with the cluster again.

Furthermore, when processing the `peer_relation_changed` event, cluster communication errors should also be ignored when updating client relation data (esp. the etcd version).

**Other changes**
- Add a new integration test for CA-rotation triggered by expiring certificates.
- Add a new method `check_certificate_validity()` to the `TLSManager` to check whether any of the installed certs/CA-certs expires within the next 24 hours. This check is executed on `update_status` and sets the unit and app status to `Blocked - "TLS certificates expiring soon..."` 
