### PR TITLE
[DPE-7389] Remove inconsistent cluster members

### DIFF
--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -318,6 +318,8 @@ class EtcdEvents(Object):
                 return
 
         self.charm.cluster_manager.clean_users()
+        if self.charm.unit.is_leader():
+            self.charm.cluster_manager.remove_inconsistent_members_if_required()
 
         for tls_type in TLSType:
             try:

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -319,7 +319,11 @@ class EtcdEvents(Object):
 
         self.charm.cluster_manager.clean_users()
         if self.charm.unit.is_leader():
-            self.charm.cluster_manager.remove_inconsistent_members_if_required()
+            try:
+                self.charm.cluster_manager.remove_inconsistent_members_if_required()
+            except (ValueError, EtcdClusterManagementError) as e:
+                logger.error(e)
+                self.charm.set_status(Status.CLUSTER_MANAGEMENT_ERROR)
 
         for tls_type in TLSType:
             try:

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -309,6 +309,23 @@ class ClusterManager:
             logger.warning(f"Could not transfer cluster leadership: {e}")
             return
 
+    def remove_inconsistent_members_if_required(self) -> None:
+        """Check current cluster members and remove those not existing anymore."""
+
+        client = EtcdClient(
+            username=self.admin_user,
+            password=self.admin_password,
+            client_url=self.state.unit_server.client_url,
+        )
+
+        cluster_members =  client.member_list()
+        for member in cluster_members:
+            if member.name not in
+
+        # for member in list
+        # if member not in servers
+        # self.update_cluster_member_state()
+
     def update_cluster_member_state(self) -> None:
         """Get up-to-date member information and store in cluster state."""
         if not self.state.cluster.cluster_state:

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -311,20 +311,21 @@ class ClusterManager:
 
     def remove_inconsistent_members_if_required(self) -> None:
         """Check current cluster members and remove those not existing anymore."""
-
         client = EtcdClient(
             username=self.admin_user,
             password=self.admin_password,
             client_url=self.state.unit_server.client_url,
         )
 
-        cluster_members =  client.member_list()
-        for member in cluster_members:
-            if member.name not in
+        cluster_members = client.member_list()
+        for name, member in cluster_members.items():
+            if name not in [server.member_name for server in self.state.servers]:
+                logger.warning(
+                    f"Member {name} does not exist anymore and will be removed from the cluster."
+                )
+                client.remove_member(member.id)
 
-        # for member in list
-        # if member not in servers
-        # self.update_cluster_member_state()
+        self.update_cluster_member_state()
 
     def update_cluster_member_state(self) -> None:
         """Get up-to-date member information and store in cluster state."""

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -51,6 +51,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> None:
     """Make sure a forcefully removed unit is removed as cluster member."""
     unit_to_remove = ops_test.model.applications[APP_NAME].units[-1]
+    removed_member_name = unit_to_remove.name.replace("/", "")
     logger.info(f"Forcefully removing unit {unit_to_remove.name}")
 
     destroy_unit_cmd = f"remove-unit {unit_to_remove.name} --model={ops_test.model.info.name} --force --no-wait --no-prompt"
@@ -69,8 +70,13 @@ async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> 
         )
 
     cluster_members = get_cluster_members(endpoints)
-    assert len(cluster_members) == NUM_UNITS - 1, (
-        f"Expected {NUM_UNITS - 1} cluster members, got {len(cluster_members)}."
+    member_names = [member["name"] for member in cluster_members]
+    for unit in ops_test.model.applications[APP_NAME].units:
+        assert unit.name.replace("/", "") in member_names, (
+            f"unit {unit.name} not in cluster members"
+        )
+    assert removed_member_name not in member_names, (
+        f"{removed_member_name} still in cluster members"
     )
 
     assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from literals import INTERNAL_USER, PEER_RELATION
+
+from ..helpers import (
+    APP_NAME,
+    CHARM_PATH,
+    get_cluster_endpoints,
+    get_cluster_members,
+    get_secret_by_label,
+)
+from ..helpers_deployment import wait_until
+from .helpers import (
+    assert_continuous_writes_consistent,
+    assert_continuous_writes_increasing,
+    start_continuous_writes,
+    stop_continuous_writes,
+)
+
+logger = logging.getLogger(__name__)
+
+NUM_UNITS = 3
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest) -> None:
+    """Build and deploy the charm, allowing for skipping if already deployed."""
+    await ops_test.model.deploy(CHARM_PATH, num_units=NUM_UNITS)
+    await wait_until(ops_test, apps=[APP_NAME], timeout=1000)
+
+    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
+    password = secret.get(f"{INTERNAL_USER}-password")
+
+    # start writing data to the cluster
+    start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> None:
+    """Make sure a forcefully removed unit is removed as cluster member."""
+    unit_to_remove = ops_test.model.applications[APP_NAME].units[-1]
+    logger.info(f"Forcefully removing unit {unit_to_remove.name}")
+
+    destroy_unit_cmd = (
+        f"remove-unit {unit_to_remove.name} --model={ops_test.model.info.name} --force --no-wait"
+    )
+    return_code, _, _ = await ops_test.juju(*destroy_unit_cmd.split())
+    assert return_code == 0, "Failed to remove unit"
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS - 1)
+
+    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
+    password = secret.get(f"{INTERNAL_USER}-password")
+
+    # wait for the next `update_status` for the cluster membership to be updated
+    async with ops_test.fast_forward("5s"):
+        assert_continuous_writes_increasing(
+            endpoints=endpoints, user=INTERNAL_USER, password=password
+        )
+
+    cluster_members = get_cluster_members(endpoints)
+    assert len(cluster_members) == NUM_UNITS - 1, (
+        f"Expected {NUM_UNITS - 1} cluster members, got {len(cluster_members)}."
+    )
+
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    stop_continuous_writes()
+    assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -53,9 +53,7 @@ async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> 
     unit_to_remove = ops_test.model.applications[APP_NAME].units[-1]
     logger.info(f"Forcefully removing unit {unit_to_remove.name}")
 
