### PR TITLE
[DPE-6998] Recover from majority failure

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -22,3 +22,7 @@ rebuild-cluster:
     This action induces a downtime if executed on a running cluster. It should only be used to
     recover from majority failure, and it must be run on the Juju leader. The cluster will be 
     initialised with new membership configuration, based on the current Juju units at runtime.
+  params:
+    force:
+      type: boolean
+      description: Force the rebuild of a cluster even if the majority was not lost.

--- a/actions.yaml
+++ b/actions.yaml
@@ -16,3 +16,9 @@ restore:
     backup-id:
       type: string
       description: A backup-id to identify the backup to restore. Format of <%Y-%m-%dT%H:%M:%SZ>
+
+rebuild-cluster:
+  description: Stop the cluster and rebuild the cluster membership configuration.
+    This action induces a downtime if executed on a running cluster. It should only be used to
+    recover from majority failure, and it must be run on the Juju leader. The cluster will be 
+    initialised with new membership configuration, based on the current Juju units at runtime.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1423,21 +1423,21 @@ wcwidth = "*"
 
 [[package]]
 name = "protobuf"
-version = "6.30.2"
+version = "6.31.1"
 description = ""
 optional = false
 python-versions = ">=3.9"
 groups = ["integration"]
 files = [
-    {file = "protobuf-6.30.2-cp310-abi3-win32.whl", hash = "sha256:b12ef7df7b9329886e66404bef5e9ce6a26b54069d7f7436a0853ccdeb91c103"},
-    {file = "protobuf-6.30.2-cp310-abi3-win_amd64.whl", hash = "sha256:7653c99774f73fe6b9301b87da52af0e69783a2e371e8b599b3e9cb4da4b12b9"},
-    {file = "protobuf-6.30.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:0eb523c550a66a09a0c20f86dd554afbf4d32b02af34ae53d93268c1f73bc65b"},
-    {file = "protobuf-6.30.2-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:50f32cc9fd9cb09c783ebc275611b4f19dfdfb68d1ee55d2f0c7fa040df96815"},
-    {file = "protobuf-6.30.2-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4f6c687ae8efae6cf6093389a596548214467778146b7245e886f35e1485315d"},
-    {file = "protobuf-6.30.2-cp39-cp39-win32.whl", hash = "sha256:524afedc03b31b15586ca7f64d877a98b184f007180ce25183d1a5cb230ee72b"},
-    {file = "protobuf-6.30.2-cp39-cp39-win_amd64.whl", hash = "sha256:acec579c39c88bd8fbbacab1b8052c793efe83a0a5bd99db4a31423a25c0a0e2"},
-    {file = "protobuf-6.30.2-py3-none-any.whl", hash = "sha256:ae86b030e69a98e08c77beab574cbcb9fff6d031d57209f574a5aea1445f4b51"},
-    {file = "protobuf-6.30.2.tar.gz", hash = "sha256:35c859ae076d8c56054c25b59e5e59638d86545ed6e2b6efac6be0b6ea3ba048"},
+    {file = "protobuf-6.31.1-cp310-abi3-win32.whl", hash = "sha256:7fa17d5a29c2e04b7d90e5e32388b8bfd0e7107cd8e616feef7ed3fa6bdab5c9"},
+    {file = "protobuf-6.31.1-cp310-abi3-win_amd64.whl", hash = "sha256:426f59d2964864a1a366254fa703b8632dcec0790d8862d30034d8245e1cd447"},
+    {file = "protobuf-6.31.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:6f1227473dc43d44ed644425268eb7c2e488ae245d51c6866d19fe158e207402"},
+    {file = "protobuf-6.31.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:a40fc12b84c154884d7d4c4ebd675d5b3b5283e155f324049ae396b95ddebc39"},
+    {file = "protobuf-6.31.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4ee898bf66f7a8b0bd21bce523814e6fbd8c6add948045ce958b73af7e8878c6"},
+    {file = "protobuf-6.31.1-cp39-cp39-win32.whl", hash = "sha256:0414e3aa5a5f3ff423828e1e6a6e907d6c65c1d5b7e6e975793d5590bdeecc16"},
+    {file = "protobuf-6.31.1-cp39-cp39-win_amd64.whl", hash = "sha256:8764cf4587791e7564051b35524b72844f845ad0bb011704c3736cce762d8fe9"},
+    {file = "protobuf-6.31.1-py3-none-any.whl", hash = "sha256:720a6c7e6b77288b85063569baae8536671b39f15cc22037ec7045658d80489e"},
+    {file = "protobuf-6.31.1.tar.gz", hash = "sha256:d8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a"},
 ]
 
 [[package]]

--- a/src/common/client.py
+++ b/src/common/client.py
@@ -660,7 +660,12 @@ class EtcdClient:
         Returns:
             str: value of the metric
         """
-        response = requests.get(self.client_url)
+        try:
+            response = requests.get(self.client_url)
+        except requests.exceptions.RequestException as e:
+            logger.error(e)
+            raise RuntimeError(e)
+
         # the metrics server always returns text format, no json available
         for line in response.text.split("\n"):
             if metric_name in line and "#" not in line:

--- a/src/common/client.py
+++ b/src/common/client.py
@@ -10,6 +10,7 @@ import os
 import subprocess
 from typing import Tuple
 
+import requests
 import tenacity
 
 from common.exceptions import (
@@ -646,3 +647,23 @@ class EtcdClient:
         ):
             return json.loads(result)["users"]
         return []
+
+    def get_metric(self, metric_name: str) -> str | None:
+        """Query the metric server.
+
+        Performs an http request to the internal metric server of etcd, searches the result for
+        the given metric and returns the first result found.
+
+        Args:
+            metric_name: name of the metric
+
+        Returns:
+            str: value of the metric
+        """
+        response = requests.get(self.client_url)
+        # the metrics server always returns text format, no json available
+        for line in response.text.split("\n"):
+            if metric_name in line and "#" not in line:
+                return line.split(" ")[1]
+
+        return None

--- a/src/common/client.py
+++ b/src/common/client.py
@@ -668,7 +668,7 @@ class EtcdClient:
 
         # the metrics server always returns text format, no json available
         for line in response.text.split("\n"):
-            if metric_name in line and "#" not in line:
+            if metric_name in line and not line.startswith("#"):
                 return line.split(" ")[1]
 
         return None

--- a/src/common/client.py
+++ b/src/common/client.py
@@ -664,7 +664,7 @@ class EtcdClient:
             response = requests.get(self.client_url)
         except requests.exceptions.RequestException as e:
             logger.error(e)
-            raise RuntimeError(e)
+            raise
 
         # the metrics server always returns text format, no json available
         for line in response.text.split("\n"):

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -284,6 +284,11 @@ class EtcdCluster(RelationState):
         """Flag for failed restore verification."""
         return bool(self.relation_data.get("restore_verification_failed", ""))
 
+    @property
+    def rebuild_cluster_in_progress(self) -> bool:
+        """Flag to indicate if the cluster is being rebuilt to recover from majority failure."""
+        return bool(self.relation_data.get("rebuild_cluster", ""))
+
 
 @dataclass
 class Member:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -161,6 +161,11 @@ class EtcdServer(RelationState):
         return self.relation_data.get("state", "") == "started"
 
     @property
+    def rebuild_completed(self) -> bool:
+        """Check if the has been processed for cluster rebuild."""
+        return self.relation_data.get("rebuild_completed", "") == "True"
+
+    @property
     def tls_peer_ca_rotation_state(self) -> TLSCARotationState:
         """Check if the peer CA rotation is enabled."""
         return TLSCARotationState(

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -435,6 +435,16 @@ class EtcdEvents(Object):
             event.fail(error)
             return
 
+        try:
+            # safeguard to avoid users wrecking fine clusters
+            if not self.charm.cluster_manager.is_cluster_failed and not event.params.get(
+                "force", ""
+            ):
+                event.fail("Cluster has not failed. Use `force` to rebuild anyway.")
+                return
+        except RuntimeError:
+            logger.warning("Could not determine if cluster failed - continue with cluster rebuild")
+
         logger.info("Cluster rebuild initiated.")
         logger.info("Stopping and disabling etcd workload.")
         # disable the service to avoid restart while workflow is in progress

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -41,6 +41,7 @@ from literals import (
     SNAP_USER,
     TLS_CLIENT_PRIVATE_KEY_CONFIG,
     TLS_PEER_PRIVATE_KEY_CONFIG,
+    EtcdClusterState,
     Status,
     TLSState,
     TLSType,
@@ -412,6 +413,11 @@ class EtcdEvents(Object):
             event.fail(error)
             return
 
+        logger.info("Cluster rebuild initiated.")
+        logger.info("Stopping and disabling etcd workload.")
+        # disable the service to avoid restart while workflow is in progress
+        self.charm.workload.disable_database()
+        self.charm.state.unit_server.update({"state": ""})
         self.charm.state.cluster.update({"rebuild_cluster": "True"})
         event.set_results({"result": "cluster rebuild in progress"})
 
@@ -499,7 +505,37 @@ class EtcdEvents(Object):
         with a `BlockedStatus`. Users should then investigate (e.g. force-remove a faulty unit)
         and re-run the action.
         """
