### PR TITLE
Fix name of release workflow and track key

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,9 +41,9 @@ jobs:
     name: Release charm
     needs:
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v32.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v32.1.0
     with:
-      channel: 3.6/edge
+      track: 3.6/edge
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the release workflow configuration to use a different workflow file and modifies the input parameters for clarity and consistency.

Changes to the release workflow:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL44-R46): Updated the workflow to use `release_charm_edge.yaml` instead of `release_charm.yaml` and replaced the `channel` parameter with `track` for better alignment with naming conventions.

[Reference](https://github.com/canonical/data-platform-workflows/releases/tag/v32.0.0)