-    destroy_unit_cmd = (
-        f"remove-unit {unit_to_remove.name} --model={ops_test.model.info.name} --force --no-wait --no-prompt"
-    )
+    destroy_unit_cmd = f"remove-unit {unit_to_remove.name} --model={ops_test.model.info.name} --force --no-wait --no-prompt"
     return_code, _, _ = await ops_test.juju(*destroy_unit_cmd.split())
     assert return_code == 0, "Failed to remove unit"
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS - 1)

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -33,7 +33,7 @@ NUM_UNITS = 3
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
-    """Build and deploy the charm, allowing for skipping if already deployed."""
+    """Build and deploy the charm."""
     await ops_test.model.deploy(CHARM_PATH, num_units=NUM_UNITS)
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000)
 

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -54,7 +54,7 @@ async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> 
     logger.info(f"Forcefully removing unit {unit_to_remove.name}")
 
     destroy_unit_cmd = (
-        f"remove-unit {unit_to_remove.name} --model={ops_test.model.info.name} --force --no-wait"
+        f"remove-unit {unit_to_remove.name} --model={ops_test.model.info.name} --force --no-wait --no-prompt"
     )
     return_code, _, _ = await ops_test.juju(*destroy_unit_cmd.split())
     assert return_code == 0, "Failed to remove unit"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -413,6 +413,7 @@ def test_removal_of_inconsistent_members():
     state_in = testing.State(relations={relation}, leader=True)
     with (
         patch("common.client.EtcdClient.member_list", return_value=cluster_member_list),
+        patch("common.client.EtcdClient.remove_member") as remove_member,
         patch("workload.EtcdWorkload.alive", return_value=True),
         patch("managers.cluster.ClusterManager.clean_users"),
         patch("workload.EtcdWorkload.exec", return_value=CompletedProcess(returncode=0, args=[])),
@@ -421,6 +422,7 @@ def test_removal_of_inconsistent_members():
         ) as update_cluster_member_state,
     ):
         ctx.run(ctx.on.update_status(), state_in)
+        remove_member.assert_called()
         update_cluster_member_state.assert_called_once()
 
     # no clean-up on non-leader units
@@ -429,11 +431,13 @@ def test_removal_of_inconsistent_members():
         patch("workload.EtcdWorkload.alive", return_value=True),
         patch("managers.cluster.ClusterManager.clean_users"),
         patch("workload.EtcdWorkload.exec", return_value=CompletedProcess(returncode=0, args=[])),
+        patch("common.client.EtcdClient.remove_member") as remove_member,
         patch(
             "managers.cluster.ClusterManager.update_cluster_member_state"
         ) as update_cluster_member_state,
     ):
         ctx.run(ctx.on.update_status(), state_in)
+        remove_member.assert_not_called()
         update_cluster_member_state.assert_not_called()
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -381,6 +381,48 @@ def test_update_status():
         )
 
 