-        pass
+        cluster_members = ",".join([unit.member_endpoint for unit in self.charm.state.servers])
+
+        if self.charm.unit.is_leader():
+            if not any(unit.is_started for unit in self.charm.state.servers):
+                logger.info("All units stopped - initialise new cluster configuration.")
+                self.charm.state.cluster.update({"cluster_state": EtcdClusterState.NEW.value})
+                self.charm.state.cluster.update({"cluster_members": cluster_members})
+                self.charm.config_manager.set_config_properties()
+
+                logger.info("Enabling and starting etcd again.")
+                self.charm.workload.enable_database()
+                self.charm.state.unit_server.update({"state": "started"})
+            elif (
+                all(unit.is_started for unit in self.charm.state.servers)
+                and self.charm.cluster_manager.is_healthy()
+            ):
+                logger.info("All units started again - cluster rebuild completed.")
+                self.charm.state.cluster.update({"cluster_state": EtcdClusterState.EXISTING.value})
+                self.charm.state.cluster.update({"rebuild_cluster": ""})
+
+            return
+
+        if self.charm.state.cluster.cluster_state == EtcdClusterState.EXISTING.value:
+            logger.info("Stopping and disabling etcd workload.")
+            self.charm.workload.disable_database()
+            self.charm.state.unit_server.update({"state": ""})
+        elif self.charm.state.cluster.cluster_state == EtcdClusterState.NEW.value:
+            logger.info("Enabling and starting etcd again.")
+            self.charm.config_manager.set_config_properties()
+            self.charm.workload.enable_database()
+            self.charm.state.unit_server.update({"state": "started"})
 
     def _exists_preventing_reason(self) -> str:
         """Check if an action can be executed, if not return error message.

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import ops
 from ops import Object
 from ops.charm import (
+    ActionEvent,
     LeaderElectedEvent,
     RelationChangedEvent,
     RelationCreatedEvent,
@@ -83,6 +84,9 @@ class EtcdEvents(Object):
         )
         self.framework.observe(
             self.charm.on[DATA_STORAGE].storage_attached, self._on_storage_attached
+        )
+        self.framework.observe(
+            self.charm.on.rebuild_cluster_action, self._on_rebuild_cluster_action
         )
 
     def _on_storage_attached(self, event: ops.StorageAttachedEvent) -> None:
@@ -385,6 +389,16 @@ class EtcdEvents(Object):
             if admin_secret_id == event.secret.id:
                 self.update_admin_password(admin_secret_id)
 
+    def _on_rebuild_cluster_action(self, event: ActionEvent) -> None:
+        """Recover from majority failure by rebuilding the cluster membership configuration."""
+        if error := self._exists_preventing_reason():
+            event.set_results({"error": error})
+            event.fail(error)
+            return
+
+        self.charm.state.cluster.update({"rebuild_cluster": "True"})
+        event.set_results({"result": "cluster rebuild in progress"})
+
     def _on_storage_detaching(self, event: ops.StorageDetachingEvent) -> None:
         """Handle removal of the data storage mount, e.g. when removing a unit."""
         if self.charm.app.planned_units() > 0:
@@ -448,3 +462,23 @@ class EtcdEvents(Object):
             return
 
         self.charm.tls_events.refresh_tls_certificates_event.emit()
+
+    def _exists_preventing_reason(self) -> str:
+        """Check if an action can be executed, if not return error message.
+
+        Returns:
+            Error message in case a preventing reason for an action exists, otherwise empty str.
+        """
+        if not self.charm.unit.is_leader():
+            return "Action must be performed on the leader unit."
+
+        if self.charm.state.cluster.is_backup_in_progress:
+            return "Backup in progress, cannot perform action."
+
+        if self.charm.state.cluster.is_restore_in_progress:
+            return "Restore in progress, cannot perform action."
+
+        if self.charm.state.cluster.rebuild_cluster_in_progress:
+            return "Rebuilding the cluster is already in progress, cannot perform action."
+
+        return ""

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -375,11 +375,16 @@ class EtcdEvents(Object):
             # if anything fails with the metrics request, we don't want to panic
             pass
 
-        self.charm.cluster_manager.clean_users()
         if self.charm.unit.is_leader():
             try:
+                self.charm.cluster_manager.clean_users()
                 self.charm.cluster_manager.remove_inconsistent_members_if_required()
-            except (ValueError, EtcdClusterManagementError) as e:
+            except (
+                AttributeError,
+                ValueError,
+                EtcdClusterManagementError,
+                EtcdUserManagementError,
+            ) as e:
                 logger.error(e)
                 self.charm.set_status(Status.CLUSTER_MANAGEMENT_ERROR)
 

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -19,6 +19,7 @@ from ops.charm import (
     RelationJoinedEvent,
 )
 from ops.model import ModelError, SecretNotFoundError
+from requests.exceptions import RequestException
 
 from common.exceptions import (
     EtcdAuthNotEnabledError,
@@ -350,7 +351,7 @@ class EtcdEvents(Object):
             if self.charm.cluster_manager.is_cluster_failed:
                 self.charm.set_status(Status.CLUSTER_FAILED)
                 return
-        except RuntimeError:
+        except RequestException:
             # if anything fails with the metrics request, we don't want to panic
             pass
 
@@ -374,7 +375,7 @@ class EtcdEvents(Object):
             if self.charm.cluster_manager.is_cluster_failed:
                 self.charm.set_status(Status.CLUSTER_FAILED)
                 return
-        except RuntimeError:
+        except RequestException:
             # if anything fails with the metrics request, we don't want to panic
             pass
 
@@ -442,7 +443,7 @@ class EtcdEvents(Object):
             ):
                 event.fail("Cluster has not failed. Use `force` to rebuild anyway.")
                 return
-        except RuntimeError:
+        except RequestException:
             logger.warning("Could not determine if cluster failed - continue with cluster rebuild")
 
         logger.info("Cluster rebuild initiated.")

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -193,8 +193,11 @@ class EtcdEvents(Object):
 
     def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:
         """Handle config_changed event."""
-        if self.charm.state.cluster.is_restore_in_progress:
-            logger.warning("Cannot update config while database restore is in progress.")
+        if (
+            self.charm.state.cluster.is_restore_in_progress
+            or self.charm.state.cluster.rebuild_cluster_in_progress
+        ):
+            logger.warning("Cannot update config while another operation is in progress.")
             event.defer()
             return
 
@@ -242,6 +245,10 @@ class EtcdEvents(Object):
     def _on_peer_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handle all events related to the cluster-peer relation."""
         if self.charm.state.cluster.is_restore_in_progress:
+            return
+
+        if self.charm.state.cluster.rebuild_cluster_in_progress:
+            self._rebuild_cluster()
             return
 
         if self.charm.unit.is_leader():
@@ -294,8 +301,11 @@ class EtcdEvents(Object):
 
     def _on_peer_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Handle event received by all units when a new unit joins the cluster relation."""
-        if self.charm.state.cluster.is_restore_in_progress:
-            logger.warning("Cannot add cluster member while database restore is in progress.")
+        if (
+            self.charm.state.cluster.is_restore_in_progress
+            or self.charm.state.cluster.rebuild_cluster_in_progress
+        ):
+            logger.warning("Cannot add cluster member while another operation is in progress.")
             event.defer()
             return
 
@@ -332,7 +342,10 @@ class EtcdEvents(Object):
 
     def _on_update_status(self, event: ops.UpdateStatusEvent) -> None:
         """Handle update_status event."""
-        if self.charm.state.cluster.is_restore_in_progress:
+        if (
+            self.charm.state.cluster.is_restore_in_progress
+            or self.charm.state.cluster.rebuild_cluster_in_progress
+        ):
             return
 
         if not self.charm.workload.alive():
@@ -380,8 +393,11 @@ class EtcdEvents(Object):
         if not self.charm.unit.is_leader():
             return
 
-        if self.charm.state.cluster.is_restore_in_progress:
-            logger.warning("Cannot update credentials while database restore is in progress.")
+        if (
+            self.charm.state.cluster.is_restore_in_progress
+            or self.charm.state.cluster.rebuild_cluster_in_progress
+        ):
+            logger.warning("Cannot update credentials while another operation is in progress.")
             event.defer()
             return
 
@@ -402,7 +418,10 @@ class EtcdEvents(Object):
     def _on_storage_detaching(self, event: ops.StorageDetachingEvent) -> None:
         """Handle removal of the data storage mount, e.g. when removing a unit."""
         if self.charm.app.planned_units() > 0:
-            if not self.charm.state.cluster.is_restore_in_progress:
+            if not (
+                self.charm.state.cluster.is_restore_in_progress
+                or self.charm.state.cluster.rebuild_cluster_in_progress
+            ):
                 # allow for unit removal when restore is in progress
                 try:
                     self.charm.cluster_manager.remove_member()
@@ -462,6 +481,25 @@ class EtcdEvents(Object):
             return
 
         self.charm.tls_events.refresh_tls_certificates_event.emit()
+
+    def _rebuild_cluster(self) -> None:
+        """Rebuild cluster with new membership configuration, to recover from majority failure.
+
+        This method handles all the logic for the rebuild-cluster workflow, initiated by running
+        the action `rebuild-cluster` on the Juju leader.
+
+        The workflow consists of the following steps:
+        - stop etcd on all units
+        - initialise the cluster with new membership configuration
+        - start etcd on all units
+        - perform a cluster health check on the Juju leader
+
+        If the health check fails or any of the units error during the process, the cluster stays
+        stuck and the flag `rebuild_cluster` in the app-databag doesn't get reset. This is shown
+        with a `BlockedStatus`. Users should then investigate (e.g. force-remove a faulty unit)
+        and re-run the action.
+        """
+        pass
 
     def _exists_preventing_reason(self) -> str:
         """Check if an action can be executed, if not return error message.

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -246,7 +246,7 @@ class EtcdEvents(Object):
         """Handle event received by a new unit when joining the cluster relation."""
         self.charm.state.unit_server.update(self.charm.cluster_manager.get_host_mapping())
 
-    def _on_peer_relation_changed(self, event: RelationChangedEvent) -> None:  # noqa: C901
+    def _on_peer_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handle all events related to the cluster-peer relation."""
         if self.charm.state.cluster.is_restore_in_progress:
             return
@@ -260,9 +260,6 @@ class EtcdEvents(Object):
                 logger.warning(e)
                 event.defer()
                 return
-        elif self.charm.state.unit_server.rebuild_completed:
-            # clean up after workflow completed
-            self.charm.state.cluster.update({"rebuild_cluster": ""})
 
         if self.charm.unit.is_leader():
             if self.charm.state.cluster.learning_member:
@@ -514,7 +511,7 @@ class EtcdEvents(Object):
 
         self.charm.tls_events.refresh_tls_certificates_event.emit()
 
-    def _rebuild_cluster(self) -> None:
+    def _rebuild_cluster(self) -> None:  # noqa: C901
         """Rebuild cluster with new membership configuration, to recover from majority failure.
 
         This method handles all the logic for the rebuild-cluster workflow, initiated by running
@@ -561,32 +558,37 @@ class EtcdEvents(Object):
             return
 
         # this is the workflow for non-leader units
+        if not self.charm.state.cluster.cluster_members:
+            # the action was executed on the leader, cluster member configuration was cleared
+            # clean up in case a previous run failed
+            self.charm.state.unit_server.update({"rebuild_completed": ""})
+
         if (
             self.charm.state.unit_server.is_started
             and not self.charm.state.unit_server.rebuild_completed
         ):
+            # shutdown phase
             logger.info("Stopping and disabling etcd workload.")
             self.charm.workload.disable_database()
-            self.charm.state.unit_server.update({"state": ""})
-        elif (
-            not self.charm.state.unit_server.is_started
-            and self.charm.state.unit_server.member_endpoint
-            in self.charm.state.cluster.cluster_members
-        ):
             logger.warning(f"Removing database file from {DATABASE_DIR} for cluster rebuild.")
             try:
                 self.charm.workload.remove_directory(DATABASE_DIR)
             except FileNotFoundError:
                 logger.info(f"No database file found in {DATABASE_DIR} - nothing to remove")
+            self.charm.state.unit_server.update({"state": ""})
+            return
+
+        if (
+            self.charm.state.unit_server.member_endpoint
+            in self.charm.state.cluster.cluster_members
+            and not self.charm.state.unit_server.is_started
+        ):
+            # startup phase
             logger.info("Enabling and starting etcd again.")
             self.charm.config_manager.set_config_properties()
             self.charm.workload.enable_service()
             self.charm.cluster_manager.start_member()
             self.charm.state.unit_server.update({"rebuild_completed": "True"})
