### PR TITLE
[DPE-7733] fix TLS switchover

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -115,7 +115,7 @@ jobs:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
       - name: Run spread job
-        timeout-minutes: 180
+        timeout-minutes: 60
         id: spread
         # TODO: replace with `charmcraft test` when
         # https://github.com/canonical/charmcraft/issues/2105 and

--- a/src/charm.py
+++ b/src/charm.py
@@ -129,7 +129,11 @@ class EtcdOperatorCharm(ops.CharmBase):
         # write config and restart workload
         self.config_manager.set_config_properties()
         if not self.cluster_manager.restart_member():
-            raise HealthCheckFailedError("Failed to check health of the member after restart")
+            try:
+                self.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
+                raise HealthCheckFailedError("Failed to check health of the member after restart")
+            except CalledProcessError:
+                logger.warning("Health check failed, TLS client certificates expired")
 
     def _restart_enable_peer_tls(self, _) -> None:
         """Enable peer TLS."""
@@ -154,7 +158,11 @@ class EtcdOperatorCharm(ops.CharmBase):
         # write config and restart workload
         self.config_manager.set_config_properties()
         if not self.cluster_manager.restart_member(move_leader=False):
-            raise HealthCheckFailedError("Failed to check health of the member after restart")
+            try:
+                self.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
+                raise HealthCheckFailedError("Failed to check health of the member after restart")
+            except CalledProcessError:
+                logger.warning("Health check failed, TLS client certificates expired")
 
     def _restart_disable_client_tls(self, _) -> None:
         """Disable client TLS."""
@@ -179,7 +187,11 @@ class EtcdOperatorCharm(ops.CharmBase):
         # write config and restart workload
         self.config_manager.set_config_properties()
         if not self.cluster_manager.restart_member(move_leader=False):
-            raise HealthCheckFailedError("Failed to check health of the member after restart")
+            try:
+                self.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
+                raise HealthCheckFailedError("Failed to check health of the member after restart")
+            except CalledProcessError:
+                logger.warning("Health check failed, TLS client certificates expired")
 
     def _restart_disable_peer_tls(self, _) -> None:
         """Disable peer TLS."""
@@ -208,7 +220,11 @@ class EtcdOperatorCharm(ops.CharmBase):
         # write config and restart workload
         self.config_manager.set_config_properties()
         if not self.cluster_manager.restart_member(move_leader=False):
-            raise HealthCheckFailedError("Failed to check health of the member after restart")
+            try:
+                self.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
+                raise HealthCheckFailedError("Failed to check health of the member after restart")
+            except CalledProcessError:
+                logger.warning("Health check failed, TLS client certificates expired")
 
     def _restart_ca_rotation(self, _) -> None:
         """Restart callback for CA rotation."""

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -214,15 +214,14 @@ class EtcdEvents(Object):
             logger.info(f"New ip address: {ip_address}")
             self.charm.state.unit_server.update({"private_ip": ip_address})
 
-            # update cluster configuration
-            self.charm.cluster_manager.broadcast_peer_url(self.charm.state.unit_server.peer_url)
-            self.charm.config_manager.set_config_properties()
-
             # we need to update the client-urls by restarting etcd
+            self.charm.config_manager.set_config_properties()
             # after ip change, this member is unavailable, no need to acquire restart lock
             if not self.charm.cluster_manager.restart_member(move_leader=False):
                 raise HealthCheckFailedError("Failed to check health of the member after restart")
 
+            # update cluster configuration
+            self.charm.cluster_manager.broadcast_peer_url(self.charm.state.unit_server.peer_url)
             if self.charm.unit.is_leader():
                 self.charm.cluster_manager.update_cluster_member_state()
 

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -179,7 +179,6 @@ class TLSEvents(Object):
             logger.error(
                 f"No assigned certificate found for the received certificate {event.certificate}"
             )
