### PR TITLE
[DPE-7663] - Migrate collecting CAs to tls manager

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -240,12 +240,12 @@ class EtcdOperatorCharm(ops.CharmBase):
 
         # peer CA rotation
         if self.state.unit_server.tls_peer_ca_rotation_state == TLSCARotationState.CERT_UPDATED:
-            self.tls_manager.update_cas([self.tls_events.collect_peer_ca()], TLSType.PEER)
+            self.tls_manager.update_cas([self.tls_manager.collect_peer_ca()], TLSType.PEER)
             self.tls_manager.set_ca_rotation_state(TLSType.PEER, TLSCARotationState.NO_ROTATION)
 
         # client CA rotation
         if self.state.unit_server.tls_client_ca_rotation_state == TLSCARotationState.CERT_UPDATED:
-            self.tls_manager.update_cas(self.tls_events.collect_client_cas(), TLSType.CLIENT)
+            self.tls_manager.update_cas(self.tls_manager.collect_client_cas(), TLSType.CLIENT)
             self.tls_manager.set_ca_rotation_state(TLSType.CLIENT, TLSCARotationState.NO_ROTATION)
 
         self.config_manager.set_config_properties()

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -127,8 +127,18 @@ class ClusterState(Object):
 
     @property
     def tls_client_certificate(self) -> ProviderCertificate:
-        """Get the client TLS certificates interface."""
+        """Get the client TLS certificate."""
         return self.charm.tls_events.client_certificate.get_assigned_certificates()[0][0]
+
+    @property
+    def tls_peer_certificate(self) -> ProviderCertificate:
+        """Get the peer TLS certificate."""
+        return self.charm.tls_events.peer_certificate.get_assigned_certificates()[0][0]
+
+    @property
+    def tls_certificate_transfer_certificates(self) -> Set[str]:
+        """Get the TLS certificates from the certificate transfer interface."""
+        return self.charm.external_clients_events.certificate_transfer.get_all_certificates()
 
     @property
     def s3_relation(self) -> Relation | None:

--- a/src/events/external_clients.py
+++ b/src/events/external_clients.py
@@ -200,6 +200,6 @@ class ExternalClientsEvents(Object):
     def _update_client_truststore(self) -> None:
         """Update the client truststore and Initiate a rolling restart of the cluster."""
         self.charm.tls_manager.update_cas(
-            self.charm.tls_events.collect_client_cas(), TLSType.CLIENT
+            self.charm.tls_manager.collect_client_cas(), TLSType.CLIENT
         )
         self.charm.rolling_restart()

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -214,7 +214,9 @@ class TLSEvents(Object):
         self.charm.tls_manager.write_certificate(cert, private_key)  # type: ignore
         # if there are client relations add their CAs to the trusted client CAs
         if cert_type == TLSType.CLIENT and tls_state == TLSState.TO_TLS:
-            self.charm.tls_manager.update_cas(self.collect_client_cas(), cert_type)
+            self.charm.tls_manager.update_cas(
+                self.charm.tls_manager.collect_client_cas(), cert_type
+            )
 
         # TLS is enabled, New CA added to all servers, and cert updated -> no rolling restart needed until we clean up old CA
         if tls_state == TLSState.TLS and tls_ca_rotation_state == TLSCARotationState.NEW_CA_ADDED:
@@ -344,42 +346,3 @@ class TLSEvents(Object):
             return None
 
         return private_key
