### PR TITLE
[DPE-6997] Verify backup before restore

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -252,6 +252,11 @@ class EtcdCluster(RelationState):
         """Current step of the restore workflow to be executed by the cluster members."""
         return RestoreStep(self.relation_data.get("restore_instruction", ""))
 
+    @property
+    def restore_verification_failed(self) -> bool:
+        """Flag for failed restore verification."""
+        return bool(self.relation_data.get("restore_verification_failed", ""))
+
 
 @dataclass
 class Member:

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -261,12 +261,13 @@ class BackupEvents(Object):
                     self.charm.set_status(Status.RESTORE_FAILED)
             case RestoreStep.STOP, RestoreStep.DOWNLOAD:
                 self.charm.backup_manager.stop_database()
+                self.charm.backup_manager.set_restore_step(RestoreStep.STOP.value)
             case RestoreStep.VERIFY, RestoreStep.STOP:
                 self._verify_restore()
             case RestoreStep.RESTORE, RestoreStep.VERIFY:
                 if self.charm.state.cluster.restore_verification_failed:
                     logger.error(
-                        "Restore procedure not successful - start previous etcd database again"
+                        "Restore procedure not successful - the etcd cluster will restart with the previous state."
                     )
                     self.charm.backup_manager.set_restore_step(RestoreStep.RESTORE.value)
                 else:
@@ -283,6 +284,7 @@ class BackupEvents(Object):
                         self.charm.cluster_manager.enable_authentication()
                     except EtcdUserManagementError:
                         logger.info("Auth already enabled")
+                self.charm.backup_manager.set_restore_step(RestoreStep.START.value)
             case RestoreStep.COMPLETED, RestoreStep.START:
                 if not self.charm.cluster_manager.is_healthy(cluster=False):
                     # if the member is not healthy, we do not complete the restore process