+def test_removal_of_inconsistent_members():
+    # this test is assuming the default relation has only one unit: remote/0
+    cluster_member_list = {
+        "remote0": Member(
+            id="1",
+            name="remote0",
+            peer_urls=["http://ip:2380"],
+            client_urls=["http://ip:2379"],
+        ),
+        "remote1": Member(
+            id="2",
+            name="remote1",
+            peer_urls=["http://ip:2381"],
+            client_urls=["http://ip:2380"],
+        ),
+    }
+
+    ctx = testing.Context(EtcdOperatorCharm)
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={
+            "cluster_state": "existing",
+            "authentication": "enabled",
+            "cluster_members": "remote0=http://ip0:2380,remote1=http://ip1:2380",
+        },
+    )
+    state_in = testing.State(relations={relation})
+
+    with (
+        patch("common.client.EtcdClient.member_list", return_value=cluster_member_list),
+        patch("workload.EtcdWorkload.alive", return_value=True),
+        patch("managers.cluster.ClusterManager.clean_users"),
+        patch("workload.EtcdWorkload.exec", return_value=CompletedProcess(returncode=0, args=[])),
+        patch(
+            "managers.cluster.ClusterManager.update_cluster_member_state"
+        ) as update_cluster_member_state,
+    ):
+        ctx.run(ctx.on.update_status(), state_in)
+        update_cluster_member_state.assert_called_once()
+
+
 def test_peer_relation_created():
     test_data = {"hostname": "my_hostname", "ip": "my_ip"}
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -425,6 +425,25 @@ def test_removal_of_inconsistent_members():
         remove_member.assert_called()
         update_cluster_member_state.assert_called_once()
 
+    # error case: clean up fails
+    state_in = testing.State(relations={relation}, leader=True)
+    with (
+        patch("common.client.EtcdClient.member_list", return_value=cluster_member_list),
+        patch(
+            "common.client.EtcdClient.remove_member", side_effect=EtcdClusterManagementError()
+        ) as remove_member,
+        patch("workload.EtcdWorkload.alive", return_value=True),
+        patch("managers.cluster.ClusterManager.clean_users"),
+        patch("workload.EtcdWorkload.exec", return_value=CompletedProcess(returncode=0, args=[])),
+        patch(
+            "managers.cluster.ClusterManager.update_cluster_member_state"
+        ) as update_cluster_member_state,
+    ):
+        state_out = ctx.run(ctx.on.update_status(), state_in)
+        remove_member.assert_called()
+        update_cluster_member_state.assert_not_called()
+        assert state_out.unit_status == ops.BlockedStatus("cluster management error")
+
     # no clean-up on non-leader units
     state_in = testing.State(relations={relation}, leader=False)
     with (

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -408,8 +408,9 @@ def test_removal_of_inconsistent_members():
             "cluster_members": "remote0=http://ip0:2380,remote1=http://ip1:2380",
         },
     )
-    state_in = testing.State(relations={relation})
 
+    # leader should clean up inconsistent cluster members
+    state_in = testing.State(relations={relation}, leader=True)
     with (
         patch("common.client.EtcdClient.member_list", return_value=cluster_member_list),
         patch("workload.EtcdWorkload.alive", return_value=True),
@@ -421,6 +422,19 @@ def test_removal_of_inconsistent_members():
     ):
         ctx.run(ctx.on.update_status(), state_in)
         update_cluster_member_state.assert_called_once()
+
+    # no clean-up on non-leader units
+    state_in = testing.State(relations={relation}, leader=False)
+    with (
+        patch("workload.EtcdWorkload.alive", return_value=True),
+        patch("managers.cluster.ClusterManager.clean_users"),
+        patch("workload.EtcdWorkload.exec", return_value=CompletedProcess(returncode=0, args=[])),
+        patch(
+            "managers.cluster.ClusterManager.update_cluster_member_state"
+        ) as update_cluster_member_state,
+    ):
+        ctx.run(ctx.on.update_status(), state_in)
+        update_cluster_member_state.assert_not_called()
 
 
 def test_peer_relation_created():

--- a/tests/unit/test_external_client_relations.py
+++ b/tests/unit/test_external_client_relations.py
@@ -982,6 +982,7 @@ def test_etcd_rotates_ca(cluster_tls_context, mtls_cert):
             patch("managers.tls.TLSManager.update_cas"),
             patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
             patch("managers.cluster.ClusterManager.clean_users"),
+            patch("managers.cluster.ClusterManager.remove_inconsistent_members_if_required"),
         ):
             charm: EtcdOperatorCharm = manager.charm
             event = MagicMock(spec=CertificateAvailableEvent)
@@ -1560,6 +1561,7 @@ def test_removing_user_crash(cluster_tls_context, mtls_cert):
     with (
         ctx(ctx.on.update_status(), state_out) as manager,
         patch("managers.cluster.ClusterManager.remove_managed_user") as remove_managed_user,
+        patch("managers.cluster.ClusterManager.remove_inconsistent_members_if_required"),
         patch("common.client.EtcdClient.list_users", return_value=[CLIENT_COMMON_NAME]),
         patch("workload.EtcdWorkload.alive", return_value=True),
     ):


### PR DESCRIPTION
If a user removes a unit from an etcd cluster with `juju remove-unit ... --force --no-wait`, it can happen that the removing unit was not correctly removed from etcd cluster membership. In order to avoid quorum issues, the cluster membership configuration should be checked for inconsistency on update_status and units that are gone should be removed from cluster membership.

This PR adds a new method `remove_inconsistent_members_if_required()` that is executed by the Juju leader on `update_status`. It also adds unit and integration test coverage.