### PR TITLE
small home page updates

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+relatedlinks: "[Charmhub](https://charmhub.io/charmed-etcd)"
+---
+
 # Charmed etcd documentation
 
 Etcd is a distributed, reliable key-value store for the most critical data of distributed systems. This charmed operator deploys and operates etcd on virtual machines.
@@ -15,10 +19,8 @@ This new charm is still under development on the [`edge` track](https://charmhub
 |                                                                                                        |                                                                                                      |
 | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | [Tutorial](/tutorial/index.md)</br>  Get started - a hands-on introduction to etcd for new users </br> | [How-to guides](/how-to/index.md) </br> Step-by-step guides covering key operations and common tasks |
+| [Explanation](/explanation/index.md) </br> Concepts - discussion and clarification of key topics | <!--[Reference](/reference/index) </br> Technical information - specifications, APIs, architecture -->|
 
-<!--
-| [Explanation](/explanation/index) </br> Concepts - discussion and clarification of key topics | [Reference](/reference/index) </br> Technical information - specifications, APIs, architecture |
--->
 
 ## Project and community
 


### PR DESCRIPTION
Added an external link to etcd's Charmhub page, since the theme doesn't currently support it in the "More resources" dropdown.

![image](https://github.com/user-attachments/assets/275b6643-3d67-47ee-8dfd-25bdedd47658)

Updated Diatáxis table to include the Explanation section.