-
-    # TODO migrate to TLS manager
-    def collect_client_cas(self) -> list[str]:
-        """Collect client CAs.
-
-        Returns:
-            list[str]: The client CAs.
-        """
-        cas: list[str] = []
-
-        # server ca
-        certs, _ = self.client_certificate.get_assigned_certificates()
-        cas.append(certs[0].ca.raw)
-
-        # managed users cas
-        for relation in self.charm.external_clients_events.etcd_provides.relations:
-            mtls_cert = self.charm.external_clients_events.etcd_provides.fetch_relation_field(
-                relation.id, "mtls-cert"
-            )
-            logger.debug(
-                f"Collecting CA from relation {relation.id}, chain exists: {bool(mtls_cert)}"
-            )
-            if mtls_cert:
-                cas.extend(self.charm.tls_manager.separate_certificates(mtls_cert))
-
-        # certificate transfer cas
-        cas.extend(self.charm.external_clients_events.certificate_transfer.get_all_certificates())
-
-        return cas
-
-    def collect_peer_ca(self) -> str:
-        """Collect peer CA.
-
-        Returns:
-            str: The peer CA.
-        """
-        # server ca
-        certs, _ = self.peer_certificate.get_assigned_certificates()
-        return certs[0].ca.raw

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -264,3 +264,33 @@ class TLSManager:
             status_list.append(Status.TLS_PEER_CERTS_EXPIRING)
 
         return status_list
+
+    def collect_client_cas(self) -> list[str]:
+        """Collect client CAs.
+
+        Returns:
+            list[str]: The client CAs.
+        """
+        cas: list[str] = [self.state.tls_client_certificate.ca.raw]
+
+        # managed users cas
+        for relation in self.state.etcd_provides.relations:
+            mtls_cert = self.state.etcd_provides.fetch_relation_field(relation.id, "mtls-cert")
+            logger.debug(
+                f"Collecting CA from relation {relation.id}, chain exists: {bool(mtls_cert)}"
+            )
+            if mtls_cert:
+                cas.extend(self.separate_certificates(mtls_cert))
+
+        # certificate transfer cas
+        cas.extend(self.state.tls_certificate_transfer_certificates)
+
+        return cas
+
+    def collect_peer_ca(self) -> str:
+        """Collect peer CA.
+
+        Returns:
+            str: The peer CA.
+        """
+        return self.state.tls_peer_certificate.ca.raw

--- a/tests/unit/test_external_client_relations.py
+++ b/tests/unit/test_external_client_relations.py
@@ -244,14 +244,12 @@ def test_add_ecr_new_user_not_leader(cluster_tls_context, mtls_cert):
     with (
         ctx(ctx.on.relation_changed(ecr_relation), state_in) as manager,
         patch("managers.cluster.ClusterManager.add_managed_user") as add_managed_user,
-        patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
         patch("workload.EtcdWorkload.write_file"),
     ):
         state_out = manager.run()
         add_managed_user.assert_not_called()
         assert "mtls_cert_updated" not in [event.name for event in state_out.deferred]
-        # TODO add more assertions after checking custom event not being emitted in non leader setting
-        # restart_member.assert_called_once()
 
 
 def test_add_ecr_new_user_no_tls_leader(cluster_no_tls_context, mtls_cert):
