### PR TITLE
[DPE-7524] - Refactor detecting certificate type

### DIFF
--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -101,7 +101,6 @@ class TLSEvents(Object):
                     common_name=common_name,
                     sans_ip=self.charm.tls_manager.get_sans_ip(TLSType.PEER),
                     sans_dns=frozenset({self.charm.unit.name, host_mapping["hostname"]}),
-                    organization=TLSType.PEER.value,
                 ),
             ],
             private_key=peer_private_key,
@@ -115,7 +114,6 @@ class TLSEvents(Object):
                     common_name=common_name,
                     sans_ip=self.charm.tls_manager.get_sans_ip(TLSType.CLIENT),
                     sans_dns=frozenset({self.charm.unit.name, host_mapping["hostname"]}),
-                    organization=TLSType.CLIENT.value,
                 ),
             ],
             private_key=client_private_key,
@@ -165,26 +163,30 @@ class TLSEvents(Object):
             return
 
         cert = event.certificate
-        cert_type = TLSType(cert.organization)
+
+        client_certificates, client_private_key = (
+            self.client_certificate.get_assigned_certificates()
+        )
+        peer_certificates, peer_private_key = self.peer_certificate.get_assigned_certificates()
+
+        if client_certificates and client_certificates[0].certificate == cert:
+            cert_type = TLSType.CLIENT
+            cert = client_certificates[0]
+            private_key = client_private_key
+            tls_state = self.charm.state.unit_server.tls_client_state
+            tls_ca_rotation_state = self.charm.state.unit_server.tls_client_ca_rotation_state
+        elif peer_certificates and peer_certificates[0].certificate == cert:
+            cert_type = TLSType.PEER
+            cert = peer_certificates[0]
+            private_key = peer_private_key
+            tls_state = self.charm.state.unit_server.tls_peer_state
+            tls_ca_rotation_state = self.charm.state.unit_server.tls_peer_ca_rotation_state
+        else:
+            logger.error(f"Received certificate does not match any assigned certificates: {cert}")
+            event.defer()
+            return
+
         logger.debug(f"Received certificate for {cert_type}")
-
-        relation_requirer = (
-            self.peer_certificate if cert_type == TLSType.PEER else self.client_certificate
-        )
-
-        certs, private_key = relation_requirer.get_assigned_certificates()
-        cert = certs[0]
-
-        tls_state = (
-            self.charm.state.unit_server.tls_peer_state
-            if cert_type == TLSType.PEER
-            else self.charm.state.unit_server.tls_client_state
-        )
-        tls_ca_rotation_state = (
-            self.charm.state.unit_server.tls_peer_ca_rotation_state
-            if cert_type == TLSType.PEER
-            else self.charm.state.unit_server.tls_client_ca_rotation_state
-        )
 
         if (
             tls_state == TLSState.TLS
@@ -211,7 +213,7 @@ class TLSEvents(Object):
                 return
 
         # write certificates to disk
-        self.charm.tls_manager.write_certificate(cert, private_key)  # type: ignore
+        self.charm.tls_manager.write_certificate(cert, private_key, cert_type)  # type: ignore
         # if there are client relations add their CAs to the trusted client CAs
         if cert_type == TLSType.CLIENT and tls_state == TLSState.TO_TLS:
             self.charm.tls_manager.update_cas(

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -183,7 +183,6 @@ class TLSEvents(Object):
             tls_ca_rotation_state = self.charm.state.unit_server.tls_peer_ca_rotation_state
         else:
             logger.error(f"Received certificate does not match any assigned certificates: {cert}")
-            event.defer()
             return
 
         logger.debug(f"Received certificate for {cert_type}")

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -42,16 +42,18 @@ class TLSManager:
             }
         )
 
-    def write_certificate(self, certificate: ProviderCertificate, private_key: PrivateKey) -> None:
+    def write_certificate(
+        self, certificate: ProviderCertificate, private_key: PrivateKey, cert_type: TLSType
+    ) -> None:
         """Write certificates to disk.
 
         Args:
             certificate (ProviderCertificate): The certificate.
             private_key (PrivateKey): The private key.
+            cert_type (TLSType): The certificate type (client or peer).
         """
         logger.debug("Writing certificates to disk")
         ca_cert = certificate.ca
-        cert_type = TLSType(certificate.certificate.organization)
         if cert_type == TLSType.CLIENT:
             certificate_path = self.workload.paths.tls.client_cert
             private_key_path = self.workload.paths.tls.client_key

--- a/tests/unit/test_external_client_relations.py
+++ b/tests/unit/test_external_client_relations.py
@@ -967,6 +967,8 @@ def test_etcd_rotates_ca(cluster_tls_context, mtls_cert):
 
         new_server_cert = MagicMock()
         new_server_cert.ca.raw = "new_test_ca_server"
+        cert = MagicMock()
+        new_server_cert.certificate = cert
 
         with (
             ctx(ctx.on.update_status(), state_out) as manager,
@@ -986,8 +988,6 @@ def test_etcd_rotates_ca(cluster_tls_context, mtls_cert):
         ):
             charm: EtcdOperatorCharm = manager.charm
             event = MagicMock(spec=CertificateAvailableEvent)