@@ -315,40 +317,41 @@ class BackupEvents(Object):
 
         If the health check succeeds, the restore procedure can continue on all units.
         """
-        if self.charm.unit.is_leader() and len(self.charm.state.servers) > 1:
-            # verify restoring the backup to avoid data loss before purging all data
-            if self.charm.state.cluster.restore_verification_failed:
-                # verification has already failed - do not try again
-                return
+        if not self.charm.unit.is_leader() or len(self.charm.state.servers) == 1:
+            self.charm.backup_manager.set_restore_step(RestoreStep.VERIFY.value)
+            return
 
+        # verify restoring the backup to avoid data loss before purging all data
+        if self.charm.state.cluster.restore_verification_failed:
+            # verification has already failed - do not try again
+            return
+
+        try:
+            self.charm.backup_manager.restore_backup()
+            self.charm.config_manager.set_config_properties()
+            self.charm.backup_manager.start_database()
             try:
-                self.charm.backup_manager.restore_backup()
-                self.charm.config_manager.set_config_properties()
-                self.charm.backup_manager.start_database()
-                try:
-                    self.charm.cluster_manager.enable_authentication()
-                except EtcdUserManagementError:
-                    logger.info("Auth already enabled")
-                if not self.charm.cluster_manager.is_healthy(cluster=False):
-                    raise HealthCheckFailedError("Health check failed")
-            except (EtcdBackupError, EtcdAuthNotEnabledError, HealthCheckFailedError):
-                # if the verification fails, the restore workflow stops here
-                # data on all other units will remain as is
-                # the cluster will try to recover as before the restore was initiated
-                logger.error("Failed to verify - cancel the restore procedure")
-                self.charm.state.cluster.update({"restore_verification_failed": "True"})
-                self.charm.backup_manager.stop_database()
-                self.charm.workload.remove_directory(DATABASE_DIR)
-                self.charm.backup_manager.set_restore_step(RestoreStep.VERIFY.value)
-                return
-            # if the verification was successful, stop etcd again and continue the workflow
-            logger.info(
-                f"Restore verification successful: Backup {self.charm.state.cluster.restore_id} can be restored."
-            )
+                self.charm.cluster_manager.enable_authentication()
+            except EtcdUserManagementError:
+                logger.info("Auth already enabled")
+            if not self.charm.cluster_manager.is_healthy(cluster=False):
+                raise HealthCheckFailedError("Health check failed")
+        except (EtcdBackupError, EtcdAuthNotEnabledError, HealthCheckFailedError):
+            # if the verification fails, the restore workflow stops here
+            # data on all other units will remain as is
+            # the cluster will try to recover as before the restore was initiated
+            logger.error("Failed to verify - cancel the restore procedure")
+            self.charm.state.cluster.update({"restore_verification_failed": "True"})
             self.charm.backup_manager.stop_database()
+            self.charm.workload.remove_directory(DATABASE_DIR)
             self.charm.backup_manager.set_restore_step(RestoreStep.VERIFY.value)
-        else:
-            self.charm.backup_manager.set_restore_step(RestoreStep.VERIFY.value)
+            return
+        # if the verification was successful, stop etcd again and continue the workflow
+        logger.info(
+            f"Restore verification successful: Backup {self.charm.state.cluster.restore_id} can be restored."
+        )
+        self.charm.backup_manager.stop_database()
+        self.charm.backup_manager.set_restore_step(RestoreStep.VERIFY.value)
 
     def _exists_preventing_reason(self) -> str:
         """Check if an action can be executed, if not return error message.

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -16,7 +16,12 @@ from charms.data_platform_libs.v0.s3 import (
 from ops import Object
 from ops.charm import ActionEvent, RelationChangedEvent
 
-from common.exceptions import EtcdBackupError, EtcdUserManagementError
+from common.exceptions import (
+    EtcdAuthNotEnabledError,
+    EtcdBackupError,
+    EtcdUserManagementError,
+    HealthCheckFailedError,
+)
 from literals import (
     PEER_RELATION,
     S3_RELATION_NAME,
@@ -187,7 +192,39 @@ class BackupEvents(Object):
                     self.charm.set_status(Status.RESTORE_FAILED)
             case RestoreStep.STOP, RestoreStep.DOWNLOAD:
                 self.charm.backup_manager.stop_database()
-            case RestoreStep.RESTORE, RestoreStep.STOP:
+            case RestoreStep.VERIFY, RestoreStep.STOP:
+                if self.charm.unit.is_leader() and len(self.charm.state.servers) > 1:
+                    # verify restoring the backup to avoid data loss before purging all data
+                    if self.charm.state.cluster.restore_verification_failed:
+                        # verification has already failed - do not try again
+                        return
+
+                    try:
+                        self.charm.backup_manager.restore_backup()
+                        self.charm.config_manager.set_config_properties()
+                        self.charm.backup_manager.start_database()
+                        try:
+                            self.charm.cluster_manager.enable_authentication()
+                        except EtcdUserManagementError:
+                            logger.info("Auth already enabled")
+                        if not self.charm.cluster_manager.is_healthy(cluster=False):
+                            raise HealthCheckFailedError("Health check failed")
+                    except (EtcdBackupError, EtcdAuthNotEnabledError, HealthCheckFailedError):
+                        # if the verification fails, the restore workflow stops here
+                        # data on all other units will remain as is, but the cluster is down
+                        # users must manually recover from this situation
+                        self.charm.state.cluster.update({"restore_verification_failed": "True"})
+                        self.charm.backup_manager.stop_database()
+                        return
+                    # if the verification was successful, stop etcd again and continue the workflow
+                    logger.info(
+                        f"Restore verification successful: Backup {self.charm.state.cluster.restore_id} can be restored."
+                    )
+                    self.charm.backup_manager.stop_database()
+                    self.charm.backup_manager.set_restore_step(RestoreStep.VERIFY.value)
+                else:
+                    self.charm.backup_manager.set_restore_step(RestoreStep.VERIFY.value)
+            case RestoreStep.RESTORE, RestoreStep.VERIFY:
                 try:
                     self.charm.backup_manager.restore_backup()
                 except EtcdBackupError:

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -193,37 +193,7 @@ class BackupEvents(Object):
             case RestoreStep.STOP, RestoreStep.DOWNLOAD:
                 self.charm.backup_manager.stop_database()
             case RestoreStep.VERIFY, RestoreStep.STOP:
-                if self.charm.unit.is_leader() and len(self.charm.state.servers) > 1:
-                    # verify restoring the backup to avoid data loss before purging all data
-                    if self.charm.state.cluster.restore_verification_failed:
-                        # verification has already failed - do not try again
-                        return
-
-                    try:
-                        self.charm.backup_manager.restore_backup()
-                        self.charm.config_manager.set_config_properties()
-                        self.charm.backup_manager.start_database()
-                        try:
-                            self.charm.cluster_manager.enable_authentication()
-                        except EtcdUserManagementError:
-                            logger.info("Auth already enabled")
-                        if not self.charm.cluster_manager.is_healthy(cluster=False):
-                            raise HealthCheckFailedError("Health check failed")
-                    except (EtcdBackupError, EtcdAuthNotEnabledError, HealthCheckFailedError):
-                        # if the verification fails, the restore workflow stops here
-                        # data on all other units will remain as is, but the cluster is down
-                        # users must manually recover from this situation
-                        self.charm.state.cluster.update({"restore_verification_failed": "True"})
-                        self.charm.backup_manager.stop_database()
-                        return
-                    # if the verification was successful, stop etcd again and continue the workflow
-                    logger.info(
-                        f"Restore verification successful: Backup {self.charm.state.cluster.restore_id} can be restored."
-                    )
-                    self.charm.backup_manager.stop_database()
-                    self.charm.backup_manager.set_restore_step(RestoreStep.VERIFY.value)
-                else:
-                    self.charm.backup_manager.set_restore_step(RestoreStep.VERIFY.value)
+                self._verify_restore()
             case RestoreStep.RESTORE, RestoreStep.VERIFY:
                 try:
                     self.charm.backup_manager.restore_backup()
@@ -248,6 +218,57 @@ class BackupEvents(Object):
         # continue to next workflow step if possible
         if self.charm.unit.is_leader():
             self.charm.backup_manager.proceed_restore_workflow_if_possible()
+
+    def _verify_restore(self) -> None:
+        """Safeguard the restore-operation in order not to cause any data loss.
+
+        As part of the restore procedure, the data directories of all units will be purged.
+        In a situation where the restore fails (e.g. wrong admin password configured), the cluster
+        would ultimately be lost and all the data could not be recovered anymore. To avoid this,
+        this method will run a verification of the restore for the given backup-id.
+
+        This should only be executed on the Juju leader. It will:
+        - purge the unit's data directory
+        - restore the backup file only on this unit
+        - immediately start etcd
+        - perform a health check on the unit
+
+        If the health check fails, it will raise. In this case, the restore workflow should NOT
+        proceed, so that the data on the remaining units will not be purged.
+
+        If the health check succeeds, the restore procedure can continue on all units.
+        """
+        if self.charm.unit.is_leader() and len(self.charm.state.servers) > 1:
+            # verify restoring the backup to avoid data loss before purging all data
+            if self.charm.state.cluster.restore_verification_failed:
+                # verification has already failed - do not try again
+                return
+
+            try:
+                self.charm.backup_manager.restore_backup()
+                self.charm.config_manager.set_config_properties()
+                self.charm.backup_manager.start_database()
+                try:
+                    self.charm.cluster_manager.enable_authentication()
+                except EtcdUserManagementError:
+                    logger.info("Auth already enabled")
+                if not self.charm.cluster_manager.is_healthy(cluster=False):
+                    raise HealthCheckFailedError("Health check failed")
+            except (EtcdBackupError, EtcdAuthNotEnabledError, HealthCheckFailedError):
+                # if the verification fails, the restore workflow stops here
+                # data on all other units will remain as is, but the cluster is down
+                # users must manually recover from this situation
+                self.charm.state.cluster.update({"restore_verification_failed": "True"})
+                self.charm.backup_manager.stop_database()
+                return
+            # if the verification was successful, stop etcd again and continue the workflow
+            logger.info(
+                f"Restore verification successful: Backup {self.charm.state.cluster.restore_id} can be restored."
+            )
+            self.charm.backup_manager.stop_database()
+            self.charm.backup_manager.set_restore_step(RestoreStep.VERIFY.value)
+        else:
+            self.charm.backup_manager.set_restore_step(RestoreStep.VERIFY.value)
 
     def _exists_preventing_reason(self) -> str:
         """Check if an action can be executed, if not return error message.

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -308,8 +308,10 @@ class BackupEvents(Object):
         - immediately start etcd
         - perform a health check on the unit
 
-        If the health check fails, it will raise. In this case, the restore workflow should NOT
-        proceed, so that the data on the remaining units will not be purged.
+        If the health check fails, the restore workflow will NOT proceed, so that the data on the
+        remaining units will not be purged. Instead, the leader unit will reset its data directory
+        and the restore-step will be skipped for all units. The cluster will be recovered as before
+        the restore was initiated.
 
         If the health check succeeds, the restore procedure can continue on all units.
         """
@@ -331,8 +333,8 @@ class BackupEvents(Object):
                     raise HealthCheckFailedError("Health check failed")
             except (EtcdBackupError, EtcdAuthNotEnabledError, HealthCheckFailedError):
                 # if the verification fails, the restore workflow stops here
-                # data on all other units will remain as is, but the cluster is down
-                # users must manually recover from this situation
+                # data on all other units will remain as is
+                # the cluster will try to recover as before the restore was initiated
                 logger.error("Failed to verify - cancel the restore procedure")
                 self.charm.state.cluster.update({"restore_verification_failed": "True"})
                 self.charm.backup_manager.stop_database()

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -29,6 +29,7 @@ from common.exceptions import (
 )
 from literals import (
     AZURE_RELATION_NAME,
+    DATABASE_DIR,
     PEER_RELATION,
     S3_RELATION_NAME,
     RestoreStep,
@@ -227,6 +228,10 @@ class BackupEvents(Object):
 
         event.log(f"Initiating restore process for backup-id {backup_id_to_restore}")
 
+        if self.charm.state.cluster.restore_verification_failed:
+            # clean up the state if previous restore procedure failed
+            self.charm.state.cluster.update({"restore_verification_failed": ""})
+
         if not self.charm.backup_manager.download_backup_file(backup_id_to_restore):
             event.fail(f"Could not download backup-file {backup_id_to_restore}.")
             return
@@ -259,10 +264,16 @@ class BackupEvents(Object):
             case RestoreStep.VERIFY, RestoreStep.STOP:
                 self._verify_restore()
             case RestoreStep.RESTORE, RestoreStep.VERIFY:
-                try:
-                    self.charm.backup_manager.restore_backup()
-                except EtcdBackupError:
-                    self.charm.set_status(Status.RESTORE_FAILED)
+                if self.charm.state.cluster.restore_verification_failed:
+                    logger.error(
+                        "Restore procedure not successful - start previous etcd database again"
+                    )
+                    self.charm.backup_manager.set_restore_step(RestoreStep.RESTORE.value)
+                else:
+                    try:
+                        self.charm.backup_manager.restore_backup()
+                    except EtcdBackupError:
+                        self.charm.set_status(Status.RESTORE_FAILED)
             case RestoreStep.START, RestoreStep.RESTORE:
                 self.charm.config_manager.set_config_properties()
                 self.charm.backup_manager.start_database()
@@ -322,8 +333,11 @@ class BackupEvents(Object):
                 # if the verification fails, the restore workflow stops here
                 # data on all other units will remain as is, but the cluster is down
                 # users must manually recover from this situation
+                logger.error("Failed to verify - cancel the restore procedure")
                 self.charm.state.cluster.update({"restore_verification_failed": "True"})
                 self.charm.backup_manager.stop_database()
+                self.charm.workload.remove_directory(DATABASE_DIR)
+                self.charm.backup_manager.set_restore_step(RestoreStep.VERIFY.value)
                 return
             # if the verification was successful, stop etcd again and continue the workflow
             logger.info(

--- a/src/literals.py
+++ b/src/literals.py
@@ -86,6 +86,12 @@ class Status(Enum):
     PEER_URL_NOT_SET = StatusLevel(MaintenanceStatus("peer-url not set"), "DEBUG")
     REMOVED = StatusLevel(BlockedStatus("unit removed from cluster"), "INFO")
     RESTORE_FAILED = StatusLevel(BlockedStatus("failed to restore backup"), "ERROR")
+    RESTORE_VERIFICATION_FAILED = StatusLevel(
+        BlockedStatus(
+            "Verification of restoring the backup failed - etcd data was not deleted on non-leader units"
+        ),
+        "ERROR",
+    )
     RESTORE_IN_PROGRESS = StatusLevel(
         MaintenanceStatus("Database restore is in progress"), "ERROR"
     )
@@ -140,6 +146,7 @@ class RestoreStep(Enum):
     NOT_STARTED = ""
     DOWNLOAD = "download_backup"
     STOP = "stop_workload"
+    VERIFY = "verify_backup"
     RESTORE = "restore_backup"
     START = "restart_workload"
     COMPLETED = "completed"

--- a/src/literals.py
+++ b/src/literals.py
@@ -91,7 +91,7 @@ class Status(Enum):
     RESTORE_FAILED = StatusLevel(BlockedStatus("failed to restore backup"), "ERROR")
     RESTORE_VERIFICATION_FAILED = StatusLevel(
         BlockedStatus(
-            "Verification of restoring the backup failed - etcd data was not deleted on non-leader units"
+            "Restore verification failed - etcd cluster still running, restore cancelled, check debug-log"
         ),
         "ERROR",
     )

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -273,11 +273,6 @@ class BackupManager:
         # disable the service to avoid restart while the backup is restored
         self.workload.disable_database()
 
-        if self.state.cluster.restore_instruction == RestoreStep.VERIFY:
-            return
-
-        self.set_restore_step(RestoreStep.STOP.value)
-
     def restore_backup(self) -> None:
         """Perform the actual restore-operation on the etcd database."""
         backup_id_to_restore = self.state.cluster.restore_id
@@ -313,11 +308,6 @@ class BackupManager:
         """Enable and start the etcd database again after restoring."""
         logger.info("Enabling and starting etcd workload.")
         self.workload.enable_database()
-
-        if self.state.cluster.restore_instruction == RestoreStep.VERIFY:
-            return
-
-        self.set_restore_step(RestoreStep.START.value)
 
     def clean_up_after_restore(self) -> None:
         """Remove backup files and state from unit."""

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -375,7 +375,10 @@ class BackupManager:
         """Check workflow progress for all units and proceed to next step if possible."""
         current_step = self.state.cluster.restore_instruction
 
-        if current_step == RestoreStep.RESTORE:
+        if (
+            current_step == RestoreStep.RESTORE
+            and not self.state.cluster.restore_verification_failed
+        ):
             # `cluster_state` must be reset before starting a restored cluster
             self.state.cluster.update({"cluster_state": EtcdClusterState.NEW.value})
         elif current_step == RestoreStep.COMPLETED:

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -200,6 +200,9 @@ class BackupManager:
         # disable the service to avoid restart while the backup is restored
         self.workload.disable_database()
 
+        if self.state.cluster.restore_instruction == RestoreStep.VERIFY:
+            return
+
         self.set_restore_step(RestoreStep.STOP.value)
 
     def restore_backup(self) -> None:
@@ -219,19 +222,27 @@ class BackupManager:
         if not etcd_client.restore_database_snapshot(
             snapshot_filename=f"{SNAP_CONFIG_PATH}/{RESTORE_FILE_NAME}",
             data_directory=SNAP_DATA_PATH,
-            cluster_config=self.state.cluster.cluster_members,
+            cluster_config=self.state.unit_server.member_endpoint
+            if self.state.cluster.restore_instruction == RestoreStep.VERIFY
+            else self.state.cluster.cluster_members,
             peer_url=self.state.unit_server.peer_url,
             member_name=self.state.unit_server.member_name,
         ):
             raise EtcdBackupError("Failed to restore database backup.")
 
         logger.info("Restored backup successfully.")
+        if self.state.cluster.restore_instruction == RestoreStep.VERIFY:
+            return
+
         self.set_restore_step(RestoreStep.RESTORE.value)
 
     def start_database(self) -> None:
         """Enable and start the etcd database again after restoring."""
         logger.info("Enabling and starting etcd workload.")
         self.workload.enable_database()
+
+        if self.state.cluster.restore_instruction == RestoreStep.VERIFY:
+            return
 
         self.set_restore_step(RestoreStep.START.value)
 
@@ -275,6 +286,8 @@ class BackupManager:
             case RestoreStep.DOWNLOAD:
                 return RestoreStep.STOP
             case RestoreStep.STOP:
+                return RestoreStep.VERIFY
+            case RestoreStep.VERIFY:
                 return RestoreStep.RESTORE
             case RestoreStep.RESTORE:
                 return RestoreStep.START
@@ -317,5 +330,8 @@ class BackupManager:
 
         if self.state.cluster.is_restore_in_progress:
             status_list.append(Status.RESTORE_IN_PROGRESS)
+
+        if self.state.cluster.restore_verification_failed:
+            status_list.append(Status.RESTORE_VERIFICATION_FAILED)
 
         return status_list

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -12,7 +12,7 @@ from ops.model import ConfigData
 
 from core.cluster import ClusterState
 from core.workload import WorkloadBase
-from literals import DATABASE_DIR, METRICS_PORT, TLSState
+from literals import DATABASE_DIR, METRICS_PORT, RestoreStep, TLSState
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,15 @@ class ConfigManager:
             config_properties = yaml.safe_load(config)
 
         config_properties["name"] = self.state.unit_server.member_name
-        if self.state.cluster.cluster_state:
+        if (
+            self.state.cluster.is_restore_in_progress
+            and self.state.cluster.restore_instruction == RestoreStep.VERIFY
+        ):
+            # when verifying a backup restore, cluster configuration is only the local unit
+            config_properties["initial-cluster-state"] = self.state.cluster.cluster_state
+            config_properties["initial-cluster"] = self.state.unit_server.member_endpoint
+        elif self.state.cluster.cluster_state:
+            # regular situation: cluster is initialized and cluster configuration should be applied
             config_properties["initial-cluster-state"] = self.state.cluster.cluster_state
             config_properties["initial-cluster"] = self.state.cluster.cluster_members
         elif self.workload.exists(DATABASE_DIR):

--- a/tests/integration/backup/test_restore_verification_failed.py
+++ b/tests/integration/backup/test_restore_verification_failed.py
@@ -9,11 +9,11 @@ from pytest_operator.plugin import OpsTest
 
 from literals import INTERNAL_USER, PEER_RELATION, Status
 
-from ..ha.helpers import get_cluster_members
 from ..helpers import (
     APP_NAME,
     CHARM_PATH,
     get_cluster_endpoints,
+    get_cluster_members,
     get_key,
     get_secret_by_label,
     put_key,

--- a/tests/integration/backup/test_restore_verification_failed.py
+++ b/tests/integration/backup/test_restore_verification_failed.py
@@ -51,10 +51,6 @@ async def test_deploy_and_configure(
     await set_credentials_action.wait()
     await wait_until(ops_test, apps=[APP_NAME, S3_INTEGRATOR], apps_statuses=["active"])
 
-    logger.info("Configure admin credentials in etcd")
-    await set_password(ops_test, PASSWORD)
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
-
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
@@ -124,8 +120,12 @@ async def test_create_backup(ops_test: OpsTest) -> None:
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_restore_backup_on_same_cluster(ops_test: OpsTest) -> None:
-    """Restore a backup and check if data is recovered."""
+async def test_restore_verification_failed(ops_test: OpsTest):
+    """Restore a backup with invalid admin password."""
+    logger.info("Configure admin credentials in etcd")
+    await set_password(ops_test, "invalid_password")
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+
     for unit in ops_test.model.applications[APP_NAME].units:
         if await unit.is_leader_from_status():
             leader_unit = unit
@@ -134,54 +134,16 @@ async def test_restore_backup_on_same_cluster(ops_test: OpsTest) -> None:
     logger.info(f"Restoring backup {backup_id}")
     restore_action = await leader_unit.run_action("restore", **{"backup-id": backup_id})
     restore_backup_response = await restore_action.wait()
-    assert restore_backup_response.results.get("return-code") == 0, "restore failed"
+    assert restore_backup_response.results.get("return-code") == 0, "restore action failed"
 
-    # wait for the restore to be performed across all units and check the restored data
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
-
-    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
-    assert get_key(endpoints, user=INTERNAL_USER, password=PASSWORD, key=TEST_KEY) == TEST_VALUE, (
-        "data not recovered"
-    )
-
-
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
-@pytest.mark.group(1)
-@pytest.mark.abort_on_fail
-async def test_restore_backup_on_different_cluster(ops_test: OpsTest):
-    """Restore a backup and check if data is recovered."""
-    logger.info("Remove existing etcd cluster and deploy a new one.")
-    await ops_test.model.remove_application(APP_NAME, block_until_done=True)
-    await ops_test.model.deploy(CHARM_PATH, num_units=NUM_UNITS)
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS, idle_period=60)
-
-    logger.info("Configure admin credentials in etcd")
-    await set_password(ops_test, PASSWORD)
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
-
-    logger.info(f"Integrate the newly deployed application with {S3_INTEGRATOR}")
-    await ops_test.model.integrate(APP_NAME, S3_INTEGRATOR)
     await wait_until(
         ops_test,
-        apps=[APP_NAME, S3_INTEGRATOR],
-        apps_statuses=["active"],
-        units_statuses=["active"],
-    )
-
-    for unit in ops_test.model.applications[APP_NAME].units:
-        if await unit.is_leader_from_status():
-            leader_unit = unit
-
-    # download the backup from storage and restore it
-    logger.info(f"Restoring backup {backup_id}")
-    restore_action = await leader_unit.run_action("restore", **{"backup-id": backup_id})
-    restore_backup_response = await restore_action.wait()
-    assert restore_backup_response.results.get("return-code") == 0, "restore failed"
-
-    # wait for the restore to be performed across all units and check the restored data
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
-
-    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
-    assert get_key(endpoints, user=INTERNAL_USER, password=PASSWORD, key=TEST_KEY) == TEST_VALUE, (
-        "data not recovered"
+        apps=[APP_NAME],
+        units_full_statuses={
+            APP_NAME: {
+                "units": {
+                    "blocked": [Status.RESTORE_VERIFICATION_FAILED.value.status.message],
+                }
+            },
+        },
     )

--- a/tests/integration/backup/test_restore_verification_failed.py
+++ b/tests/integration/backup/test_restore_verification_failed.py
@@ -7,13 +7,15 @@ import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from literals import INTERNAL_USER, Status
+from literals import INTERNAL_USER, PEER_RELATION, Status
 
+from ..ha.helpers import get_cluster_members
 from ..helpers import (
     APP_NAME,
     CHARM_PATH,
     get_cluster_endpoints,
     get_key,
+    get_secret_by_label,
     put_key,
     set_password,
 )
@@ -25,7 +27,6 @@ NUM_UNITS = 3
 S3_INTEGRATOR = "s3-integrator"
 TEST_KEY = "test_key"
 TEST_VALUE = "42"
-PASSWORD = "some-password"
 backup_id = ""
 
 
@@ -77,18 +78,23 @@ async def test_create_backup(ops_test: OpsTest) -> None:
     global backup_id
 
     # Before creating a backup, enter some data
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
+    initial_password = secret.get(f"{INTERNAL_USER}-password")
     endpoints = get_cluster_endpoints(ops_test, APP_NAME)
     assert (
         put_key(
             endpoints,
             user=INTERNAL_USER,
-            password=PASSWORD,
+            password=initial_password,
             key=TEST_KEY,
             value=TEST_VALUE,
         )
         == "OK"
     )
-    assert get_key(endpoints, user=INTERNAL_USER, password=PASSWORD, key=TEST_KEY) == TEST_VALUE
+    assert (
+        get_key(endpoints, user=INTERNAL_USER, password=initial_password, key=TEST_KEY)
+        == TEST_VALUE
+    )
 
     for unit in ops_test.model.applications[APP_NAME].units:
         if await unit.is_leader_from_status():
@@ -113,7 +119,8 @@ async def test_create_backup(ops_test: OpsTest) -> None:
 
     # update test data to later check if it was restored
     assert (
-        put_key(endpoints, user=INTERNAL_USER, password=PASSWORD, key=TEST_KEY, value="0") == "OK"
+        put_key(endpoints, user=INTERNAL_USER, password=initial_password, key=TEST_KEY, value="0")
+        == "OK"
     )
 
 
@@ -123,19 +130,21 @@ async def test_create_backup(ops_test: OpsTest) -> None:
 async def test_restore_verification_failed(ops_test: OpsTest):
     """Restore a backup with invalid admin password."""
     logger.info("Configure admin credentials in etcd")
-    await set_password(ops_test, "invalid_password")
+    invalid_password = "invalid_password"
+    await set_password(ops_test, invalid_password)
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
     for unit in ops_test.model.applications[APP_NAME].units:
         if await unit.is_leader_from_status():
             leader_unit = unit
 
-    # download the backup from storage and restore it
+    # download the backup from storage and try to restore it
     logger.info(f"Restoring backup {backup_id}")
     restore_action = await leader_unit.run_action("restore", **{"backup-id": backup_id})
     restore_backup_response = await restore_action.wait()
     assert restore_backup_response.results.get("return-code") == 0, "restore action failed"
 
+    # the restore will fail because the current password is not valid for the backup-file
     await wait_until(
         ops_test,
         apps=[APP_NAME],
@@ -146,4 +155,17 @@ async def test_restore_verification_failed(ops_test: OpsTest):
                 }
             },
         },
+    )
+
+    # ensure test data was not restored
+    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    assert not (
+        get_key(endpoints, user=INTERNAL_USER, password=invalid_password, key=TEST_KEY)
+        == TEST_VALUE
+    ), "Test data was restored even though restore should have failed"
+
+    # ensure cluster is fully formed
+    cluster_members = get_cluster_members(endpoints)
+    assert len(cluster_members) == NUM_UNITS, (
+        f"Expected {NUM_UNITS} cluster members, got {len(cluster_members)}."
     )

--- a/tests/integration/backup/test_s3_backup_restore.py
+++ b/tests/integration/backup/test_s3_backup_restore.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from literals import INTERNAL_USER, Status
+from literals import INTERNAL_USER
 
 from ..helpers import (
     APP_NAME,

--- a/tests/integration/backup/test_s3_backup_restore.py
+++ b/tests/integration/backup/test_s3_backup_restore.py
@@ -215,7 +215,6 @@ async def test_restore_verification_failed(ops_test: OpsTest):
             APP_NAME: {
                 "units": {
                     "blocked": [Status.RESTORE_VERIFICATION_FAILED.value.status.message],
-                    "active": [],
                 }
             },
         },

--- a/tests/integration/backup/test_s3_backup_restore.py
+++ b/tests/integration/backup/test_s3_backup_restore.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from literals import INTERNAL_USER
+from literals import INTERNAL_USER, Status
 
 from ..helpers import (
     APP_NAME,
@@ -121,6 +121,7 @@ async def test_create_backup(ops_test: OpsTest) -> None:
     )
 
 
+@pytest.mark.skip()
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -145,6 +146,7 @@ async def test_restore_backup_on_same_cluster(ops_test: OpsTest) -> None:
     )
 
 
+@pytest.mark.skip()
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -184,4 +186,37 @@ async def test_restore_backup_on_different_cluster(ops_test: OpsTest):
     endpoints = get_cluster_endpoints(ops_test, APP_NAME)
     assert get_key(endpoints, user=INTERNAL_USER, password=PASSWORD, key=TEST_KEY) == TEST_VALUE, (
         "data not recovered"
+    )
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_restore_verification_failed(ops_test: OpsTest):
+    """Restore a backup with invalid admin password."""
+    logger.info("Configure admin credentials in etcd")
+    await set_password(ops_test, "invalid_password")
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+
+    for unit in ops_test.model.applications[APP_NAME].units:
+        if await unit.is_leader_from_status():
+            leader_unit = unit
+
+    # download the backup from storage and restore it
+    logger.info(f"Restoring backup {backup_id}")
+    restore_action = await leader_unit.run_action("restore", **{"backup-id": backup_id})
+    restore_backup_response = await restore_action.wait()
+    assert restore_backup_response.results.get("return-code") == 0, "restore action failed"
+
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        units_full_statuses={
+            APP_NAME: {
+                "units": {
+                    "blocked": [Status.RESTORE_VERIFICATION_FAILED.value.status.message],
+                    "active": [],
+                }
+            },
+        },
     )

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -378,7 +378,11 @@ def test_restore_workflow_order():
                 == RestoreStep.STOP
             )
             assert (
-                context.charm.backup_manager.next_restore_step(current_step=RestoreStep.STOP)
+                    context.charm.backup_manager.next_restore_step(current_step=RestoreStep.STOP)
+                    == RestoreStep.VERIFY
+            )
+            assert (
+                context.charm.backup_manager.next_restore_step(current_step=RestoreStep.VERIFY)
                 == RestoreStep.RESTORE
             )
             assert (
@@ -443,14 +447,66 @@ def test_restore_workflow_synchronization():
         )
         assert (
             state_out.get_relation(1).local_app_data.get("restore_instruction")
-            == RestoreStep.RESTORE.value
+            == RestoreStep.VERIFY.value
+        )
+
+    # restore step: verify (leader)
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_unit_data={"state": "started", "restore_step": RestoreStep.STOP.value},
+        local_app_data={
+            "restore_id": "xyz",
+            "restore_instruction": RestoreStep.VERIFY.value,
+            "cluster_state": EtcdClusterState.EXISTING.value,
+            "authentication": "enabled",
+        },
+    )
+    state_in = testing.State(relations={relation}, leader=True)
+    with (
+        patch("workload.EtcdWorkload.stop"),
+        patch("workload.EtcdWorkload.disable_service"),
+    ):
+        state_out = ctx.run(ctx.on.relation_changed(relation=relation), state_in)
+
+        assert state_out.unit_status == ops.MaintenanceStatus("Database restore is in progress")
+        assert (
+                state_out.get_relation(1).local_unit_data.get("restore_step") == RestoreStep.VERIFY.value
+        )
+        assert (
+                state_out.get_relation(1).local_app_data.get("restore_instruction")
+                == RestoreStep.RESTORE.value
+        )
+
+    # restore step: verify (non-leader)
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_unit_data={"state": "started", "restore_step": RestoreStep.STOP.value},
+        local_app_data={
+            "restore_id": "xyz",
+            "restore_instruction": RestoreStep.VERIFY.value,
+            "cluster_state": EtcdClusterState.EXISTING.value,
+            "authentication": "enabled",
+        },
+    )
+    state_in = testing.State(relations={relation})
+    with (
+        patch("workload.EtcdWorkload.stop"),
+        patch("workload.EtcdWorkload.disable_service"),
+    ):
+        state_out = ctx.run(ctx.on.relation_changed(relation=relation), state_in)
+
+        assert state_out.unit_status == ops.MaintenanceStatus("Database restore is in progress")
+        assert (
+                state_out.get_relation(1).local_unit_data.get("restore_step") == RestoreStep.VERIFY.value
         )
 
     # restore step: restore (non-leader)
     relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