@@ -498,7 +496,7 @@ def test_ecr_update_common_name_leader(cluster_tls_context, mtls_cert, mtls_cert
         patch("common.client.EtcdClient.get_user", return_value=None),
         patch("common.client.EtcdClient._run_etcdctl", return_value="success"),
         patch("workload.EtcdWorkload.write_file"),
-        patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
         patch(
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
             return_value=([server_cert], MagicMock()),
@@ -588,7 +586,7 @@ def test_ecr_update_common_name_leader_crash(
         patch("common.client.EtcdClient.get_user", return_value=None),
         patch("common.client.EtcdClient._run_etcdctl", return_value="success"),
         patch("workload.EtcdWorkload.write_file"),
-        patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
         patch(
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
             return_value=([server_cert], MagicMock()),
@@ -677,7 +675,7 @@ def test_ecr_update_chain_same_common_name(
         patch("common.client.EtcdClient.get_user", return_value=None),
         patch("common.client.EtcdClient._run_etcdctl", return_value="success"),
         patch("workload.EtcdWorkload.write_file"),
-        patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
         patch(
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
             return_value=([server_cert], MagicMock()),
@@ -760,7 +758,7 @@ def test_ecr_update_common_name_non_leader(
     with (
         ctx(ctx.on.relation_changed(ecr_relation), state_in) as manager,
         patch("workload.EtcdWorkload.write_file"),
-        patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
     ):
         charm: EtcdOperatorCharm = manager.charm
         state_out = manager.run()
@@ -788,7 +786,7 @@ def test_ecr_update_common_name_non_leader(
         ctx(ctx.on.secret_changed(secret), state_in) as manager,
         patch("managers.tls.TLSManager.is_new_ca", return_value=False),
         patch("workload.EtcdWorkload.write_file"),
-        patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
     ):
         peer_relation.local_app_data["managed_users"] = f'{{"5":"diff-{CLIENT_COMMON_NAME}"}}'
         charm: EtcdOperatorCharm = manager.charm
@@ -870,7 +868,7 @@ def test_ecr_relation_broken_leader(cluster_tls_context, mtls_cert):
         ctx(ctx.on.relation_broken(ecr_relation), state_in) as manager,
         patch("common.client.EtcdClient.remove_role") as remove_role,
         patch("common.client.EtcdClient.remove_user") as remove_user,
-        patch("events.tls.TLSEvents.collect_client_cas") as collect_client_cas,
+        patch("managers.tls.TLSManager.collect_client_cas") as collect_client_cas,
         patch("managers.tls.TLSManager.update_cas") as update_cas,
         patch("charm.EtcdOperatorCharm._restart") as restart,
     ):
@@ -917,7 +915,7 @@ def test_ecr_relation_broken_not_leader(cluster_tls_context):
         patch("workload.EtcdWorkload.alive", return_value=True),
         patch("managers.cluster.ClusterManager.remove_managed_user") as remove_managed_user,
         patch("workload.EtcdWorkload.write_file"),
-        patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
     ):
         manager.run()
         remove_managed_user.assert_not_called()
@@ -980,7 +978,9 @@ def test_etcd_rotates_ca(cluster_tls_context, mtls_cert):
             patch("managers.tls.TLSManager.is_new_ca_saved_on_all_servers", return_value=True),
             patch("managers.tls.TLSManager.write_certificate"),
             patch("managers.tls.TLSManager.update_cas"),
-            patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+            patch(
+                "managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]
+            ),
             patch("managers.cluster.ClusterManager.clean_users"),
             patch("managers.cluster.ClusterManager.remove_inconsistent_members_if_required"),
         ):
@@ -1280,7 +1280,7 @@ def test_ecr_update_chain_invalid_new_value(cluster_tls_context, mtls_cert, ca_c
         patch("common.client.EtcdClient.get_user", return_value=None),
         patch("common.client.EtcdClient._run_etcdctl", return_value="success"),
         patch("workload.EtcdWorkload.write_file"),
-        patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
         patch(
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
             return_value=([server_cert], MagicMock()),
@@ -1356,7 +1356,7 @@ def test_certificate_transfer_new_ca(cluster_tls_context, ca_cert):
     with (
         patch("common.client.EtcdClient._run_etcdctl", return_value="success"),
         patch("workload.EtcdWorkload.write_file"),
-        patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
         patch("managers.cluster.ClusterManager.restart_member"),
         patch("managers.tls.TLSManager.update_cas") as update_cas,
     ):
@@ -1390,7 +1390,7 @@ def test_certificate_transfer_old_ca(cluster_tls_context, ca_cert):
     with (
         patch("common.client.EtcdClient._run_etcdctl", return_value="success"),
         patch("workload.EtcdWorkload.write_file"),
-        patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
         patch("managers.cluster.ClusterManager.restart_member"),
         patch("managers.tls.TLSManager.update_cas") as update_cas,
         patch("managers.tls.TLSManager.is_new_ca", return_value=False),
@@ -1427,7 +1427,7 @@ def test_certificate_transfer_new_ca_rotation_happening(cluster_tls_context, ca_
     with (
         patch("common.client.EtcdClient._run_etcdctl", return_value="success"),
         patch("workload.EtcdWorkload.write_file"),
-        patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
         patch("managers.cluster.ClusterManager.restart_member"),
         patch("managers.tls.TLSManager.update_cas") as update_cas,
     ):
@@ -1462,7 +1462,7 @@ def test_certificate_transfer_removed(cluster_tls_context, ca_cert):
     with (
         # patch("common.client.EtcdClient._run_etcdctl", return_value="success"),
         patch("workload.EtcdWorkload.write_file"),
-        patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
         patch("managers.cluster.ClusterManager.restart_member"),
         patch("managers.tls.TLSManager.update_cas") as update_cas,
     ):
@@ -1498,7 +1498,7 @@ def test_certificate_transfer_removed_on_rotation(cluster_tls_context, ca_cert):
     with (
         # patch("common.client.EtcdClient._run_etcdctl", return_value="success"),
         patch("workload.EtcdWorkload.write_file"),
-        patch("events.tls.TLSEvents.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
         patch("managers.cluster.ClusterManager.restart_member"),
         patch("managers.tls.TLSManager.update_cas") as update_cas,
     ):
@@ -1543,7 +1543,7 @@ def test_removing_user_crash(cluster_tls_context, mtls_cert):
         ctx(ctx.on.relation_broken(ecr_relation), state_in) as manager,
         patch("common.client.EtcdClient.remove_role") as remove_role,
         patch("common.client.EtcdClient.remove_user") as remove_user,
-        patch("events.tls.TLSEvents.collect_client_cas") as collect_client_cas,
+        patch("managers.tls.TLSManager.collect_client_cas") as collect_client_cas,
         patch("managers.tls.TLSManager.update_cas") as update_cas,
         patch("charm.EtcdOperatorCharm._restart") as restart,
     ):


### PR DESCRIPTION
### Refactoring TLS Certificate Management:

* [`src/managers/tls.py`](diffhunk://#diff-a2c036f44ae9bbab595aad84b23bc3106a342c5ab12f7b0cf3d26268b51cdc83R267-R296): Migrated methods `collect_client_cas` and `collect_peer_ca` to centralize certificate collection logic within `TLSManager` previously in `TLSEvents`.

### Code Updates for Certificate Collection:

* `src/charm.py`, `src/events/external_clients.py`, `src/events/tls.py`: Updated calls to certificate collection methods to use `TLSManager.collect_client_cas` and `TLSManager.collect_peer_ca` instead of the removed `TLSEvents` methods. [[1]](diffhunk://#diff-b9ed39bbc9c0387bd3e07da31d13373745534a1cd723d3e292c73496b12e307cL243-R248) [[2]](diffhunk://#diff-41d3b0e68fba8bc44a83df27841cc482ba1df8a5cfe8e476397765673f46f446L203-R203) [[3]](diffhunk://#diff-3dfb4a104b407f7d4b2e07795a63745a09cde228a8dbe86602e7b72ea600fbe4L217-R219)

### Unit Test Updates:

* [`tests/unit/test_external_client_relations.py`](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L247-L254): Replaced all references to `events.tls.TLSEvents.collect_client_cas` with `managers.tls.TLSManager.collect_client_cas` across multiple test cases to ensure compatibility with the refactored code. [[1]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L247-L254) [[2]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L501-R499) [[3]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L591-R589) [[4]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L680-R678) [[5]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L763-R761) [[6]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L791-R789) [[7]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L873-R871) [[8]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L920-R918) [[9]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L983-R983) [[10]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L1283-R1283) [[11]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L1359-R1359) [[12]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L1393-R1393) [[13]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L1430-R1430) [[14]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L1465-R1465) [[15]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L1501-R1501) [[16]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L1546-R1546)