-        else:
-            # in case a previous run failed, and we run again - clean up
-            self.charm.state.unit_server.update({"state": ""})
-            self.charm.state.unit_server.update({"rebuild_completed": ""})
 
     def _exists_preventing_reason(self) -> str:
         """Check if an action can be executed, if not return error message.

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -523,8 +523,9 @@ class EtcdEvents(Object):
         The workflow consists of the following steps:
         - stop etcd on all units
         - initialise the cluster with new membership configuration
-        - start etcd on all units
-        - perform a cluster health check on the Juju leader
+        - start etcd on the Juju leader
+        - add other units one-by-one as new member and start it
+        - perform a cluster health check on the Juju leader after all units are added and started
 
         If the health check fails or any of the units error during the process, the cluster stays
         stuck and the flag `rebuild_cluster` in the app-databag doesn't get reset. This is shown

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -478,7 +478,4 @@ class EtcdEvents(Object):
         if self.charm.state.cluster.is_restore_in_progress:
             return "Restore in progress, cannot perform action."
 
-        if self.charm.state.cluster.rebuild_cluster_in_progress:
-            return "Rebuilding the cluster is already in progress, cannot perform action."
-
         return ""

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -384,6 +384,7 @@ class EtcdEvents(Object):
                 self.charm.cluster_manager.remove_inconsistent_members_if_required()
             except (
                 AttributeError,
+                KeyError,
                 ValueError,
                 EtcdClusterManagementError,
                 EtcdUserManagementError,

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -566,7 +566,8 @@ class EtcdEvents(Object):
             self.charm.workload.disable_database()
             self.charm.state.unit_server.update({"state": ""})
         elif (
-            self.charm.state.unit_server.member_endpoint
+            not self.charm.state.unit_server.is_started
+            and self.charm.state.unit_server.member_endpoint
             in self.charm.state.cluster.cluster_members
         ):
             logger.warning(f"Removing database file from {DATABASE_DIR} for cluster rebuild.")

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -542,6 +542,7 @@ class EtcdEvents(Object):
                 self.charm.state.unit_server.update({"rebuild_completed": "True"})
             elif (
                 all(unit.rebuild_completed for unit in self.charm.state.servers)
+                and not self.charm.state.cluster.learning_member
                 and self.charm.cluster_manager.is_healthy()
             ):
                 logger.info("All units started again - cluster rebuild completed.")
@@ -550,11 +551,13 @@ class EtcdEvents(Object):
             if self.charm.state.cluster.learning_member:
                 self.charm.cluster_manager.promote_learning_member()
 
-            for unit in self.charm.state.servers:
-                if unit.member_endpoint not in self.charm.state.cluster.cluster_members:
-                    # we only add one learner at a time to not overload the raft leader
-                    self.charm.cluster_manager.add_member(unit.unit_name)
-                    break
+            if self.charm.state.unit_server.rebuild_completed:
+                # after leader has started again, subsequently add all other units
+                for unit in self.charm.state.servers:
+                    if unit.member_endpoint not in self.charm.state.cluster.cluster_members:
+                        # we only add one learner at a time to not overload the raft leader
+                        self.charm.cluster_manager.add_member(unit.unit_name)
+                        break
 
             return
 

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -41,7 +41,6 @@ from literals import (
     SNAP_USER,
     TLS_CLIENT_PRIVATE_KEY_CONFIG,
     TLS_PEER_PRIVATE_KEY_CONFIG,
-    EtcdClusterState,
     Status,
     TLSState,
     TLSType,
@@ -249,8 +248,14 @@ class EtcdEvents(Object):
             return
 
         if self.charm.state.cluster.rebuild_cluster_in_progress:
-            self._rebuild_cluster()
-            return
+            try:
+                self._rebuild_cluster()
+                return
+            except EtcdClusterManagementError as e:
+                # if adding a member or promoting a learner fails, we want to re-run this again
+                logger.warning(e)
+                event.defer()
+                return
 
         if self.charm.unit.is_leader():
             if self.charm.state.cluster.learning_member:
@@ -337,6 +342,14 @@ class EtcdEvents(Object):
                 password = self.charm.workload.generate_password()
 
             self.charm.state.cluster.update({f"{INTERNAL_USER}-password": password})
+
+        try:
+            if self.charm.cluster_manager.is_cluster_failed:
+                self.charm.set_status(Status.CLUSTER_FAILED)
+                return
+        except RuntimeError:
+            # if anything fails with the metrics request, we don't want to panic
+            pass
 
         # reflect membership updates in the cluster state
         self.charm.cluster_manager.update_cluster_member_state()
@@ -505,50 +518,51 @@ class EtcdEvents(Object):
         with a `BlockedStatus`. Users should then investigate (e.g. force-remove a faulty unit)
         and re-run the action.
         """
-        cluster_members = ",".join([unit.member_endpoint for unit in self.charm.state.servers])
-
-        if len(self.charm.state.servers) == 1:
-            # no need for orchestrated workflow
-            self.charm.state.cluster.update({"cluster_state": EtcdClusterState.NEW.value})
-            self.charm.state.cluster.update({"cluster_members": cluster_members})
-            self.charm.config_manager.set_config_properties()
-
-            logger.info("Enabling and starting etcd again.")
-            self.charm.workload.enable_database()
-            self.charm.state.unit_server.update({"state": "started"})
-            self.charm.state.cluster.update({"cluster_state": EtcdClusterState.EXISTING.value})
-            self.charm.state.cluster.update({"rebuild_cluster": ""})
-            return
-
         if self.charm.unit.is_leader():
             if not any(unit.is_started for unit in self.charm.state.servers):
                 logger.info("All units stopped - initialise new cluster configuration.")
-                self.charm.state.cluster.update({"cluster_state": EtcdClusterState.NEW.value})
-                self.charm.state.cluster.update({"cluster_members": cluster_members})
+                self.charm.state.cluster.update({"cluster_state": ""})
                 self.charm.config_manager.set_config_properties()
 
                 logger.info("Enabling and starting etcd again.")
-                self.charm.workload.enable_database()
-                self.charm.state.unit_server.update({"state": "started"})
+                self.charm.workload.enable_service()
+                self.charm.cluster_manager.start_member()
+                self.charm.state.unit_server.update({"rebuild_completed": "True"})
             elif (
-                all(unit.is_started for unit in self.charm.state.servers)
+                all(unit.rebuild_completed for unit in self.charm.state.servers)
                 and self.charm.cluster_manager.is_healthy()
             ):
                 logger.info("All units started again - cluster rebuild completed.")
-                self.charm.state.cluster.update({"cluster_state": EtcdClusterState.EXISTING.value})
                 self.charm.state.cluster.update({"rebuild_cluster": ""})
+
+            if self.charm.state.cluster.learning_member:
+                self.charm.cluster_manager.promote_learning_member()
+
+            for unit in self.charm.state.servers:
+                if unit.member_endpoint not in self.charm.state.cluster.cluster_members:
+                    # we only add one learner at a time to not overload the raft leader
+                    self.charm.cluster_manager.add_member(unit.unit_name)
+                    break
 
             return
 
-        if self.charm.state.cluster.cluster_state == EtcdClusterState.EXISTING.value:
+        # this is the workflow for non-leader units
+        if (
+            self.charm.state.unit_server.is_started
+            and not self.charm.state.unit_server.rebuild_completed
+        ):
             logger.info("Stopping and disabling etcd workload.")
             self.charm.workload.disable_database()
             self.charm.state.unit_server.update({"state": ""})
-        elif self.charm.state.cluster.cluster_state == EtcdClusterState.NEW.value:
+        elif (
+            self.charm.state.unit_server.member_endpoint
+            in self.charm.state.cluster.cluster_members
+        ):
             logger.info("Enabling and starting etcd again.")
             self.charm.config_manager.set_config_properties()
-            self.charm.workload.enable_database()
-            self.charm.state.unit_server.update({"state": "started"})
+            self.charm.workload.enable_service()
+            self.charm.cluster_manager.start_member()
+            self.charm.state.unit_server.update({"rebuild_completed": "True"})
 
     def _exists_preventing_reason(self) -> str:
         """Check if an action can be executed, if not return error message.

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -260,6 +260,9 @@ class EtcdEvents(Object):
                 logger.warning(e)
                 event.defer()
                 return
+        elif self.charm.state.unit_server.rebuild_completed:
+            # clean up after workflow completed
+            self.charm.state.cluster.update({"rebuild_cluster": ""})
 
         if self.charm.unit.is_leader():
             if self.charm.state.cluster.learning_member:
@@ -316,7 +319,6 @@ class EtcdEvents(Object):
             or self.charm.state.cluster.rebuild_cluster_in_progress
         ):
             logger.warning("Cannot add cluster member while another operation is in progress.")
-            event.defer()
             return
 
         if self.charm.unit.is_leader():

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -104,6 +104,10 @@ class EtcdEvents(Object):
 
     def _on_start(self, event: ops.StartEvent) -> None:  # noqa: C901
         """Handle start event."""
+        if self.charm.state.cluster.rebuild_cluster_in_progress:
+            logger.info("Do not start, orchestration is handled by rebuild-cluster workflow.")
+            return
+
         # check if data exists before doing any operation
         storage_reuse = self.charm.workload.exists(DATABASE_DIR)
 
@@ -436,7 +440,9 @@ class EtcdEvents(Object):
         # disable the service to avoid restart while workflow is in progress
         self.charm.workload.disable_database()
         self.charm.state.unit_server.update({"state": ""})
+        self.charm.state.unit_server.update({"rebuild_completed": ""})
         self.charm.state.cluster.update({"rebuild_cluster": "True"})
+        self.charm.state.cluster.update({"cluster_members": ""})
         event.set_results({"result": "cluster rebuild in progress"})
 
     def _on_storage_detaching(self, event: ops.StorageDetachingEvent) -> None:
@@ -564,12 +570,19 @@ class EtcdEvents(Object):
             in self.charm.state.cluster.cluster_members
         ):
             logger.warning(f"Removing database file from {DATABASE_DIR} for cluster rebuild.")
-            self.charm.workload.remove_directory(DATABASE_DIR)
+            try:
+                self.charm.workload.remove_directory(DATABASE_DIR)
+            except FileNotFoundError:
+                logger.info(f"No database file found in {DATABASE_DIR} - nothing to remove")
             logger.info("Enabling and starting etcd again.")
             self.charm.config_manager.set_config_properties()
             self.charm.workload.enable_service()
             self.charm.cluster_manager.start_member()
             self.charm.state.unit_server.update({"rebuild_completed": "True"})
+        else:
+            # in case a previous run failed, and we run again - clean up
+            self.charm.state.unit_server.update({"state": ""})
+            self.charm.state.unit_server.update({"rebuild_completed": ""})
 
     def _exists_preventing_reason(self) -> str:
         """Check if an action can be executed, if not return error message.

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -202,7 +202,9 @@ class EtcdEvents(Object):
             self.charm.state.cluster.is_restore_in_progress
             or self.charm.state.cluster.rebuild_cluster_in_progress
         ):