-        local_unit_data={"state": "started", "restore_step": RestoreStep.STOP.value},
+        local_unit_data={"state": "started", "restore_step": RestoreStep.VERIFY.value},
         local_app_data={
             "restore_id": "xyz",
             "restore_instruction": RestoreStep.RESTORE.value,
@@ -474,7 +530,7 @@ def test_restore_workflow_synchronization():
     relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
-        local_unit_data={"state": "started", "restore_step": RestoreStep.STOP.value},
+        local_unit_data={"state": "started", "restore_step": RestoreStep.VERIFY.value},
         local_app_data={
             "restore_id": "xyz",
             "restore_instruction": RestoreStep.RESTORE.value,
@@ -506,7 +562,7 @@ def test_restore_workflow_synchronization():
     relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
-        local_unit_data={"state": "started", "restore_step": RestoreStep.STOP.value},
+        local_unit_data={"state": "started", "restore_step": RestoreStep.VERIFY.value},
         local_app_data={
             "restore_id": "xyz",
             "restore_instruction": RestoreStep.RESTORE.value,

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -378,8 +378,8 @@ def test_restore_workflow_order():
                 == RestoreStep.STOP
             )
             assert (
-                    context.charm.backup_manager.next_restore_step(current_step=RestoreStep.STOP)
-                    == RestoreStep.VERIFY
+                context.charm.backup_manager.next_restore_step(current_step=RestoreStep.STOP)
+                == RestoreStep.VERIFY
             )
             assert (
                 context.charm.backup_manager.next_restore_step(current_step=RestoreStep.VERIFY)
@@ -410,7 +410,7 @@ def test_restore_workflow_synchronization():
             "authentication": "enabled",
         },
     )
-    state_in = testing.State(relations={relation})
+    state_in = testing.State(relations={relation}, leader=False)
     with (
         patch("workload.EtcdWorkload.stop"),
         patch("workload.EtcdWorkload.disable_service"),
@@ -450,6 +450,26 @@ def test_restore_workflow_synchronization():
             == RestoreStep.VERIFY.value
         )
 
+    # restore step: verify (non-leader)
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_unit_data={"state": "started", "restore_step": RestoreStep.STOP.value},
+        local_app_data={
+            "restore_id": "xyz",
+            "restore_instruction": RestoreStep.VERIFY.value,
+            "cluster_state": EtcdClusterState.EXISTING.value,
+            "authentication": "enabled",
+        },
+    )
+    state_in = testing.State(relations={relation}, leader=False)
+    state_out = ctx.run(ctx.on.relation_changed(relation=relation), state_in)
+
+    assert state_out.unit_status == ops.MaintenanceStatus("Database restore is in progress")
+    assert (
+        state_out.get_relation(1).local_unit_data.get("restore_step") == RestoreStep.VERIFY.value
+    )
+
     # restore step: verify (leader)
     relation = testing.PeerRelation(
         id=1,
@@ -464,6 +484,12 @@ def test_restore_workflow_synchronization():
     )
     state_in = testing.State(relations={relation}, leader=True)
     with (
+        patch("workload.EtcdWorkload.remove_directory"),
+        patch("subprocess.run", return_value=CompletedProcess(returncode=0, args=[], stdout="")),
+        patch("workload.EtcdWorkload.write_file"),
+        patch("workload.EtcdWorkload.start"),
+        patch("workload.EtcdWorkload.enable_service"),
+        patch("managers.cluster.ClusterManager.is_healthy", return_value=True),
         patch("workload.EtcdWorkload.stop"),
         patch("workload.EtcdWorkload.disable_service"),
     ):
