### PR TITLE
[DPE-7632] - Block charm if parameters are missing in backup integrator

### DIFF
--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -20,10 +20,12 @@ from ops import Object, Relation, Unit
 
 from core.models import EtcdCluster, EtcdServer
 from literals import (
+    AZURE_RELATION_NAME,
     CLIENT_TLS_RELATION_NAME,
     EXTERNAL_CLIENTS_RELATION,
     PEER_RELATION,
     PEER_TLS_RELATION_NAME,
+    S3_RELATION_NAME,
     SECRETS_APP,
     SUBSTRATES,
 )
@@ -127,6 +129,16 @@ class ClusterState(Object):
     def tls_client_certificate(self) -> ProviderCertificate:
         """Get the client TLS certificates interface."""
         return self.charm.tls_events.client_certificate.get_assigned_certificates()[0][0]
+
+    @property
+    def s3_relation(self) -> Relation | None:
+        """Get the S3 integrator relation."""
+        return self.model.get_relation(S3_RELATION_NAME)
+
+    @property
+    def azure_relation(self) -> Relation | None:
+        """Get the Azure integrator relation."""
+        return self.model.get_relation(AZURE_RELATION_NAME)
 
     @property
     def can_restore_workflow_proceed(self) -> bool:

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -99,7 +99,10 @@ class BackupEvents(Object):
         # make sure we have all required parameters for writing to the storage
         required_parameters = ["bucket", "endpoint", "path", "access-key", "secret-key"]
         if missing_parameters := [p for p in required_parameters if p not in s3_parameters]:
-            raise KeyError(f"Parameters missing from S3 integrator: {missing_parameters}")
+            logger.error(
+                f"Parameters missing from S3 integrator: {missing_parameters}. Please check the relation with s3-integrator."
+            )
+            return
 
         # Strip whitespaces from all parameters
         for key, value in s3_parameters.items():
@@ -148,7 +151,10 @@ class BackupEvents(Object):
         # make sure we have all required parameters for writing to the storage
         required_parameters = ["container", "storage-account", "path", "secret-key"]
         if missing_parameters := [p for p in required_parameters if p not in azure_parameters]:
-            raise KeyError(f"Parameters missing from Azure integrator: {missing_parameters}")
+            logger.error(
+                f"Parameters missing from Azure integrator: {missing_parameters}. Please check the relation with azure-storage-integrator."
+            )
+            return
 
         # Strip whitespaces from all parameters
         for key, value in azure_parameters.items():

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -368,26 +368,16 @@ class BackupEvents(Object):
         if not self.charm.unit.is_leader():
             return "Action must be performed on the leader unit."
 
-        if self.charm.model.get_relation(AZURE_RELATION_NAME) and self.charm.model.get_relation(
-            S3_RELATION_NAME
-        ):
+        if self.charm.state.azure_relation and self.charm.state.s3_relation:
             return "Azure and S3 storages configured - please remove one."
 
-        if not self.charm.model.get_relation(
-            AZURE_RELATION_NAME
-        ) and not self.charm.model.get_relation(S3_RELATION_NAME):
+        if not self.charm.state.azure_relation and not self.charm.state.s3_relation:
             return "No object storage configured - please add Azure or S3 relation."
 
-        if (
-            self.charm.model.get_relation(S3_RELATION_NAME)
-            and not self.charm.state.cluster.s3_credentials
-        ):
+        if self.charm.state.s3_relation and not self.charm.state.cluster.s3_credentials:
             return "No credentials for S3 object storage available."
 
-        if (
-            self.charm.model.get_relation(AZURE_RELATION_NAME)
-            and not self.charm.state.cluster.azure_credentials
-        ):
+        if self.charm.state.azure_relation and not self.charm.state.cluster.azure_credentials:
             return "No credentials for Azure object storage available."
 
         if self.charm.state.cluster.is_backup_in_progress:

--- a/src/literals.py
+++ b/src/literals.py
@@ -74,6 +74,12 @@ class Status(Enum):
         BlockedStatus("failed to enable authentication in etcd"), "ERROR"
     )
     BACKUP_IN_PROGRESS = StatusLevel(MaintenanceStatus("Creating database backup..."), "DEBUG")