-            logger.warning("Cannot update config while another operation is in progress.")
+            logger.warning(
+                "Cannot update config while a restore or cluster-rebuild operation is in progress."
+            )
             event.defer()
             return
 
@@ -255,12 +257,12 @@ class EtcdEvents(Object):
         if self.charm.state.cluster.rebuild_cluster_in_progress:
             try:
                 self._rebuild_cluster()
-                return
             except EtcdClusterManagementError as e:
                 # if adding a member or promoting a learner fails, we want to re-run this again
                 logger.warning(e)
                 event.defer()
-                return
+
+            return
 
         if self.charm.unit.is_leader():
             if self.charm.state.cluster.learning_member:
@@ -316,7 +318,9 @@ class EtcdEvents(Object):
             self.charm.state.cluster.is_restore_in_progress
             or self.charm.state.cluster.rebuild_cluster_in_progress
         ):
-            logger.warning("Cannot add cluster member while another operation is in progress.")
+            logger.warning(
+                "Cannot add cluster member while a restore or cluster-rebuild operation is in progress."
+            )
             return
 
         if self.charm.unit.is_leader():
@@ -421,7 +425,9 @@ class EtcdEvents(Object):
             self.charm.state.cluster.is_restore_in_progress
             or self.charm.state.cluster.rebuild_cluster_in_progress
         ):
-            logger.warning("Cannot update credentials while another operation is in progress.")
+            logger.warning(
+                "Cannot update credentials while a restore or cluster-rebuild operation is in progress."
+            )
             event.defer()
             return
 
@@ -431,7 +437,7 @@ class EtcdEvents(Object):
 
     def _on_rebuild_cluster_action(self, event: ActionEvent) -> None:
         """Recover from majority failure by rebuilding the cluster membership configuration."""
-        if error := self._exists_preventing_reason():
+        if error := self._check_rebuild_preventing_reason():
             event.set_results({"error": error})
             event.fail(error)
             return
@@ -439,7 +445,7 @@ class EtcdEvents(Object):
         try:
             # safeguard to avoid users wrecking fine clusters
             if not self.charm.cluster_manager.is_cluster_failed and not event.params.get(
-                "force", ""
+                "force", False
             ):
                 event.fail("Cluster has not failed. Use `force` to rebuild anyway.")
                 return
@@ -605,7 +611,7 @@ class EtcdEvents(Object):
             self.charm.cluster_manager.start_member()
             self.charm.state.unit_server.update({"rebuild_completed": "True"})
 
-    def _exists_preventing_reason(self) -> str:
+    def _check_rebuild_preventing_reason(self) -> str:
         """Check if an action can be executed, if not return error message.
 
         Returns:

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -339,7 +339,6 @@ class EtcdEvents(Object):
         try:
             if self.charm.cluster_manager.is_cluster_failed:
                 self.charm.set_status(Status.CLUSTER_FAILED)
-                # set flag in databag
                 return
         except RuntimeError:
             # if anything fails with the metrics request, we don't want to panic

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -336,6 +336,15 @@ class EtcdEvents(Object):
                 self.charm.set_status(Status.SERVICE_NOT_RUNNING)
                 return
 
+        try:
+            if self.charm.cluster_manager.is_cluster_failed:
+                self.charm.set_status(Status.CLUSTER_FAILED)
+                # set flag in databag
+                return
+        except RuntimeError:
+            # if anything fails with the metrics request, we don't want to panic
+            pass
+
         self.charm.cluster_manager.clean_users()
         if self.charm.unit.is_leader():
             try:

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -246,7 +246,7 @@ class EtcdEvents(Object):
         """Handle event received by a new unit when joining the cluster relation."""
         self.charm.state.unit_server.update(self.charm.cluster_manager.get_host_mapping())
 
-    def _on_peer_relation_changed(self, event: RelationChangedEvent) -> None:
+    def _on_peer_relation_changed(self, event: RelationChangedEvent) -> None:  # noqa: C901
         """Handle all events related to the cluster-peer relation."""
         if self.charm.state.cluster.is_restore_in_progress:
             return

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -507,6 +507,19 @@ class EtcdEvents(Object):
         """
         cluster_members = ",".join([unit.member_endpoint for unit in self.charm.state.servers])
 
+        if len(self.charm.state.servers) == 1:
+            # no need for orchestrated workflow
+            self.charm.state.cluster.update({"cluster_state": EtcdClusterState.NEW.value})
+            self.charm.state.cluster.update({"cluster_members": cluster_members})
+            self.charm.config_manager.set_config_properties()
+
+            logger.info("Enabling and starting etcd again.")
+            self.charm.workload.enable_database()
+            self.charm.state.unit_server.update({"state": "started"})
+            self.charm.state.cluster.update({"cluster_state": EtcdClusterState.EXISTING.value})
+            self.charm.state.cluster.update({"rebuild_cluster": ""})
+            return
+
         if self.charm.unit.is_leader():
             if not any(unit.is_started for unit in self.charm.state.servers):
                 logger.info("All units stopped - initialise new cluster configuration.")

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -563,6 +563,8 @@ class EtcdEvents(Object):
             self.charm.state.unit_server.member_endpoint
             in self.charm.state.cluster.cluster_members
         ):
+            logger.warning(f"Removing database file from {DATABASE_DIR} for cluster rebuild.")
+            self.charm.workload.remove_directory(DATABASE_DIR)
             logger.info("Enabling and starting etcd again.")
             self.charm.config_manager.set_config_properties()
             self.charm.workload.enable_service()

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -154,8 +154,11 @@ class TLSEvents(Object):
         Args:
             event (CertificateAvailableEvent): The event object.
         """
-        if self.charm.state.cluster.is_restore_in_progress:
-            logger.warning("Cannot update certificates while database restore is in progress.")
+        if (
+            self.charm.state.cluster.is_restore_in_progress
+            or self.charm.state.cluster.rebuild_cluster_in_progress
+        ):
+            logger.warning("Cannot update certificates while another operation is in progress.")
             event.defer()
             return
 
@@ -264,8 +267,11 @@ class TLSEvents(Object):
         Args:
             event (RelationBrokenEvent): The event object.
         """
-        if self.charm.state.cluster.is_restore_in_progress:
-            logger.warning("Cannot update certificates while database restore is in progress.")
+        if (
+            self.charm.state.cluster.is_restore_in_progress
+            or self.charm.state.cluster.rebuild_cluster_in_progress
+        ):
+            logger.warning("Cannot update certificates while another operation is in progress.")
             event.defer()
             return
 

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -158,7 +158,9 @@ class TLSEvents(Object):
             self.charm.state.cluster.is_restore_in_progress
             or self.charm.state.cluster.rebuild_cluster_in_progress
         ):
-            logger.warning("Cannot update certificates while another operation is in progress.")
+            logger.warning(
+                "Cannot update certificates while a restore or cluster-rebuild operation is in progress."
+            )
             event.defer()
             return
 
@@ -271,7 +273,9 @@ class TLSEvents(Object):
             self.charm.state.cluster.is_restore_in_progress
             or self.charm.state.cluster.rebuild_cluster_in_progress
         ):
