### PR TITLE
Fix tics and release workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v32.1.0
     with:
-      track: 3.6/edge
+      track: 3.6
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}

--- a/.github/workflows/tics_run_sh_ghaction_test.yaml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y python3.10-venv
+        run: sudo apt-get update && sudo apt-get install -y python3-venv
 
       - name: Install pipx
         run: python3 -m pip install --user pipx && python3 -m pipx ensurepath


### PR DESCRIPTION

### Workflow Configuration Updates:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL46-R46): Updated the `track` parameter from `3.6/edge` to `3.6` in the `release_charm_edge.yaml` workflow.

### System Dependency Compatibility:

* [`.github/workflows/tics_run_sh_ghaction_test.yaml`](diffhunk://#diff-edc3c0cb977fd69fff800544d6c6e31c3509e901a1e6567302873260851d1424L20-R20): Changed the installation command for Python virtual environment tools to use `python3-venv` instead of the version-specific `python3.10-venv`. The new version of Ubuntu comes with `3.12`.