### PR TITLE
[DPE-7736] fix disaster recover integration test

### DIFF
--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -81,8 +81,6 @@ async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> 
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
-@pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_rebuild_on_healthy_cluster(ops_test: OpsTest) -> None:
     """Users can run `rebuild-cluster` on a healthy cluster if the use the `force` parameter."""
@@ -116,8 +114,6 @@ async def test_rebuild_on_healthy_cluster(ops_test: OpsTest) -> None:
         logger.info(f"{unit.name} in cluster members")
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
-@pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
     """When the majority of the cluster is lost, users can run `rebuild-cluster`."""

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -145,9 +145,7 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
 @pytest.mark.abort_on_fail
 async def test_rebuild_on_healthy_cluster(ops_test: OpsTest) -> None:
     """Users can run `rebuild-cluster` on a healthy cluster if the use the `force` parameter."""
-    logger.info("Scale up to HA cluster again")
-    await ops_test.model.applications[APP_NAME].add_unit(count=1)
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=3)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=2)
 
     for unit in ops_test.model.applications[APP_NAME].units:
         if await unit.is_leader_from_status():
@@ -165,7 +163,7 @@ async def test_rebuild_on_healthy_cluster(ops_test: OpsTest) -> None:
     assert rebuild_force_response.results.get("return-code") == 0, "rebuild failed"
 
     # wait for the rebuild to be performed
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=3)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=2)
 
     endpoints = get_cluster_endpoints(ops_test, APP_NAME)
     cluster_members = get_cluster_members(endpoints)

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -84,6 +84,41 @@ async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
+async def test_rebuild_on_healthy_cluster(ops_test: OpsTest) -> None:
+    """Users can run `rebuild-cluster` on a healthy cluster if the use the `force` parameter."""
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=2)
+
+    for unit in ops_test.model.applications[APP_NAME].units:
+        if await unit.is_leader_from_status():
+            leader_unit = unit
+
+    logger.info("Executing rebuild-cluster on healthy cluster - this should fail")
+    rebuild_action = await leader_unit.run_action("rebuild-cluster")
+    rebuild_response = await rebuild_action.wait()
+    assert rebuild_response.results.get("return-code") == 0, "rebuild failed"
+    assert rebuild_response.status == "failed"
+
+    logger.info("Try again with `force` option")
+    rebuild_force_action = await leader_unit.run_action("rebuild-cluster", **{"force": True})
+    rebuild_force_response = await rebuild_force_action.wait()
+    assert rebuild_force_response.results.get("return-code") == 0, "rebuild failed"
+
+    # wait for the rebuild to be performed
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=2)
+
+    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    cluster_members = get_cluster_members(endpoints)
+    member_names = [member["name"] for member in cluster_members]
+    for unit in ops_test.model.applications[APP_NAME].units:
+        assert unit.name.replace("/", "") in member_names, (
+            f"unit {unit.name} not in cluster members"
+        )
+        logger.info(f"{unit.name} in cluster members")
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
 async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
     """When the majority of the cluster is lost, users can run `rebuild-cluster`."""
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS - 1)
@@ -138,38 +173,3 @@ async def test_recover_from_majority_failure(ops_test: OpsTest) -> None:
         f"{second_removed_member_name} still in cluster members"
     )
     logger.info(f"{second_removed_member_name} not in cluster members")
-
-
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
-@pytest.mark.group(1)
-@pytest.mark.abort_on_fail
-async def test_rebuild_on_healthy_cluster(ops_test: OpsTest) -> None:
-    """Users can run `rebuild-cluster` on a healthy cluster if the use the `force` parameter."""
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=2)
-
-    for unit in ops_test.model.applications[APP_NAME].units:
-        if await unit.is_leader_from_status():
-            leader_unit = unit
-
-    logger.info("Executing rebuild-cluster on healthy cluster - this should fail")
-    rebuild_action = await leader_unit.run_action("rebuild-cluster")
-    rebuild_response = await rebuild_action.wait()
-    assert rebuild_response.results.get("return-code") == 0, "rebuild failed"
-    assert rebuild_response.status == "failed"
-
-    logger.info("Try again with `force` option")
-    rebuild_force_action = await leader_unit.run_action("rebuild-cluster", **{"force": True})
-    rebuild_force_response = await rebuild_force_action.wait()
-    assert rebuild_force_response.results.get("return-code") == 0, "rebuild failed"
-
-    # wait for the rebuild to be performed
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=2)
-
-    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
-    cluster_members = get_cluster_members(endpoints)
-    member_names = [member["name"] for member in cluster_members]
-    for unit in ops_test.model.applications[APP_NAME].units:
-        assert unit.name.replace("/", "") in member_names, (
-            f"unit {unit.name} not in cluster members"
-        )
-        logger.info(f"{unit.name} in cluster members")

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -86,7 +86,7 @@ async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> 
 @pytest.mark.abort_on_fail
 async def test_rebuild_on_healthy_cluster(ops_test: OpsTest) -> None:
     """Users can run `rebuild-cluster` on a healthy cluster if the use the `force` parameter."""
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=2)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS - 1)
 
     for unit in ops_test.model.applications[APP_NAME].units:
         if await unit.is_leader_from_status():