-            logger.warning("Cannot update certificates while another operation is in progress.")
+            logger.warning(
+                "Cannot update certificates while a restore or cluster-rebuild operation is in progress."
+            )
             event.defer()
             return
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -76,7 +76,10 @@ class Status(Enum):
     BACKUP_IN_PROGRESS = StatusLevel(MaintenanceStatus("Creating database backup..."), "DEBUG")
     CLUSTER_INITIALIZING = StatusLevel(MaintenanceStatus("Initializing etcd cluster..."), "DEBUG")
     CLUSTER_FAILED = StatusLevel(
-        BlockedStatus("Cluster failure - majority of cluster members lost"), "ERROR"
+        BlockedStatus(
+            "Cluster failure - majority of cluster members lost. Run action `rebuild-cluster` to recover."
+        ),
+        "ERROR",
     )
     CLUSTER_MANAGEMENT_ERROR = StatusLevel(BlockedStatus("cluster management error"), "ERROR")
     CLUSTER_NOT_INITIALIZED = StatusLevel(

--- a/src/literals.py
+++ b/src/literals.py
@@ -86,6 +86,9 @@ class Status(Enum):
     CLUSTER_MEMBER_NOT_PROMOTED = StatusLevel(
         MaintenanceStatus("Waiting to promote learning member"), "DEBUG"
     )
+    CLUSTER_REBUILD_IN_PROGRESS = StatusLevel(
+        BlockedStatus("Rebuilding with new cluster configuration..."), "ERROR"
+    )
     HEALTH_CHECK_FAILED = StatusLevel(MaintenanceStatus("health check failed"), "DEBUG")
     NO_PEER_RELATION = StatusLevel(MaintenanceStatus("no peer relation available"), "DEBUG")
     OBJECT_STORAGE_CONFLICT = StatusLevel(

--- a/src/literals.py
+++ b/src/literals.py
@@ -75,6 +75,9 @@ class Status(Enum):
     )
     BACKUP_IN_PROGRESS = StatusLevel(MaintenanceStatus("Creating database backup..."), "DEBUG")
     CLUSTER_INITIALIZING = StatusLevel(MaintenanceStatus("Initializing etcd cluster..."), "DEBUG")
+    CLUSTER_FAILED = StatusLevel(
+        BlockedStatus("Cluster failure - majority of cluster members lost"), "ERROR"
+    )
     CLUSTER_MANAGEMENT_ERROR = StatusLevel(BlockedStatus("cluster management error"), "ERROR")
     CLUSTER_NOT_INITIALIZED = StatusLevel(
         BlockedStatus("Waiting for cluster initialization"), "ERROR"

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -385,6 +385,9 @@ class ClusterManager:
         if not self.state.cluster.cluster_state:
             status_list.append(Status.CLUSTER_INITIALIZING)
 
+        if self.state.cluster.rebuild_cluster_in_progress:
+            status_list.append(Status.CLUSTER_REBUILD_IN_PROGRESS)
+
         return status_list
 
     def get_user(self, username: str) -> dict | None:

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -21,7 +21,7 @@ from common.exceptions import (
 from core.cluster import ClusterState
 from core.models import Member
 from core.workload import WorkloadBase
-from literals import INTERNAL_USER, EtcdClusterState, Status, TLSState
+from literals import INTERNAL_USER, METRICS_PORT, EtcdClusterState, Status, TLSState
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +67,25 @@ class ClusterManager:
             return hex(leader_id)[2:]
         except (KeyError, JSONDecodeError) as e:
             raise RaftLeaderNotFoundError(f"No raft leader found: {e}")
+
+    @property
+    def is_cluster_failed(self) -> bool:
+        """Check if the cluster is experiencing majority failure.
+
+        Returns:
+            bool: True if the cluster has failed, False if not.
+        """
+        client = EtcdClient(
+            username=self.admin_user,
+            password=self.admin_password,
+            client_url=f"http://{self.state.unit_server.ip}:{METRICS_PORT}/metrics",
+        )
+
+        if client.get_metric(metric_name="etcd_server_has_leader") == "0":
+            logger.warning("Cluster failed - no raft leader")
+            return True
+
+        return False
 
     @retry(
         stop=stop_after_attempt(3),

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -218,7 +218,7 @@ class ClusterManager:
                 client = EtcdClient(
                     username=self.admin_user,
                     password=self.admin_password,
-                    client_url=",".join(e for e in self.cluster_endpoints),
+                    client_url=self.state.unit_server.client_url,
                 )
                 cluster_members, member_id = client.add_member_as_learner(
                     server.member_name, peer_url
@@ -373,6 +373,7 @@ class ClusterManager:
             if (
                 self.state.cluster.cluster_state != EtcdClusterState.EXISTING.value
                 and not self.state.cluster.is_restore_in_progress
+                and not self.state.cluster.rebuild_cluster_in_progress
             ):
                 status_list.append(Status.CLUSTER_NOT_INITIALIZED)
 

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -61,6 +61,7 @@ class ConfigManager:
         elif self.workload.exists(DATABASE_DIR):
             # if no cluster state is available, but we find a database file
             # we force a new one-cluster-member with existing data
+            # this is the case for storage reuse and `rebuild_cluster` workflows
             config_properties["force-new-cluster"] = True
         else:
             config_properties["initial-cluster-state"] = "new"

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -152,7 +152,7 @@ async def test_rebuild_on_healthy_cluster(ops_test: OpsTest) -> None:
     """Users can run `rebuild-cluster` on a healthy cluster if the use the `force` parameter."""
     logger.info("Scale up to HA cluster again")
     await ops_test.model.applications[APP_NAME].add_unit(count=1)
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=3)
 
     for unit in ops_test.model.applications[APP_NAME].units:
         if await unit.is_leader_from_status():
@@ -171,7 +171,7 @@ async def test_rebuild_on_healthy_cluster(ops_test: OpsTest) -> None:
     assert rebuild_response.results.get("return-code") == 0, "rebuild failed"
 
     # wait for the rebuild to be performed
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=3)
 
     endpoints = get_cluster_endpoints(ops_test, APP_NAME)
     cluster_members = get_cluster_members(endpoints)

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 NUM_UNITS = 5
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
@@ -45,7 +45,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> None:
@@ -86,7 +86,7 @@ async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> 
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
@@ -145,7 +145,7 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
     logger.info(f"{second_removed_member_name} not in cluster members")
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_rebuild_on_healthy_cluster(ops_test: OpsTest) -> None:

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -143,3 +143,41 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
         f"{second_removed_member_name} still in cluster members"
     )
     logger.info(f"{second_removed_member_name} not in cluster members")
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_rebuild_on_healthy_cluster(ops_test: OpsTest) -> None:
+    """Users can run `rebuild-cluster` on a healthy cluster if the use the `force` parameter."""
+    logger.info("Scale up to HA cluster again")
+    await ops_test.model.applications[APP_NAME].add_unit(count=1)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+
+    for unit in ops_test.model.applications[APP_NAME].units:
+        if await unit.is_leader_from_status():
+            leader_unit = unit
+
+    logger.info("Executing rebuild-cluster on healthy cluster - this should fail")
+    rebuild_action = await leader_unit.run_action("rebuild-cluster")
+    rebuild_response = await rebuild_action.wait()
+    assert rebuild_response.results.get("return-code") == 1, (
+        "rebuild was allowed on healthy cluster"
+    )
+
+    logger.info("Try again with `force` option")
+    rebuild_action = await leader_unit.run_action("rebuild-cluster", **{"force": True})
+    rebuild_response = await rebuild_action.wait()
+    assert rebuild_response.results.get("return-code") == 0, "rebuild failed"
+
+    # wait for the rebuild to be performed
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+
+    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    cluster_members = get_cluster_members(endpoints)
+    member_names = [member["name"] for member in cluster_members]
+    for unit in ops_test.model.applications[APP_NAME].units:
+        assert unit.name.replace("/", "") in member_names, (
+            f"unit {unit.name} not in cluster members"
+        )
+        logger.info(f"{unit.name} in cluster members")

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -114,7 +114,7 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
                     "blocked": [Status.CLUSTER_FAILED.value.status.message],
                 },
             },
-            wait_for_exact_units=2
+            wait_for_exact_units=2,
         )
 
     # typically users would try to add a third unit to regain quorum
@@ -128,7 +128,7 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
                     "blocked": [Status.CLUSTER_FAILED.value.status.message],
                 },
             },
-            wait_for_exact_units=3
+            wait_for_exact_units=3,
         )
 
     for unit in ops_test.model.applications[APP_NAME].units:

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -125,7 +125,11 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
             apps=[APP_NAME],
             apps_full_statuses={
                 APP_NAME: {
-                    "blocked": [Status.CLUSTER_FAILED.value.status.message],
+                    "blocked": [
+                        Status.CLUSTER_FAILED.value.status.message,
+                        Status.SERVICE_NOT_RUNNING.value.status.message,
+                    ],
+                    "maintenance": [Status.CLUSTER_NOT_JOINED.value.status.message],
                 },
             },
             wait_for_exact_units=3,

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from literals import INTERNAL_USER, PEER_RELATION
+from literals import INTERNAL_USER, PEER_RELATION, Status
 
 from ..helpers import (
     APP_NAME,
@@ -22,6 +22,11 @@ from .helpers import (
     assert_continuous_writes_increasing,
     start_continuous_writes,
     stop_continuous_writes,
+)
+from .helpers_network import (
+    cut_network_from_unit_with_ip_change,
+    hostname_from_unit,
+    is_unit_reachable,
 )
 
 logger = logging.getLogger(__name__)
@@ -82,3 +87,32 @@ async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> 
     assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
     stop_continuous_writes()
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_detect_cluster_failure(ops_test: OpsTest) -> None:
+    """When the majority of the cluster is lost, the charm should detect cluster failure."""
+    logger.info("Cut network from one of the two units to force majority loss")
+    unit_to_cut = ops_test.model.applications[APP_NAME].units[-1]
+    hostname_to_cut = await hostname_from_unit(ops_test, unit_name=unit_to_cut.name)
+    cut_network_from_unit_with_ip_change(hostname_to_cut)
+
+    unit_remaining = ops_test.model.applications[APP_NAME].units[0]
+    hostname_remaining = await hostname_from_unit(ops_test, unit_remaining.name)
+    assert not is_unit_reachable(hostname_remaining, hostname_to_cut), (
+        f"{hostname_to_cut} is reachable from {hostname_remaining}"
+    )
+
+    # wait for the next `update_status` to detect the cluster failure
+    async with ops_test.fast_forward("10s"):
+        await wait_until(
+            ops_test,
+            apps=[APP_NAME],
+            apps_full_statuses={
+                APP_NAME: {
+                    "blocked": [Status.CLUSTER_FAILED.value.status.message],
+                },
+            },
+        )

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -116,3 +116,64 @@ async def test_detect_cluster_failure(ops_test: OpsTest) -> None:
                 },
             },
         )
+
+    # remove the entire application to clean up for the next test
+    await ops_test.model.remove_application(APP_NAME, block_until_done=True)
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
+    """When the majority of the cluster is lost, users can run `rebuild-cluster`."""
+    await ops_test.model.deploy(CHARM_PATH, num_units=4)
+    await wait_until(ops_test, apps=[APP_NAME], timeout=1000)
+
+    first_unit_to_remove = ops_test.model.applications[APP_NAME].units[0]
+    first_removed_member_name = first_unit_to_remove.name.replace("/", "")
+    second_unit_to_remove = ops_test.model.applications[APP_NAME].units[1]
+    second_removed_member_name = second_unit_to_remove.name.replace("/", "")
+    logger.info(
+        f"Forcefully removing units {first_unit_to_remove.name} and {second_unit_to_remove.name}"
+    )
+
+    destroy_unit_cmd = f"remove-unit {first_unit_to_remove.name} {second_unit_to_remove.name} --model={ops_test.model.info.name} --force --no-wait --no-prompt"
+    return_code, _, _ = await ops_test.juju(*destroy_unit_cmd.split())
+    assert return_code == 0, "Failed to remove units"
+
+    async with ops_test.fast_forward("10s"):
+        await wait_until(
+            ops_test,
+            apps=[APP_NAME],
+            apps_full_statuses={
+                APP_NAME: {
+                    "blocked": [Status.CLUSTER_FAILED.value.status.message],
+                },
+            },
+        )
+
+    for unit in ops_test.model.applications[APP_NAME].units:
+        if await unit.is_leader_from_status():
+            leader_unit = unit
+
+    logger.info("Rebuilding cluster after majority failure")
+    rebuild_action = await leader_unit.run_action("rebuild-cluster")
+    rebuild_response = await rebuild_action.wait()
+    assert rebuild_response.results.get("return-code") == 0, "rebuild failed"
+
+    # wait for the rebuild to be performed
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=2)
+
+    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    cluster_members = get_cluster_members(endpoints)
+    member_names = [member["name"] for member in cluster_members]
+    for unit in ops_test.model.applications[APP_NAME].units:
+        assert unit.name.replace("/", "") in member_names, (
+            f"unit {unit.name} not in cluster members"
+        )
+    assert first_removed_member_name not in member_names, (
+        f"{first_removed_member_name} still in cluster members"
+    )
+    assert second_removed_member_name not in member_names, (
+        f"{second_removed_member_name} still in cluster members"
+    )

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -105,22 +105,15 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
     return_code, _, _ = await ops_test.juju(*destroy_unit_cmd.split())
     assert return_code == 0, "Failed to remove units"
 
-    # typically users would try to add a third unit to regain quorum
-    await ops_test.model.applications[APP_NAME].add_unit(count=1)
-    await wait_until(
-        ops_test,
-        apps=[APP_NAME],
-        apps_full_statuses={
-            APP_NAME: {
-                "blocked": [
-                    Status.CLUSTER_FAILED.value.status.message,
-                    Status.SERVICE_NOT_RUNNING.value.status.message,
-                ],
-                "maintenance": [Status.CLUSTER_NOT_JOINED.value.status.message],
+    async with ops_test.fast_forward("10s"):
+        await wait_until(
+            ops_test,
+            apps=[APP_NAME],
+            apps_full_statuses={
+                APP_NAME: {"blocked": [Status.CLUSTER_FAILED.value.status.message]},
             },
-        },
-        wait_for_exact_units=3,
-    )
+            wait_for_exact_units=2,
+        )
 
     for unit in ops_test.model.applications[APP_NAME].units:
         if await unit.is_leader_from_status():
@@ -132,7 +125,7 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
     assert rebuild_response.results.get("return-code") == 0, "rebuild failed"
 
     # wait for the rebuild to be performed
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=3)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=2)
 
     endpoints = get_cluster_endpoints(ops_test, APP_NAME)
     cluster_members = get_cluster_members(endpoints)

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -23,15 +23,10 @@ from .helpers import (
     start_continuous_writes,
     stop_continuous_writes,
 )