-            cert = MagicMock()
-            cert.organization = TLSType.CLIENT
             event.certificate = cert
             charm.tls_manager.set_ca_rotation_state(
                 TLSType.CLIENT, TLSCARotationState.NEW_CA_ADDED

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -118,7 +118,6 @@ def certificate_available_context():
     peer_csr = generate_csr(
         private_key=requirer_private_key,
         common_name="etcd-test-1",
-        organization=TLSType.PEER.value,
     )
     peer_certificate = generate_certificate(
         ca_private_key=provider_private_key,
@@ -137,7 +136,6 @@ def certificate_available_context():
     client_csr = generate_csr(
         private_key=requirer_private_key,
         common_name="etcd-test-1",
-        organization=TLSType.CLIENT.value,
     )
     client_certificate = generate_certificate(
         ca_private_key=provider_private_key,
@@ -386,7 +384,10 @@ def test_certificate_available_new_cluster(certificate_available_context):
 
             with patch(
                 "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
-                return_value=([peer_provider_certificate], requirer_private_key),
+                side_effect=[
+                    ([client_provider_certificate], requirer_private_key),
+                    ([peer_provider_certificate], requirer_private_key),
+                ],
             ):
                 event.certificate = peer_certificate
                 charm.tls_events._on_certificate_available(event)
@@ -452,7 +453,10 @@ def test_certificate_available_enabling_tls(certificate_available_context):
                 with (
                     patch(
                         "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
-                        return_value=([peer_provider_certificate], requirer_private_key),
+                        side_effect=[
+                            ([client_provider_certificate], requirer_private_key),
+                            ([peer_provider_certificate], requirer_private_key),
+                        ],
                     ),
                     patch(
                         "charm.EtcdOperatorCharm.rolling_restart",
@@ -558,7 +562,10 @@ def test_enabling_tls_one_restart(certificate_available_context):
                 with (
                     patch(
                         "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
-                        return_value=([peer_provider_certificate], requirer_private_key),
+                        side_effect=[
+                            ([client_provider_certificate], requirer_private_key),
+                            ([peer_provider_certificate], requirer_private_key),
+                        ],
                     ),
                     patch(
                         "charm.EtcdOperatorCharm.rolling_restart",
@@ -731,7 +738,10 @@ def test_certificate_expiration(certificate_available_context):
             ):
                 with patch(
                     "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
-                    return_value=([peer_provider_certificate], requirer_private_key),
+                    side_effect=[
+                        ([client_provider_certificate], requirer_private_key),
+                        ([peer_provider_certificate], requirer_private_key),
+                    ],
                 ):
                     charm.tls_manager.set_tls_state(TLSState.TLS, tls_type=TLSType.PEER)
                     charm.tls_manager.set_tls_state(TLSState.TLS, tls_type=TLSType.CLIENT)
@@ -1079,10 +1089,6 @@ def test_ca_peer_rotation(certificate_available_context):
     with (
         patch("managers.tls.TLSManager.load_trusted_ca", return_value=[]),
         patch("managers.tls.TLSManager.add_trusted_ca"),
-        patch(
-            "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
-            return_value=([peer_provider_certificate], requirer_private_key),
-        ),
         patch("managers.config.ConfigManager.set_config_properties"),
         patch("managers.cluster.ClusterManager.restart_member"),
         patch("workload.EtcdWorkload.write_file"),
@@ -1102,9 +1108,18 @@ def test_ca_peer_rotation(certificate_available_context):
             event.certificate = peer_certificate
 
             # detect new ca and store it
-            with patch(
-                "charm.EtcdOperatorCharm.rolling_restart",
-                lambda _, callback: charm._restart_ca_rotation(event),
+            with (
+                patch(
+                    "charm.EtcdOperatorCharm.rolling_restart",
+                    lambda _, callback: charm._restart_ca_rotation(event),
+                ),
+                patch(
+                    "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
+                    side_effect=[
+                        ([], requirer_private_key),
+                        ([peer_provider_certificate], requirer_private_key),
+                    ],
+                ),
             ):
                 charm.tls_events._on_certificate_available(event)
                 assert charm.state.unit_server.peer_cert_ready
@@ -1115,8 +1130,15 @@ def test_ca_peer_rotation(certificate_available_context):
                 )
                 event.defer.assert_called_once()
 
-            # Other units have not updated their certs
-            charm.tls_events._on_certificate_available(event)
+            with patch(
+                "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
+                side_effect=[
+                    ([], requirer_private_key),
+                    ([peer_provider_certificate], requirer_private_key),
+                ],
+            ):
+                # Other units have not updated their certs
+                charm.tls_events._on_certificate_available(event)
             assert (
                 charm.state.unit_server.tls_peer_ca_rotation_state
                 == TLSCARotationState.NEW_CA_ADDED
@@ -1148,6 +1170,13 @@ def test_ca_peer_rotation(certificate_available_context):
             patch("managers.tls.TLSManager.write_certificate") as write_certificate_mock,
             patch("charm.EtcdOperatorCharm.rolling_restart") as restart_mock,
             ctx(ctx.on.update_status(), state_out) as manager,
+            patch(
+                "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
+                side_effect=[
+                    ([], requirer_private_key),
+                    ([peer_provider_certificate], requirer_private_key),
+                ],
+            ),
         ):
             # state_out = manager.run()
             charm = manager.charm
@@ -1224,6 +1253,12 @@ def test_ca_peer_rotation(certificate_available_context):
             patch("workload.EtcdWorkload.remove_file"),
             patch("managers.tls.TLSManager.add_trusted_ca"),
             ctx(ctx.on.update_status(), state_out) as manager,
+            patch(
+                "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
+                side_effect=[
+                    ([peer_provider_certificate], requirer_private_key),
+                ],
+            ),
         ):
             charm = manager.charm
             state_out = manager.run()


### PR DESCRIPTION
This pull request refactors the TLS handling logic in the `EtcdOperatorCharm` by removing the reliance on the `organization` field in certificates and improving the certificate assignment logic. It also updates related unit tests to reflect these changes.

### Refactoring TLS handling logic:

* [`src/events/tls.py`](diffhunk://#diff-3dfb4a104b407f7d4b2e07795a63745a09cde228a8dbe86602e7b72ea600fbe4L104): Removed the use of the `organization` field to determine certificate type and replaced it with explicit checks against assigned certificates. Updated the `_on_certificate_available` method to handle certificates based on their assignment and added the `cert_type` parameter to the `write_certificate` method for clarity. [[1]](diffhunk://#diff-3dfb4a104b407f7d4b2e07795a63745a09cde228a8dbe86602e7b72ea600fbe4L104) [[2]](diffhunk://#diff-3dfb4a104b407f7d4b2e07795a63745a09cde228a8dbe86602e7b72ea600fbe4L118) [[3]](diffhunk://#diff-3dfb4a104b407f7d4b2e07795a63745a09cde228a8dbe86602e7b72ea600fbe4L168-R189) [[4]](diffhunk://#diff-3dfb4a104b407f7d4b2e07795a63745a09cde228a8dbe86602e7b72ea600fbe4L214-R216)

* [`src/managers/tls.py`](diffhunk://#diff-a2c036f44ae9bbab595aad84b23bc3106a342c5ab12f7b0cf3d26268b51cdc83L45-L54): Updated the `write_certificate` method to explicitly accept `cert_type` as an argument instead of deriving it from the `organization` field in the certificate.

### Updates to unit tests:

* [`tests/unit/test_external_client_relations.py`](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176R970-R971): Adjusted the `test_etcd_rotates_ca` test to remove references to the `organization` field and added new mocks for certificate handling. [[1]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176R970-R971) [[2]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L989-L990)

* [`tests/unit/test_tls.py`](diffhunk://#diff-a32fba3e75331a440e32977437daaa8d9c93cb87e72dc5f5e3a543794b0df51bL121): Refactored multiple test cases (`certificate_available_context`, `test_certificate_available_new_cluster`, `test_certificate_available_enabling_tls`, `test_enabling_tls_one_restart`, `test_certificate_expiration`, `test_ca_peer_rotation`) to replace `return_value` with `side_effect` for mocking certificate assignments and removed references to the `organization` field. This ensures tests align with the updated logic. [[1]](diffhunk://#diff-a32fba3e75331a440e32977437daaa8d9c93cb87e72dc5f5e3a543794b0df51bL121) [[2]](diffhunk://#diff-a32fba3e75331a440e32977437daaa8d9c93cb87e72dc5f5e3a543794b0df51bL140) [[3]](diffhunk://#diff-a32fba3e75331a440e32977437daaa8d9c93cb87e72dc5f5e3a543794b0df51bL389-R390) [[4]](diffhunk://#diff-a32fba3e75331a440e32977437daaa8d9c93cb87e72dc5f5e3a543794b0df51bL455-R459) [[5]](diffhunk://#diff-a32fba3e75331a440e32977437daaa8d9c93cb87e72dc5f5e3a543794b0df51bL561-R568) [[6]](diffhunk://#diff-a32fba3e75331a440e32977437daaa8d9c93cb87e72dc5f5e3a543794b0df51bL734-R744) [[7]](diffhunk://#diff-a32fba3e75331a440e32977437daaa8d9c93cb87e72dc5f5e3a543794b0df51bL1082-L1085) [[8]](diffhunk://#diff-a32fba3e75331a440e32977437daaa8d9c93cb87e72dc5f5e3a543794b0df51bL1105-R1122) [[9]](diffhunk://#diff-a32fba3e75331a440e32977437daaa8d9c93cb87e72dc5f5e3a543794b0df51bR1133-R1139) [[10]](diffhunk://#diff-a32fba3e75331a440e32977437daaa8d9c93cb87e72dc5f5e3a543794b0df51bR1173-R1179) [[11]](diffhunk://#diff-a32fba3e75331a440e32977437daaa8d9c93cb87e72dc5f5e3a543794b0df51bR1256-R1261)