### PR TITLE
Change default channel for grafana agent

### DIFF
--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -40,7 +40,7 @@ variable "self-signed-certificates" {
 variable "grafana-agent" {
   description = "Configuration for the grafana-agent"
   type = object({
-    channel     = optional(string, "2/stable")
+    channel     = optional(string, "1/stable")
     revision    = optional(string, null)
     base        = optional(string, "ubuntu@24.04")
     constraints = optional(string, "arch=amd64")

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -40,7 +40,7 @@ variable "self-signed-certificates" {
 variable "grafana-agent" {
   description = "Configuration for the grafana-agent"
   type = object({
-    channel     = optional(string, "latest/stable")
+    channel     = optional(string, "2/stable")
     revision    = optional(string, null)
     base        = optional(string, "ubuntu@24.04")
     constraints = optional(string, "arch=amd64")


### PR DESCRIPTION
This pull request updates the default configuration for the `grafana-agent` variable in the Terraform module.

Key change:

* [`terraform/product/variables.tf`](diffhunk://#diff-a6f432bf624629ab66a3f4580437bca1602e9da85b9c282ec99d9d27e1c51a2fL43-R43): Updated the default value of the `channel` property in the `grafana-agent` variable from `"latest/stable"` to `"1/stable"`, ensuring the use of a specific stable version for improved reliability.