-from .helpers_network import (
-    cut_network_from_unit_with_ip_change,
-    hostname_from_unit,
-    is_unit_reachable,
-)
 
 logger = logging.getLogger(__name__)
 
-NUM_UNITS = 3
+NUM_UNITS = 5
 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
@@ -92,42 +87,9 @@ async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_detect_cluster_failure(ops_test: OpsTest) -> None:
-    """When the majority of the cluster is lost, the charm should detect cluster failure."""
-    logger.info("Cut network from one of the two units to force majority loss")
-    unit_to_cut = ops_test.model.applications[APP_NAME].units[-1]
-    hostname_to_cut = await hostname_from_unit(ops_test, unit_name=unit_to_cut.name)
-    cut_network_from_unit_with_ip_change(hostname_to_cut)
-
-    unit_remaining = ops_test.model.applications[APP_NAME].units[0]
-    hostname_remaining = await hostname_from_unit(ops_test, unit_remaining.name)
-    assert not is_unit_reachable(hostname_remaining, hostname_to_cut), (
-        f"{hostname_to_cut} is reachable from {hostname_remaining}"
-    )
-
-    # wait for the next `update_status` to detect the cluster failure
-    async with ops_test.fast_forward("10s"):
-        await wait_until(
-            ops_test,
-            apps=[APP_NAME],
-            apps_full_statuses={
-                APP_NAME: {
-                    "blocked": [Status.CLUSTER_FAILED.value.status.message],
-                },
-            },
-        )
-
-    # remove the entire application to clean up for the next test
-    await ops_test.model.remove_application(APP_NAME, block_until_done=True)
-
-
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
-@pytest.mark.group(1)
-@pytest.mark.abort_on_fail
 async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
     """When the majority of the cluster is lost, users can run `rebuild-cluster`."""
-    await ops_test.model.deploy(CHARM_PATH, num_units=4)
-    await wait_until(ops_test, apps=[APP_NAME], timeout=1000)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS - 1)
 
     first_unit_to_remove = ops_test.model.applications[APP_NAME].units[0]
     first_removed_member_name = first_unit_to_remove.name.replace("/", "")
@@ -162,7 +124,7 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
     assert rebuild_response.results.get("return-code") == 0, "rebuild failed"
 
     # wait for the rebuild to be performed
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=2)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS - 3)
 
     endpoints = get_cluster_endpoints(ops_test, APP_NAME)
     cluster_members = get_cluster_members(endpoints)

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -75,9 +75,11 @@ async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> 
         assert unit.name.replace("/", "") in member_names, (
             f"unit {unit.name} not in cluster members"
         )
+        logger.info(f"{unit.name} in cluster members")
     assert removed_member_name not in member_names, (
         f"{removed_member_name} still in cluster members"
     )
+    logger.info(f"{removed_member_name} not in cluster members")
 
     assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
     stop_continuous_writes()
@@ -133,9 +135,12 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
         assert unit.name.replace("/", "") in member_names, (
             f"unit {unit.name} not in cluster members"
         )
+        logger.info(f"{unit.name} in cluster members")
     assert first_removed_member_name not in member_names, (
         f"{first_removed_member_name} still in cluster members"
     )
+    logger.info(f"{first_removed_member_name} not in cluster members")
     assert second_removed_member_name not in member_names, (
         f"{second_removed_member_name} still in cluster members"
     )
+    logger.info(f"{second_removed_member_name} not in cluster members")

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -114,6 +114,21 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
                     "blocked": [Status.CLUSTER_FAILED.value.status.message],
                 },
             },
+            wait_for_exact_units=2
+        )
+
+    # typically users would try to add a third unit to regain quorum
+    await ops_test.model.applications[APP_NAME].add_unit(count=1)
+    async with ops_test.fast_forward("10s"):
+        await wait_until(
+            ops_test,
+            apps=[APP_NAME],
+            apps_full_statuses={
+                APP_NAME: {
+                    "blocked": [Status.CLUSTER_FAILED.value.status.message],
+                },
+            },
+            wait_for_exact_units=3
         )
 
     for unit in ops_test.model.applications[APP_NAME].units:
@@ -126,7 +141,7 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
     assert rebuild_response.results.get("return-code") == 0, "rebuild failed"
 
     # wait for the rebuild to be performed
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS - 3)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=3)
 
     endpoints = get_cluster_endpoints(ops_test, APP_NAME)
     cluster_members = get_cluster_members(endpoints)

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -105,35 +105,22 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
     return_code, _, _ = await ops_test.juju(*destroy_unit_cmd.split())
     assert return_code == 0, "Failed to remove units"
 
-    async with ops_test.fast_forward("10s"):
-        await wait_until(
-            ops_test,
-            apps=[APP_NAME],
-            apps_full_statuses={
-                APP_NAME: {
-                    "blocked": [Status.CLUSTER_FAILED.value.status.message],
-                },
-            },
-            wait_for_exact_units=2,
-        )
-
     # typically users would try to add a third unit to regain quorum
     await ops_test.model.applications[APP_NAME].add_unit(count=1)
-    async with ops_test.fast_forward("10s"):
-        await wait_until(
-            ops_test,
-            apps=[APP_NAME],
-            apps_full_statuses={
-                APP_NAME: {
-                    "blocked": [
-                        Status.CLUSTER_FAILED.value.status.message,
-                        Status.SERVICE_NOT_RUNNING.value.status.message,
-                    ],
-                    "maintenance": [Status.CLUSTER_NOT_JOINED.value.status.message],
-                },
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        apps_full_statuses={
+            APP_NAME: {
+                "blocked": [
+                    Status.CLUSTER_FAILED.value.status.message,
+                    Status.SERVICE_NOT_RUNNING.value.status.message,
+                ],
+                "maintenance": [Status.CLUSTER_NOT_JOINED.value.status.message],
             },
-            wait_for_exact_units=3,
-        )
+        },
+        wait_for_exact_units=3,
+    )
 
     for unit in ops_test.model.applications[APP_NAME].units:
         if await unit.is_leader_from_status():

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -161,14 +161,13 @@ async def test_rebuild_on_healthy_cluster(ops_test: OpsTest) -> None:
     logger.info("Executing rebuild-cluster on healthy cluster - this should fail")
     rebuild_action = await leader_unit.run_action("rebuild-cluster")
     rebuild_response = await rebuild_action.wait()
-    assert rebuild_response.results.get("return-code") == 1, (
-        "rebuild was allowed on healthy cluster"
-    )
+    assert rebuild_response.results.get("return-code") == 0, "rebuild failed"
+    assert rebuild_response.status == "failed"
 
     logger.info("Try again with `force` option")
-    rebuild_action = await leader_unit.run_action("rebuild-cluster", **{"force": True})
-    rebuild_response = await rebuild_action.wait()
-    assert rebuild_response.results.get("return-code") == 0, "rebuild failed"
+    rebuild_force_action = await leader_unit.run_action("rebuild-cluster", **{"force": True})
+    rebuild_force_response = await rebuild_force_action.wait()
+    assert rebuild_force_response.results.get("return-code") == 0, "rebuild failed"
 
     # wait for the rebuild to be performed
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=3)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,6 +11,7 @@ import ops
 import yaml
 from ops import testing
 from pytest import raises
+from requests.exceptions import RequestException
 
 from charm import EtcdOperatorCharm
 from common.exceptions import (
@@ -495,7 +496,7 @@ def test_cluster_majority_failure():
     with (
         patch("workload.EtcdWorkload.alive", return_value=True),
         patch("managers.cluster.ClusterManager.clean_users"),
-        patch("managers.cluster.EtcdClient.get_metric", side_effect=RuntimeError()),
+        patch("managers.cluster.EtcdClient.get_metric", side_effect=RequestException()),
     ):
         state_out = ctx.run(ctx.on.update_status(), state_in)
         assert state_out.unit_status == ops.ActiveStatus()
@@ -863,7 +864,7 @@ def test_rebuild_cluster_action_error_cases():
     peer_relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION, local_app_data={})
     state_in = testing.State(relations={peer_relation}, leader=True)
     with (
-        patch("managers.cluster.EtcdClient.get_metric", side_effect=RuntimeError()),
+        patch("managers.cluster.EtcdClient.get_metric", side_effect=RequestException()),
         patch("workload.EtcdWorkload.stop"),
         patch("workload.EtcdWorkload.disable_service"),
     ):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -866,13 +866,17 @@ def test_rebuild_cluster_action_happy_path():
         local_app_data={"rebuild_cluster": "True"},
     )
     state_in = testing.State(relations={peer_relation}, leader=True)
-    state_out = ctx.run(ctx.on.action("rebuild-cluster"), state_in)
+    with (
+        patch("workload.EtcdWorkload.stop") as stop_etcd,
+        patch("workload.EtcdWorkload.disable_service") as disable_etcd,
+    ):
+        state_out = ctx.run(ctx.on.action("rebuild-cluster"), state_in)
 
-    assert ctx.action_results == {"result": "cluster rebuild in progress"}
-    assert state_out.unit_status == ops.BlockedStatus(
-        "Rebuilding with new cluster configuration..."
-    )
-    assert state_out.get_relation(1).local_app_data.get("rebuild_cluster")
+        assert ctx.action_results == {"result": "cluster rebuild in progress"}
+        assert state_out.unit_status == ops.BlockedStatus(
+            "Rebuilding with new cluster configuration..."
+        )
+        assert state_out.get_relation(1).local_app_data.get("rebuild_cluster")
 
 
 def test_rebuild_cluster_workflow_synchronisation():
@@ -882,7 +886,7 @@ def test_rebuild_cluster_workflow_synchronisation():
     peer_relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
-        local_app_data={"rebuild_cluster": "True", "initial_cluster_state": "existing"},
+        local_app_data={"rebuild_cluster": "True", "cluster_state": "existing"},
         local_unit_data={"state": "started"},
     )
     state_in = testing.State(relations={peer_relation}, leader=False)
@@ -901,7 +905,7 @@ def test_rebuild_cluster_workflow_synchronisation():
     peer_relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
-        local_app_data={"rebuild_cluster": "True", "initial_cluster_state": "existing"},
+        local_app_data={"rebuild_cluster": "True", "cluster_state": "existing"},
         local_unit_data={},
     )
     state_in = testing.State(relations={peer_relation}, leader=True)
@@ -917,13 +921,13 @@ def test_rebuild_cluster_workflow_synchronisation():
         start_etcd.assert_called_once()
         enable_etcd.assert_called_once()
         assert state_out.get_relation(1).local_unit_data.get("state") == "started"