+    BACKUP_S3_PARAMETERS_MISSING = StatusLevel(
+        BlockedStatus("S3 parameters are missing - please provide them"), "ERROR"
+    )
+    BACKUP_AZURE_PARAMETERS_MISSING = StatusLevel(
+        BlockedStatus("Azure parameters are missing - please provide them"), "ERROR"
+    )
     CLUSTER_INITIALIZING = StatusLevel(MaintenanceStatus("Initializing etcd cluster..."), "DEBUG")
     CLUSTER_MANAGEMENT_ERROR = StatusLevel(BlockedStatus("cluster management error"), "ERROR")
     CLUSTER_NOT_INITIALIZED = StatusLevel(

--- a/src/literals.py
+++ b/src/literals.py
@@ -75,10 +75,10 @@ class Status(Enum):
     )
     BACKUP_IN_PROGRESS = StatusLevel(MaintenanceStatus("Creating database backup..."), "DEBUG")
     BACKUP_S3_PARAMETERS_MISSING = StatusLevel(
-        BlockedStatus("S3 parameters are missing - please provide them"), "ERROR"
+        BlockedStatus("Missing required parameters in the s3 relation."), "ERROR"
     )
     BACKUP_AZURE_PARAMETERS_MISSING = StatusLevel(
-        BlockedStatus("Azure parameters are missing - please provide them"), "ERROR"
+        BlockedStatus("Missing required parameters in the azure relation."), "ERROR"
     )
     CLUSTER_INITIALIZING = StatusLevel(MaintenanceStatus("Initializing etcd cluster..."), "DEBUG")
     CLUSTER_MANAGEMENT_ERROR = StatusLevel(BlockedStatus("cluster management error"), "ERROR")

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -403,4 +403,10 @@ class BackupManager:
         if self.state.cluster.s3_credentials and self.state.cluster.azure_credentials:
             status_list.append(Status.OBJECT_STORAGE_CONFLICT)
 
+        if self.state.s3_relation and not self.state.cluster.s3_credentials:
+            status_list.append(Status.BACKUP_S3_PARAMETERS_MISSING)
+
+        if self.state.azure_relation and not self.state.cluster.azure_credentials:
+            status_list.append(Status.BACKUP_AZURE_PARAMETERS_MISSING)
+
         return status_list

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -21,6 +21,7 @@ from literals import (
     S3_RELATION_NAME,
     EtcdClusterState,
     RestoreStep,
+    Status,
 )
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
@@ -62,10 +63,8 @@ def test_s3_relation():
 
     state_in = testing.State(relations={peer_relation, s3_relation}, leader=True)
     with patch("managers.backup.BackupManager.create_bucket"):
-        with raises(testing.errors.UncaughtCharmError) as e:
-            ctx.run(ctx.on.relation_changed(s3_relation), state_in)
-
-        assert isinstance(e.value.__cause__, KeyError)
+        state_out = ctx.run(ctx.on.relation_changed(s3_relation), state_in)
+        assert state_out.unit_status == Status.BACKUP_S3_PARAMETERS_MISSING.value.status
 
 
 def test_azure_relation():
@@ -108,10 +107,9 @@ def test_azure_relation():
 
     state_in = testing.State(relations={peer_relation, azure_relation}, leader=True)
     with patch("managers.backup.BackupManager.create_container"):
-        with raises(testing.errors.UncaughtCharmError) as e:
-            ctx.run(ctx.on.relation_changed(azure_relation), state_in)
+        state_out = ctx.run(ctx.on.relation_changed(azure_relation), state_in)
 
-        assert isinstance(e.value.__cause__, KeyError)
+        assert state_out.unit_status == Status.BACKUP_AZURE_PARAMETERS_MISSING.value.status
 
 
 def test_create_backup_action_s3():


### PR DESCRIPTION
Fixes #99 
This pull request replaces raising exceptions with error logging, updating status reporting for missing parameters of backup integrators.

### Support for S3 and Azure integrator relations:
* Added `s3_relation` and `azure_relation` properties in `src/core/cluster.py` to retrieve the respective integrator relations.
* Updated `src/literals.py` with new statuses: `BACKUP_S3_PARAMETERS_MISSING` and `BACKUP_AZURE_PARAMETERS_MISSING` for better error reporting.

### Improved error handling:
* Replaced `KeyError` exceptions with error logging and early returns in `_on_s3_credentials_changed` and `_on_azure_credentials_changed` methods in `src/events/backup.py`. This ensures the charm doesn't crash when required parameters are missing. [[1]](diffhunk://#diff-ad959188bbaf55316575b2e26d4d155b09e71de16ce05ea31339fe6089fea1e1L102-R105) [[2]](diffhunk://#diff-ad959188bbaf55316575b2e26d4d155b09e71de16ce05ea31339fe6089fea1e1L151-R157)

### Status reporting enhancements:
* Updated `compute_component_status` in `src/managers/backup.py` to append new statuses when S3 or Azure credentials are missing but their relations exist.

### Unit test updates:
* Modified `test_s3_relation` and `test_azure_relation` in `tests/unit/test_backup.py` to validate the new statuses instead of expecting exceptions. [[1]](diffhunk://#diff-aa5595fbd89e64a35df876c1abefce9f0d230a876fb05c2f25d6ccec43295cf3L65-R67) [[2]](diffhunk://#diff-aa5595fbd89e64a35df876c1abefce9f0d230a876fb05c2f25d6ccec43295cf3L111-R112)