@@ -471,14 +497,15 @@ def test_restore_workflow_synchronization():
 
         assert state_out.unit_status == ops.MaintenanceStatus("Database restore is in progress")
         assert (
-                state_out.get_relation(1).local_unit_data.get("restore_step") == RestoreStep.VERIFY.value
+            state_out.get_relation(1).local_unit_data.get("restore_step")
+            == RestoreStep.VERIFY.value
         )
         assert (
-                state_out.get_relation(1).local_app_data.get("restore_instruction")
-                == RestoreStep.RESTORE.value
+            state_out.get_relation(1).local_app_data.get("restore_instruction")
+            == RestoreStep.RESTORE.value
         )
 
-    # restore step: verify (non-leader)
+    # restore step: verify (leader) -> failed
     relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
@@ -490,16 +517,28 @@ def test_restore_workflow_synchronization():
             "authentication": "enabled",
         },
     )
-    state_in = testing.State(relations={relation})
+    state_in = testing.State(relations={relation}, leader=True)
     with (
+        patch("workload.EtcdWorkload.remove_directory"),
+        patch("subprocess.run", return_value=CompletedProcess(returncode=0, args=[], stdout="")),
+        patch("workload.EtcdWorkload.write_file"),
+        patch("workload.EtcdWorkload.start"),
+        patch("workload.EtcdWorkload.enable_service"),
+        patch("managers.cluster.ClusterManager.is_healthy", return_value=False),
         patch("workload.EtcdWorkload.stop"),
         patch("workload.EtcdWorkload.disable_service"),
     ):
         state_out = ctx.run(ctx.on.relation_changed(relation=relation), state_in)
 