-        assert state_out.get_relation(1).local_app_data.get("initial_cluster_state") == "new"
+        assert state_out.get_relation(1).local_app_data.get("cluster_state") == "new"
 
     # after leader has initialised, non-leaders start
     peer_relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
-        local_app_data={"rebuild_cluster": "True", "initial_cluster_state": "new"},
+        local_app_data={"rebuild_cluster": "True", "cluster_state": "new"},
         local_unit_data={},
     )
     state_in = testing.State(relations={peer_relation}, leader=False)
@@ -939,21 +943,21 @@ def test_rebuild_cluster_workflow_synchronisation():
         start_etcd.assert_called_once()
         enable_etcd.assert_called_once()
         assert state_out.get_relation(1).local_unit_data.get("state") == "started"
-        assert state_out.get_relation(1).local_app_data.get("initial_cluster_state") == "new"
+        assert state_out.get_relation(1).local_app_data.get("cluster_state") == "new"
 
     # after all units started, leader performs health check and completes workflow
     peer_relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
-        local_app_data={"rebuild_cluster": "True", "initial_cluster_state": "new"},
-        local_unit_data={},
+        local_app_data={"rebuild_cluster": "True", "cluster_state": "new"},
+        local_unit_data={"state": "started"},
     )
-    state_in = testing.State(relations={peer_relation}, leader=False)
+    state_in = testing.State(relations={peer_relation}, leader=True)
 
     with patch("managers.cluster.ClusterManager.is_healthy") as health_check:
         state_out = ctx.run(ctx.on.relation_changed(relation=peer_relation), state_in)
 
         health_check.assert_called_once()
         assert state_out.get_relation(1).local_unit_data.get("state") == "started"
-        assert state_out.get_relation(1).local_app_data.get("initial_cluster_state") == "existing"
+        assert state_out.get_relation(1).local_app_data.get("cluster_state") == "existing"
         assert not state_out.get_relation(1).local_app_data.get("rebuild_cluster") == "True"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -801,3 +801,65 @@ def test_unit_removal():
         assert not state_out.get_relation(1).local_app_data.get("authentication")
         assert not state_out.get_relation(1).local_app_data.get("cluster_state")
         assert not state_out.get_relation(1).local_app_data.get("cluster_members")
+
+
+def test_rebuild_cluster_action_error_cases():
+    ctx = testing.Context(EtcdOperatorCharm)
+    peer_relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
+
+    # ensure action fails if run on non-leader unit
+    state_in = testing.State(relations={peer_relation}, leader=False)
+    with raises(testing.ActionFailed) as e:
+        ctx.run(ctx.on.action("rebuild-cluster"), state_in)
+
+        assert e.message == "Action must be performed on the leader unit."
+
+    # ensure action fails if rebuild-cluster already in progress
+    peer_relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={"rebuild_cluster": "True"},
+    )
+    state_in = testing.State(relations={peer_relation}, leader=True)
+    with raises(testing.ActionFailed) as e:
+        ctx.run(ctx.on.action("rebuild-cluster"), state_in)
+
+        assert e.message == "Rebuilding the cluster is already in progress, cannot perform action."
+
+    # ensure action fails if backup is in progress
+    peer_relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={"backup_id": "xyz"},
+    )
+    state_in = testing.State(relations={peer_relation}, leader=True)
+    with raises(testing.ActionFailed) as e:
+        ctx.run(ctx.on.action("rebuild-cluster"), state_in)
+
+        assert e.message == "Backup in progress, cannot perform action."
+
+    # ensure action fails if restore is in progress
+    peer_relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={"restore_id": "xyz"},
+    )
+    state_in = testing.State(relations={peer_relation}, leader=True)
+    with raises(testing.ActionFailed) as e:
+        ctx.run(ctx.on.action("rebuild-cluster"), state_in)
+
+        assert e.message == "Restore in progress, cannot perform action."
+
+
+def test_rebuild_cluster_action_happy_path():
+    ctx = testing.Context(EtcdOperatorCharm)
+    peer_relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
+
+    state_in = testing.State(relations={peer_relation}, leader=True)
+    state_out = ctx.run(ctx.on.action("rebuild-cluster"), state_in)
+
+    assert ctx.action_results == {"result": "cluster rebuild in progress"}
+    assert state_out.unit_status == ops.BlockedStatus(
+        "Rebuilding with new cluster configuration..."
+    )
+    assert state_out.get_relation(1).local_app_data.get("rebuild_cluster")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -937,12 +937,14 @@ def test_rebuild_cluster_workflow_synchronisation():
     state_in = testing.State(relations={peer_relation}, leader=False)
 
     with (
+        patch("workload.EtcdWorkload.remove_directory") as remove_data,
         patch("workload.EtcdWorkload.write_file") as write_config,
         patch("workload.EtcdWorkload.start") as start_etcd,
         patch("workload.EtcdWorkload.enable_service") as enable_etcd,
     ):
         state_out = ctx.run(ctx.on.relation_changed(relation=peer_relation), state_in)
 
+        remove_data.assert_called_once()
         write_config.assert_called_once()
         start_etcd.assert_called_once()
         enable_etcd.assert_called_once()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -894,11 +894,13 @@ def test_rebuild_cluster_workflow_synchronisation():
     with (
         patch("workload.EtcdWorkload.stop") as stop_etcd,
         patch("workload.EtcdWorkload.disable_service") as disable_etcd,
+        patch("workload.EtcdWorkload.remove_directory") as remove_data,
     ):
         state_out = ctx.run(ctx.on.relation_changed(relation=peer_relation), state_in)
 
         stop_etcd.assert_called_once()
         disable_etcd.assert_called_once()
+        remove_data.assert_called_once()
         assert not state_out.get_relation(1).local_unit_data.get("state") == "started"
 
     # after all units are stopped, the leader initialises a new cluster and starts
@@ -937,14 +939,12 @@ def test_rebuild_cluster_workflow_synchronisation():
     state_in = testing.State(relations={peer_relation}, leader=False)
 
     with (
-        patch("workload.EtcdWorkload.remove_directory") as remove_data,
         patch("workload.EtcdWorkload.write_file") as write_config,
         patch("workload.EtcdWorkload.start") as start_etcd,
         patch("workload.EtcdWorkload.enable_service") as enable_etcd,
     ):
         state_out = ctx.run(ctx.on.relation_changed(relation=peer_relation), state_in)
 
-        remove_data.assert_called_once()
         write_config.assert_called_once()
         start_etcd.assert_called_once()
         enable_etcd.assert_called_once()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -814,18 +814,6 @@ def test_rebuild_cluster_action_error_cases():
 
         assert e.message == "Action must be performed on the leader unit."
 
-    # ensure action fails if rebuild-cluster already in progress
-    peer_relation = testing.PeerRelation(
-        id=1,
-        endpoint=PEER_RELATION,
-        local_app_data={"rebuild_cluster": "True"},
-    )
-    state_in = testing.State(relations={peer_relation}, leader=True)
-    with raises(testing.ActionFailed) as e:
-        ctx.run(ctx.on.action("rebuild-cluster"), state_in)
-
-        assert e.message == "Rebuilding the cluster is already in progress, cannot perform action."
-
     # ensure action fails if backup is in progress
     peer_relation = testing.PeerRelation(
         id=1,
@@ -856,6 +844,28 @@ def test_rebuild_cluster_action_happy_path():
     peer_relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
 
     state_in = testing.State(relations={peer_relation}, leader=True)
+    with (
+        patch("workload.EtcdWorkload.stop") as stop_etcd,
+        patch("workload.EtcdWorkload.disable_service") as disable_etcd,
+    ):
+        state_out = ctx.run(ctx.on.action("rebuild-cluster"), state_in)
+
+        stop_etcd.assert_called_once()
+        disable_etcd.assert_called_once()
+        assert ctx.action_results == {"result": "cluster rebuild in progress"}
+        assert state_out.unit_status == ops.BlockedStatus(
+            "Rebuilding with new cluster configuration..."
+        )
+        assert state_out.get_relation(1).local_app_data.get("rebuild_cluster")
+        assert not state_out.get_relation(1).local_unit_data.get("state") == "started"
+
+    # ensure action can be run multiple times
+    peer_relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={"rebuild_cluster": "True"},
+    )
+    state_in = testing.State(relations={peer_relation}, leader=True)
     state_out = ctx.run(ctx.on.action("rebuild-cluster"), state_in)
 
     assert ctx.action_results == {"result": "cluster rebuild in progress"}
@@ -863,3 +873,87 @@ def test_rebuild_cluster_action_happy_path():
         "Rebuilding with new cluster configuration..."
     )
     assert state_out.get_relation(1).local_app_data.get("rebuild_cluster")
+
+
+def test_rebuild_cluster_workflow_synchronisation():
+    ctx = testing.Context(EtcdOperatorCharm)
+
+    # after leader initiated workflow (on_action), non-leaders will stop
+    peer_relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={"rebuild_cluster": "True", "initial_cluster_state": "existing"},
+        local_unit_data={"state": "started"},
+    )
+    state_in = testing.State(relations={peer_relation}, leader=False)
+
+    with (
+        patch("workload.EtcdWorkload.stop") as stop_etcd,
+        patch("workload.EtcdWorkload.disable_service") as disable_etcd,
+    ):
+        state_out = ctx.run(ctx.on.relation_changed(relation=peer_relation), state_in)
+
+        stop_etcd.assert_called_once()
+        disable_etcd.assert_called_once()
+        assert not state_out.get_relation(1).local_unit_data.get("state") == "started"
+
+    # after all units are stopped, the leader initialises a new cluster and starts
+    peer_relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={"rebuild_cluster": "True", "initial_cluster_state": "existing"},
+        local_unit_data={},
+    )
+    state_in = testing.State(relations={peer_relation}, leader=True)
+
+    with (
+        patch("workload.EtcdWorkload.write_file") as write_config,
+        patch("workload.EtcdWorkload.start") as start_etcd,
+        patch("workload.EtcdWorkload.enable_service") as enable_etcd,
+    ):
+        state_out = ctx.run(ctx.on.relation_changed(relation=peer_relation), state_in)
+
+        write_config.assert_called_once()
+        start_etcd.assert_called_once()
+        enable_etcd.assert_called_once()
+        assert state_out.get_relation(1).local_unit_data.get("state") == "started"
+        assert state_out.get_relation(1).local_app_data.get("initial_cluster_state") == "new"
+
+    # after leader has initialised, non-leaders start
+    peer_relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={"rebuild_cluster": "True", "initial_cluster_state": "new"},
+        local_unit_data={},
+    )
+    state_in = testing.State(relations={peer_relation}, leader=False)
+
+    with (
+        patch("workload.EtcdWorkload.write_file") as write_config,
+        patch("workload.EtcdWorkload.start") as start_etcd,
+        patch("workload.EtcdWorkload.enable_service") as enable_etcd,
+    ):
+        state_out = ctx.run(ctx.on.relation_changed(relation=peer_relation), state_in)
+
+        write_config.assert_called_once()
+        start_etcd.assert_called_once()
+        enable_etcd.assert_called_once()
+        assert state_out.get_relation(1).local_unit_data.get("state") == "started"
+        assert state_out.get_relation(1).local_app_data.get("initial_cluster_state") == "new"
+
+    # after all units started, leader performs health check and completes workflow
+    peer_relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={"rebuild_cluster": "True", "initial_cluster_state": "new"},
+        local_unit_data={},
+    )
+    state_in = testing.State(relations={peer_relation}, leader=False)
+
+    with patch("managers.cluster.ClusterManager.is_healthy") as health_check:
+        state_out = ctx.run(ctx.on.relation_changed(relation=peer_relation), state_in)
+
+        health_check.assert_called_once()
+        assert state_out.get_relation(1).local_unit_data.get("state") == "started"
+        assert state_out.get_relation(1).local_app_data.get("initial_cluster_state") == "existing"
+        assert not state_out.get_relation(1).local_app_data.get("rebuild_cluster") == "True"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -880,7 +880,7 @@ def test_rebuild_cluster_action_happy_path():
 
 
 def test_rebuild_cluster_workflow_synchronisation():