@@ -104,7 +104,7 @@ async def test_rebuild_on_healthy_cluster(ops_test: OpsTest) -> None:
     assert rebuild_force_response.results.get("return-code") == 0, "rebuild failed"
 
     # wait for the rebuild to be performed
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=2)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS - 1)
 
     endpoints = get_cluster_endpoints(ops_test, APP_NAME)
     cluster_members = get_cluster_members(endpoints)

--- a/tests/integration/ha/test_storage_reuse.py
+++ b/tests/integration/ha/test_storage_reuse.py
@@ -80,9 +80,9 @@ async def test_attach_storage_after_scale_down(ops_test: OpsTest) -> None:
 
     # add unit with previous storage attached
     add_unit_cmd = f"add-unit {app} --model={ops_test.model.info.name} --attach-storage={data_storage_id} --attach-storage={archive_storage_id}"
-    return_code, _, _ = await ops_test.juju(*add_unit_cmd.split())
+    return_code, _, std_err = await ops_test.juju(*add_unit_cmd.split())
     assert return_code == 0, (
-        f"Failed to add unit with storages {data_storage_id} and {archive_storage_id}"
+        f"Failed to add unit with storages {data_storage_id} and {archive_storage_id}: {std_err}"
     )
 
     new_unit = ops_test.model.applications[app].units[-1]
@@ -145,8 +145,8 @@ async def test_attach_storage_after_scale_to_zero(ops_test: OpsTest) -> None:
         add_unit_cmd = (
             f"add-unit {app} --model={ops_test.model.info.name} --attach-storage={storage_id}"
         )
-        return_code, _, _ = await ops_test.juju(*add_unit_cmd.split())
-        assert return_code == 0, f"Failed to add unit with storage {storage_id}"
+        return_code, _, std_err = await ops_test.juju(*add_unit_cmd.split())
+        assert return_code == 0, f"Failed to add unit with storage {storage_id}: {std_err}"
 
     await wait_until(ops_test, apps=[app], wait_for_exact_units=len(storage_ids), idle_period=120)
 

--- a/tests/integration/ha/test_storage_reuse.py
+++ b/tests/integration/ha/test_storage_reuse.py
@@ -138,6 +138,8 @@ async def test_attach_storage_after_scale_to_zero(ops_test: OpsTest) -> None:
         # if the cluster member cannot be removed immediately, the `storage_detaching` hook might fail temporarily
         raise_on_error=False,
         timeout=1000,
+        # give Juju some time to release the storage volumes
+        idle_period=60,
     )
 
     # scale up again re-attaching the storage

--- a/tests/spread/test_storage_reuse.py/task.yaml
+++ b/tests/spread/test_storage_reuse.py/task.yaml
@@ -2,8 +2,8 @@ summary: test_storage_reuse.py
 environment:
   TEST_MODULE: ha/test_storage_reuse.py
 systems:
-  - self-hosted-linux-amd64-noble-medium
-  - self-hosted-linux-arm64-noble-medium
+  - self-hosted-linux-amd64-noble-large
+  - self-hosted-linux-arm64-noble-large
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:


### PR DESCRIPTION
This PR improves the stability of integration tests:

`test_disaster_recovery.py`:
- adjust test execution order
- do not scale up before running `rebuild-cluster` on healthy cluster

`test_storage_reuse.py`:
- execute on large runner
- increase `idle_period` before reattaching storage volumes
- improve logging in case of errors