### PR TITLE
Add docs URL to metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,6 +12,9 @@ description: |
   distributed systems, such as Kubernetes. This charmed operator deploys and operates
   etcd on virtual machines.
 
+  To learn more about its deployment and operation, see the 
+  [official Charmed etcd documentation](https://canonical-charmed-etcd.readthedocs-hosted.com/).
+
 peers:
   etcd-peers:
     interface: etcd_peers


### PR DESCRIPTION
## Issue
etcd's [Charmhub page](https://charmhub.io/charmed-etcd) does not direct the user to the documentation in any way.

## Solution
Add URL to RTD documentation to description rendered by Charmhub.

Changes will take effect next time a charm revision is published to Charmhub.