### PR TITLE
Change tiobe runner to default one

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,3 +5,4 @@ self-hosted-runner:
     - amd64
     - tiobe
     - noble
+    - jammy

--- a/.github/workflows/tics_run_sh_ghaction_test.yaml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tiobe-scan:
-    runs-on: [self-hosted, linux, amd64, tiobe, noble]
+    runs-on: [self-hosted, tiobe]
 
     steps:
       - name: Checkout the project

--- a/.github/workflows/tics_run_sh_ghaction_test.yaml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tiobe-scan:
-    runs-on: [self-hosted, tiobe]
+    runs-on: [self-hosted, jammy, tiobe]
 
     steps:
       - name: Checkout the project

--- a/.github/workflows/tics_run_sh_ghaction_test.yaml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yaml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Move results to necessary folder for TICS
         run: |
-          mkdir -p .cover
-          mv coverage.xml .cover/coverage.xml
+          mkdir -p cover
+          mv coverage.xml cover/coverage.xml
 
       - name: Run TICS analysis with github-action
         uses: tiobe/tics-github-action@v3


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to simplify the runner labels for the `tiobe-scan` job.

* [`.github/workflows/tics_run_sh_ghaction_test.yaml`](diffhunk://#diff-edc3c0cb977fd69fff800544d6c6e31c3509e901a1e6567302873260851d1424L13-R13): Simplified the `runs-on` configuration for the `tiobe-scan` job by reducing the runner labels from `[self-hosted, linux, amd64, tiobe, noble]` to `[self-hosted, tiobe]`.