-        assert state_out.unit_status == ops.MaintenanceStatus("Database restore is in progress")
+        assert state_out.unit_status == ops.BlockedStatus(
+            "Verification of restoring the backup failed - etcd data was not deleted on non-leader units"
+        )
         assert (
-                state_out.get_relation(1).local_unit_data.get("restore_step") == RestoreStep.VERIFY.value
+            state_out.get_relation(1).local_unit_data.get("restore_step") == RestoreStep.STOP.value
+        )
+        assert (
+            state_out.get_relation(1).local_app_data.get("restore_instruction")
+            == RestoreStep.VERIFY.value
         )
 
     # restore step: restore (non-leader)
@@ -514,7 +553,7 @@ def test_restore_workflow_synchronization():
             "authentication": "enabled",
         },
     )
-    state_in = testing.State(relations={relation})
+    state_in = testing.State(relations={relation}, leader=False)
     with (
         patch("workload.EtcdWorkload.remove_directory"),
         patch("subprocess.run", return_value=CompletedProcess(returncode=0, args=[], stdout="")),
@@ -596,7 +635,7 @@ def test_restore_workflow_synchronization():
             "authentication": "enabled",
         },
     )
-    state_in = testing.State(relations={relation})
+    state_in = testing.State(relations={relation}, leader=False)
     with (
         patch("workload.EtcdWorkload.write_file") as write_config,
         patch("workload.EtcdWorkload.start"),
@@ -653,7 +692,7 @@ def test_restore_workflow_synchronization():
             "authentication": "enabled",
         },
     )