-            event.defer()
             return
 
         tls_state = (

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -179,6 +179,7 @@ class TLSEvents(Object):
             logger.error(
                 f"No assigned certificate found for the received certificate {event.certificate}"
             )
+            event.defer()
             return
 
         tls_state = (

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -172,8 +172,14 @@ class TLSEvents(Object):
             self.peer_certificate if cert_type == TLSType.PEER else self.client_certificate
         )
 
-        certs, private_key = relation_requirer.get_assigned_certificates()
-        cert = certs[0]
+        try:
+            certs, private_key = relation_requirer.get_assigned_certificates()
+            cert = certs[0]
+        except IndexError:
+            logger.error(
+                f"No assigned certificate found for the received certificate {event.certificate}"
+            )
+            return
 
         tls_state = (
             self.charm.state.unit_server.tls_peer_state

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -169,19 +169,25 @@ class TLSEvents(Object):
         )
         peer_certificates, peer_private_key = self.peer_certificate.get_assigned_certificates()
 
-        if client_certificates and client_certificates[0].certificate == cert:
-            cert_type = TLSType.CLIENT
-            cert = client_certificates[0]
-            private_key = client_private_key
-            tls_state = self.charm.state.unit_server.tls_client_state
-            tls_ca_rotation_state = self.charm.state.unit_server.tls_client_ca_rotation_state
-        elif peer_certificates and peer_certificates[0].certificate == cert:
-            cert_type = TLSType.PEER
-            cert = peer_certificates[0]
-            private_key = peer_private_key
-            tls_state = self.charm.state.unit_server.tls_peer_state
-            tls_ca_rotation_state = self.charm.state.unit_server.tls_peer_ca_rotation_state
-        else:
+        try:
+            if client_certificates and client_certificates[0].certificate == cert:
+                cert_type = TLSType.CLIENT
+                cert = client_certificates[0]
+                private_key = client_private_key
+                tls_state = self.charm.state.unit_server.tls_client_state
+                tls_ca_rotation_state = self.charm.state.unit_server.tls_client_ca_rotation_state
+            elif peer_certificates and peer_certificates[0].certificate == cert:
+                cert_type = TLSType.PEER
+                cert = peer_certificates[0]
+                private_key = peer_private_key
+                tls_state = self.charm.state.unit_server.tls_peer_state
+                tls_ca_rotation_state = self.charm.state.unit_server.tls_peer_ca_rotation_state
+            else:
+                logger.error(
+                    f"Received certificate does not match any assigned certificates: {cert}"
+                )
+                return
+        except IndexError:
             logger.error(f"Received certificate does not match any assigned certificates: {cert}")
             return
 

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -121,7 +121,7 @@ class ClusterManager:
         client = EtcdClient(
             username=self.admin_user,
             password=self.admin_password,
-            client_url=",".join(e for e in self.cluster_endpoints),
+            client_url=self.state.unit_server.client_url,
         )
 
         member_list = client.member_list()
@@ -150,7 +150,7 @@ class ClusterManager:
         client = EtcdClient(
             username=self.admin_user,
             password=self.admin_password,
-            client_url=",".join(e for e in self.cluster_endpoints),
+            client_url=self.state.unit_server.client_url,
         )
         client.broadcast_peer_url(self.member.id, peer_urls)
 

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -258,9 +258,9 @@ async def test_ca_rotation_by_expiration(ops_test: OpsTest) -> None:
     )
     assert current_client_certificate, "Failed to get the current client certificate"
 
-    logger.info("Waiting ~6m for expiration of certificates - renewed certs will have a new CA")
-    # 6m + 30s for renewal to start
-    time.sleep(390)
+    logger.info("Waiting ~5.4m for expiration of certificates - renewed certs will have a new CA")
+    # the juju secret expires at 90% of the certificate validity; 360s * 0.9 = 324s
+    time.sleep(330)
     await wait_until(
         ops_test,
         apps=[APP_NAME, TLS_NAME],

--- a/tests/spread/test_ca_rotation.py/task.yaml
+++ b/tests/spread/test_ca_rotation.py/task.yaml
@@ -2,8 +2,8 @@ summary: test_ca_rotation.py
 environment:
   TEST_MODULE: tls/test_ca_rotation.py
 systems:
-  - self-hosted-linux-amd64-noble-medium
-  - self-hosted-linux-arm64-noble-medium
+  - self-hosted-linux-amd64-noble-large
+  - self-hosted-linux-arm64-noble-large
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:


### PR DESCRIPTION
**Issue**

During the TLS switchover for client connections, it might happen that the operator tries to connect with TLS to etcd servers without TLS (or vice versa). This can happen due to a mismatch between:
- the client TLS state of another server in the databag at the beginning of the current event hook
- the actual TLS state of that server at the time an `etcdctl` command is executed by the operator code

If that server has restarted and changed client TLS mode during the event execution, the connection from operator code might fail.

This behavior mostly happens when the operator tries to update the peer url of it's local etcd server when switching TLS mode. It can be seen in various CI runs, for example [here](https://github.com/canonical/charmed-etcd-operator/actions/runs/16406465883/job/46361823833#step:13:1172) and [here](https://github.com/canonical/charmed-etcd-operator/actions/runs/16432100325/job/46435494512#step:13:2696) and [here](https://github.com/canonical/charmed-etcd-operator/actions/runs/16432100325/job/46435494535#step:13:3137). To mitigate the risk of failed connections, it would be better to only execute `etcdctl` commands against the local etcd server when updating the peer url settings.

**Solution**

This PR changes the behavior of the following methods to only execute the command against the local etcd server instead of all cluster endpoints:
- `cluster_manager.member`
- `cluster_manager.broadcast_peer_url()`

This reduces the risk of errors for the operator code in situations where a) client TLS mode is switched over or b) network disruptions happen.

Due to the changed behavior, it is required to rearrange the operations executed after a change of IP address (`config_changed`), because the peer url can only be updated against the local server after the server has been restarted and picked up its new IP address (it happened before the restart until this PR).

**Other changes:**
- add error handling for `certificate_available` event in case it is not possible to get the assigned certificates; this occasionally fails in integration tests, as can be seen  [here](https://github.com/canonical/charmed-etcd-operator/actions/runs/16406465883/job/46361823622#step:13:19668)
- while working on it: minor adjustments to integration test for `ca_rotation`: 
  - less waiting time because secret expiration for expiring certificates now already happens before the actual expiration (see: [secret expiration time in TLS lib](https://github.com/canonical/charmed-etcd-operator/blob/3.6/edge/lib/charms/tls_certificates_interface/v4/tls_certificates.py#L1202-L1204))
  - running on large runner (for performance reasons)