-    ctx = testing.Context(EtcdOperatorCharm)
+    ctx = testing.Context(EtcdOperatorCharm, app_name="etcd", unit_id=0)
 
     # after leader initiated workflow (on_action), non-leaders will stop
     peer_relation = testing.PeerRelation(
@@ -921,14 +921,18 @@ def test_rebuild_cluster_workflow_synchronisation():
         start_etcd.assert_called_once()
         enable_etcd.assert_called_once()
         assert state_out.get_relation(1).local_unit_data.get("state") == "started"
-        assert state_out.get_relation(1).local_app_data.get("cluster_state") == "new"
+        assert state_out.get_relation(1).local_unit_data.get("rebuild_completed") == "True"
 
-    # after leader has initialised, non-leaders start
+    # after leader has initialised and non-leader unit was added, it starts
     peer_relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
-        local_app_data={"rebuild_cluster": "True", "cluster_state": "new"},
-        local_unit_data={},
+        local_app_data={
+            "rebuild_cluster": "True",
+            "cluster_state": "existing",
+            "cluster_members": "etcd0=http://ip0:2380,etcd1=http://ip1:2380",
+        },
+        local_unit_data={"hostname": "etcd0", "ip": "ip0"},
     )
     state_in = testing.State(relations={peer_relation}, leader=False)
 
@@ -943,14 +947,23 @@ def test_rebuild_cluster_workflow_synchronisation():
         start_etcd.assert_called_once()
         enable_etcd.assert_called_once()
         assert state_out.get_relation(1).local_unit_data.get("state") == "started"
-        assert state_out.get_relation(1).local_app_data.get("cluster_state") == "new"
+        assert state_out.get_relation(1).local_unit_data.get("rebuild_completed") == "True"
 
     # after all units started, leader performs health check and completes workflow
     peer_relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
-        local_app_data={"rebuild_cluster": "True", "cluster_state": "new"},
-        local_unit_data={"state": "started"},
+        local_app_data={
+            "rebuild_cluster": "True",
+            "cluster_state": "existing",
+            "cluster_members": "etcd0=http://ip0:2380,etcd1=http://ip1:2380",
+        },
+        local_unit_data={
+            "state": "started",
+            "rebuild_completed": "True",
+            "hostname": "etcd0",
+            "ip": "ip0",
+        },
     )
     state_in = testing.State(relations={peer_relation}, leader=True)
 
@@ -958,6 +971,4 @@ def test_rebuild_cluster_workflow_synchronisation():
         state_out = ctx.run(ctx.on.relation_changed(relation=peer_relation), state_in)
 
         health_check.assert_called_once()
-        assert state_out.get_relation(1).local_unit_data.get("state") == "started"
-        assert state_out.get_relation(1).local_app_data.get("cluster_state") == "existing"
         assert not state_out.get_relation(1).local_app_data.get("rebuild_cluster") == "True"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -460,6 +460,58 @@ def test_removal_of_inconsistent_members():
         update_cluster_member_state.assert_not_called()
 
 
+def test_cluster_majority_failure():
+    ctx = testing.Context(EtcdOperatorCharm)
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={
+            "authentication": "enabled",
+            "cluster_state": "existing",
+        },
+        local_unit_data={"ip": "ip0"},
+    )
+    state_in = testing.State(relations={relation})
+
+    # happy path: metric "etcd_server_has_leader" == 1
+    with (
+        patch("workload.EtcdWorkload.alive", return_value=True),
+        patch("managers.cluster.ClusterManager.clean_users"),
+        patch("managers.cluster.EtcdClient.get_metric", return_value="1"),
+    ):
+        state_out = ctx.run(ctx.on.update_status(), state_in)
+        assert state_out.unit_status == ops.ActiveStatus()
+
+    # error querying the metrics (metric not found)
+    with (
+        patch("workload.EtcdWorkload.alive", return_value=True),
+        patch("managers.cluster.ClusterManager.clean_users"),
+        patch("managers.cluster.EtcdClient.get_metric", return_value=None),
+    ):
+        state_out = ctx.run(ctx.on.update_status(), state_in)
+        assert state_out.unit_status == ops.ActiveStatus()
+
+    # error querying the metrics (request error)
+    with (
+        patch("workload.EtcdWorkload.alive", return_value=True),
+        patch("managers.cluster.ClusterManager.clean_users"),
+        patch("managers.cluster.EtcdClient.get_metric", side_effect=RuntimeError()),
+    ):
+        state_out = ctx.run(ctx.on.update_status(), state_in)
+        assert state_out.unit_status == ops.ActiveStatus()
+
+    # cluster has failed
+    with (
+        patch("workload.EtcdWorkload.alive", return_value=True),
+        patch("managers.cluster.ClusterManager.clean_users"),
+        patch("managers.cluster.EtcdClient.get_metric", return_value="0"),
+    ):
+        state_out = ctx.run(ctx.on.update_status(), state_in)
+        assert state_out.unit_status == ops.BlockedStatus(
+            "Cluster failure - majority of cluster members lost"
+        )
+
+
 def test_peer_relation_created():
     test_data = {"hostname": "my_hostname", "ip": "my_ip"}
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -838,6 +838,39 @@ def test_rebuild_cluster_action_error_cases():
 
         assert e.message == "Restore in progress, cannot perform action."
 
+    # cluster didn't fail and not `force`
+    peer_relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION, local_app_data={})
+    state_in = testing.State(relations={peer_relation}, leader=True)
+    with patch("managers.cluster.EtcdClient.get_metric", return_value="1"):
+        with raises(testing.ActionFailed) as e:
+            ctx.run(ctx.on.action("rebuild-cluster"), state_in)
+
+            assert e.message == "Cluster has not failed. Use `force` to rebuild anyway."
+
+    # cluster didn't fail and `force`
+    peer_relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION, local_app_data={})
+    state_in = testing.State(relations={peer_relation}, leader=True)
+    with (
+        patch("managers.cluster.EtcdClient.get_metric", return_value="1"),
+        patch("workload.EtcdWorkload.stop"),
+        patch("workload.EtcdWorkload.disable_service"),
+    ):
+        ctx.run(ctx.on.action("rebuild-cluster", params={"force": True}), state_in)
+
+        assert ctx.action_results == {"result": "cluster rebuild in progress"}
+
+    # error querying metrics server
+    peer_relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION, local_app_data={})
+    state_in = testing.State(relations={peer_relation}, leader=True)
+    with (
+        patch("managers.cluster.EtcdClient.get_metric", side_effect=RuntimeError()),
+        patch("workload.EtcdWorkload.stop"),
+        patch("workload.EtcdWorkload.disable_service"),
+    ):
+        ctx.run(ctx.on.action("rebuild-cluster"), state_in)
+
+        assert ctx.action_results == {"result": "cluster rebuild in progress"}
+
 
 def test_rebuild_cluster_action_happy_path():
     ctx = testing.Context(EtcdOperatorCharm)
@@ -845,6 +878,7 @@ def test_rebuild_cluster_action_happy_path():
 
     state_in = testing.State(relations={peer_relation}, leader=True)
     with (
+        patch("managers.cluster.EtcdClient.get_metric", return_value="0"),
         patch("workload.EtcdWorkload.stop") as stop_etcd,
         patch("workload.EtcdWorkload.disable_service") as disable_etcd,
     ):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -508,7 +508,7 @@ def test_cluster_majority_failure():
     ):
         state_out = ctx.run(ctx.on.update_status(), state_in)
         assert state_out.unit_status == ops.BlockedStatus(
-            "Cluster failure - majority of cluster members lost"
+            "Cluster failure - majority of cluster members lost. Run action `rebuild-cluster` to recover."
         )
 
 


### PR DESCRIPTION
If an etcd cluster experiences majority failure, it can not recover on its own. This PR adds a solution for these kind of error cases. It allows users to rebuild the existing cluster, but with new cluster membership configuration, while keeping the existing data.

It includes the following changes:

**UI/UX:**
- add a new `BlockedStatus` if cluster majority failure was detected: `Cluster failure - majority of cluster members lost. Run action rebuild-cluster to recover.`
- add a new action `rebuild-cluster` that allows users to recover a cluster from majority failure be re-initializing the cluster membership configuration. If the cluster is working fine, the action will fail to avoid shutting down the cluster unintentionally. This can be overridden with `force=True`.
- add a new `BlockedStatus` if cluster rebuild was executed by a user: `Rebuilding with new cluster configuration...`

**Implementation:**
- `EtcdClient`: new method `get_metric()` that allows querying the etcd metric server for a given metric (used by the `ClusterManager` to detect cluster failure)
- add check to detected failed clusters on `update_status`
- new handler `_on_rebuild_cluster_action` for `EtcdEvents`
- new properties for unit and cluster state to check the cluster rebuild progress
- block all potentially concurring event handlers if cluster rebuild is in progress, such as `config_changed`, `certificate_available` or others
- new method `_rebuild_cluster()` in `EtcdEvents` to orchestrate the workflow for rebuilding a cluster based on `peer_relation_changed` events

The workflow is also documented in this wiki page: https://github.com/canonical/charmed-etcd-operator/wiki/Rebuild-cluster:-Workflow

**Testing:**
- unit test coverage for the `rebuild-cluster` action
- unit test coverage for the workflow for rebuilding the cluster which is based on `peer_relation_changed` events
- integration test coverage for rebuilding a failed cluster by running the action in `test_disaster_recovery.py`

Unrelated change:
- updating `protobuf` dependency to `6.31.1` because of [CVE-2025-4565](https://github.com/canonical/charmed-etcd-operator/security/dependabot/8)