-    state_in = testing.State(relations={relation})
+    state_in = testing.State(relations={relation}, leader=False)
     with (
         patch("workload.EtcdWorkload.remove_file") as remove_backup,
         patch("managers.cluster.ClusterManager.is_healthy", return_value=True),
@@ -678,7 +717,7 @@ def test_restore_workflow_synchronization():
             "authentication": "enabled",
         },
     )
-    state_in = testing.State(relations={relation})
+    state_in = testing.State(relations={relation}, leader=False)
     with (
         patch("workload.EtcdWorkload.remove_file") as remove_backup,
         patch("managers.cluster.ClusterManager.is_healthy", return_value=False),

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -620,7 +620,10 @@ def test_restore_action_s3():
     secret_content = {secret_key: secret_value}
     admin_secret = testing.Secret(tracked_content=secret_content, remote_grants=APP_NAME)
     peer_relation = testing.PeerRelation(
-        id=1, endpoint=PEER_RELATION, local_unit_data={"state": "started"}
+        id=1,
+        endpoint=PEER_RELATION,
+        local_unit_data={"state": "started"},
+        local_app_data={"restore_verification_failed": "True"},
     )
     secret_content = {"s3-credentials": json.dumps(s3_credentials)}
     secret = Secret(secret_content, label=f"{PEER_RELATION}.{APP_NAME}.app")
@@ -873,14 +876,18 @@ def test_restore_workflow_synchronization():
         state_out = ctx.run(ctx.on.relation_changed(relation=relation), state_in)
 
         assert state_out.unit_status == ops.BlockedStatus(
-            "Verification of restoring the backup failed - etcd data was not deleted on non-leader units"
+            "Restore verification failed - etcd cluster still running, restore cancelled, check debug-log"
         )
         assert (
-            state_out.get_relation(1).local_unit_data.get("restore_step") == RestoreStep.STOP.value
+            state_out.get_relation(1).local_unit_data.get("restore_step")
+            == RestoreStep.VERIFY.value
         )
         assert (
             state_out.get_relation(1).local_app_data.get("restore_instruction")
-            == RestoreStep.VERIFY.value
+            == RestoreStep.RESTORE.value
+        )
+        assert (
+            state_out.get_relation(1).local_app_data.get("restore_verification_failed") == "True"
         )
 
     # restore step: restore (non-leader)
@@ -937,6 +944,70 @@ def test_restore_workflow_synchronization():
         assert (
             state_out.get_relation(1).local_app_data.get("cluster_state")
             == EtcdClusterState.NEW.value
+        )
+
+    # restore step: skip restore after verification failed (non-leader)
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_unit_data={"state": "started", "restore_step": RestoreStep.VERIFY.value},
+        local_app_data={
+            "restore_id": "xyz",
+            "restore_instruction": RestoreStep.RESTORE.value,
+            "restore_verification_failed": "True",
+            "cluster_state": EtcdClusterState.EXISTING.value,
+            "authentication": "enabled",
+        },
+    )
+    state_in = testing.State(relations={relation}, leader=False)
+    with (
+        patch("managers.backup.BackupManager.restore_backup") as restore_backup,
+    ):
+        state_out = ctx.run(ctx.on.relation_changed(relation=relation), state_in)
+
+        restore_backup.assert_not_called()
+        assert (
+            state_out.get_relation(1).local_unit_data.get("restore_step")
+            == RestoreStep.RESTORE.value
+        )
+        assert state_out.unit_status == ops.BlockedStatus(
+            "Restore verification failed - etcd cluster still running, restore cancelled, check debug-log"
+        )
+
+    # restore step: skip restore after verification failed (leader)
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_unit_data={"state": "started", "restore_step": RestoreStep.VERIFY.value},
+        local_app_data={
+            "restore_id": "xyz",
+            "restore_instruction": RestoreStep.RESTORE.value,
+            "restore_verification_failed": "True",
+            "cluster_state": EtcdClusterState.EXISTING.value,
+            "authentication": "enabled",
+        },
+    )
+    state_in = testing.State(relations={relation}, leader=True)
+    with (
+        patch("managers.backup.BackupManager.restore_backup") as restore_backup,
+    ):
+        state_out = ctx.run(ctx.on.relation_changed(relation=relation), state_in)
+
+        restore_backup.assert_not_called()
+        assert (
+            state_out.get_relation(1).local_unit_data.get("restore_step")
+            == RestoreStep.RESTORE.value
+        )
+        assert (
+            state_out.get_relation(1).local_app_data.get("restore_instruction")
+            == RestoreStep.START.value
+        )
+        assert (
+            state_out.get_relation(1).local_app_data.get("cluster_state")
+            == EtcdClusterState.EXISTING.value
+        )
+        assert state_out.unit_status == ops.BlockedStatus(
+            "Restore verification failed - etcd cluster still running, restore cancelled, check debug-log"
         )
 
     # restore step: restore -> failed


### PR DESCRIPTION
As part of the restore procedure, the data directories of all units will be purged. In a situation where the restore fails (e.g. wrong admin password configured), the cluster would ultimately be lost and all the data could not be recovered anymore. To avoid this, we will run a verification of the restore on the leader before actually executing the restore on all units.

The restore-verification will:
- purge the unit's data directory
- restore the backup file only on the leader unit
- immediately start etcd
- perform a health check on the leader unit

If the health check fails, the restore workflow will NOT proceed, so that the data on the remaining units will not be purged. Instead, the leader unit will reset its data directory and the restore-step will be skipped for all units. The cluster will be recovered as before the restore was initiated.

If the health check succeeds, the restore procedure can continue on all units.

**UI/UX:**
- add new status `Blocked: Restore verification failed - etcd cluster still running, restore cancelled, check debug-log`
- if a new `restore` action is executed by a user, the status will be reset

**Implementation:**
- add `RestoreStep.VERIFY`
- add new method `_verify_restore()` to the `BackupEvents` class that bundles the execution flow for the `verify` step
- adjust workflow execution for the `restore` step

**Testing:**
- adjust unit test coverage in `test_restore_workflow_synchronization()`
- add new integration test file `test_restore_verification_failed.py`