### PR TITLE
chore: fixes detected with k8s integration

### DIFF
--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -30,6 +30,7 @@ from common.exceptions import (
 )
 from common.secrets import get_secret_from_id
 from literals import (
+    CLIENT_PORT,
     DATA_STORAGE,
     DATABASE_DIR,
     INTERNAL_USER,
@@ -193,7 +194,10 @@ class EtcdEvents(Object):
             event.defer()
             return
 
-        if not self.charm.workload.alive():
+        if self.charm.workload.alive():
+            logger.info("Workload started successfully. Opening client port")
+            self.charm.unit.open_port("tcp", CLIENT_PORT)
+        else:
             self.charm.set_status(Status.SERVICE_NOT_RUNNING)
 
     def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:

--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -141,6 +141,10 @@ class ExternalClientsManager:
         server_ca = self.state.tls_client_certificate.ca.raw
 
         for relation in self.state.etcd_provides.relations:
+            if not self.state.etcd_provides.fetch_relation_field(relation.id, "prefix"):
+                # Skip relations that are not ready yet
+                continue
+
             relation_data = self.state.etcd_provides.fetch_my_relation_data(
                 [relation.id], ["uris", "endpoints", "tls-ca", "version"]
             )[relation.id]

--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -144,8 +144,10 @@ class ExternalClientsManager:
         server_ca = self.state.tls_client_certificate.ca.raw
 
         for relation in self.state.etcd_provides.relations:
-            if not self.state.etcd_provides.fetch_relation_field(relation.id, "prefix"):
-                # Skip relations that have not requested a prefix yet
+            if not self.state.etcd_provides.fetch_relation_field(
+                relation.id, "prefix"
+            ) or not self.state.etcd_provides.fetch_relation_field(relation.id, "mtls-cert"):
+                # Skip relations with invalid paylods
                 continue
 
             relation_data = self.state.etcd_provides.fetch_my_relation_data(

--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -147,7 +147,8 @@ class ExternalClientsManager:
             if not self.state.etcd_provides.fetch_relation_field(
                 relation.id, "prefix"
             ) or not self.state.etcd_provides.fetch_relation_field(relation.id, "mtls-cert"):
-                # Skip relations with invalid paylods
+                # Skip relations with invalid payloads
+                logger.warning(f"Skipping relation {relation.id} with invalid payloads.")
                 continue
 
             relation_data = self.state.etcd_provides.fetch_my_relation_data(

--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -13,7 +13,7 @@ from cryptography import x509
 
 from core.cluster import ClusterState
 from core.workload import WorkloadBase
-from literals import CLIENT_PORT, SUBSTRATES, Status
+from literals import CLIENT_PORT, SUBSTRATES, Status, TLSState
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +132,10 @@ class ExternalClientsManager:
             uri.split("=")[0] for uri in self.state.cluster.cluster_members.split(",")
         }
         cluster_servers = {
-            server for server in self.state.servers if server.member_name in cluster_server_names
+            server
+            for server in self.state.servers
+            if server.member_name in cluster_server_names
+            and server.tls_client_state == TLSState.TLS
         }
 
         uris = {server.client_url for server in cluster_servers}

--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -145,7 +145,7 @@ class ExternalClientsManager:
 
         for relation in self.state.etcd_provides.relations:
             if not self.state.etcd_provides.fetch_relation_field(relation.id, "prefix"):
-                # Skip relations that are not ready yet
+                # Skip relations that have not requested a prefix yet
                 continue
 
             relation_data = self.state.etcd_provides.fetch_my_relation_data(

--- a/tests/unit/test_external_client_relations.py
+++ b/tests/unit/test_external_client_relations.py
@@ -155,7 +155,7 @@ def test_add_ecr_new_user_leader(cluster_tls_context, mtls_cert):
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
             "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
-            "provided-secrets": '["mtls-cert"]'
+            "provided-secrets": '["mtls-cert"]',
         },
     )
 
@@ -933,7 +933,7 @@ def test_etcd_rotates_ca(cluster_tls_context, mtls_cert):
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
             "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
-            "provided-secrets": '["mtls-cert"]'
+            "provided-secrets": '["mtls-cert"]',
         },
     )
 
@@ -1015,7 +1015,7 @@ def test_etcd_updates_endpoints(cluster_tls_context, mtls_cert):
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
             "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
-            "provided-secrets": '["mtls-cert"]'
+            "provided-secrets": '["mtls-cert"]',
         },
     )
 
@@ -1095,7 +1095,7 @@ def test_etcd_updates_version(cluster_tls_context, mtls_cert):
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
             "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
-            "provided-secrets": '["mtls-cert"]'
+            "provided-secrets": '["mtls-cert"]',
         },
     )
 

--- a/tests/unit/test_external_client_relations.py
+++ b/tests/unit/test_external_client_relations.py
@@ -154,7 +154,8 @@ def test_add_ecr_new_user_leader(cluster_tls_context, mtls_cert):
         remote_app_data={
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
-            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "mtls-cert"]',
+            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
+            "provided-secrets": '["mtls-cert"]'
         },
     )
 
@@ -931,7 +932,8 @@ def test_etcd_rotates_ca(cluster_tls_context, mtls_cert):
         remote_app_data={
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
-            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "mtls-cert"]',
+            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
+            "provided-secrets": '["mtls-cert"]'
         },
     )
 
@@ -1012,7 +1014,8 @@ def test_etcd_updates_endpoints(cluster_tls_context, mtls_cert):
         remote_app_data={
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
-            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "mtls-cert"]',
+            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
+            "provided-secrets": '["mtls-cert"]'
         },
     )
 
@@ -1091,7 +1094,8 @@ def test_etcd_updates_version(cluster_tls_context, mtls_cert):
         remote_app_data={
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
-            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "mtls-cert"]',
+            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
+            "provided-secrets": '["mtls-cert"]'
         },
     )
 


### PR DESCRIPTION
* [`src/events/etcd.py`](diffhunk://#diff-4d4b45129d72bf79a08e70009a59f4ebe0a016b4727117155249c864ae4a1b49L196-R200): Added logic to open the client port (`CLIENT_PORT`) when the workload starts successfully, along with a corresponding log message. 

* [`src/managers/external_clients.py`](diffhunk://#diff-7cf18beef6c6df0f0e1a46e25a3b1bdb9aec8f5a433fb89bd09549560bfca7bfL135-R138): Updated the `update_client_relations_data` method to filter cluster servers based on their `tls_client_state`, ensuring only servers with `TLSState.TLS` are included. 

* [`src/managers/external_clients.py`](diffhunk://#diff-7cf18beef6c6df0f0e1a46e25a3b1bdb9aec8f5a433fb89bd09549560bfca7bfR147-R150): Added a check to skip relations that do not have the "prefix" and "mtls-cert" fields set, ensuring that only fully initialised relations are processed in the `update_client_relations_data` method.
