### PR TITLE
[DPE-7630] make leader/timeout parameters configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,3 +19,17 @@ options:
     type: secret
     description: |
       A Juju secret URI of a secret containing the private key for client-to-server TLS certificates.
+  
+  election-timeout:
+    type: int
+    default: 1000
+    description: How long, in milliseconds, a follower node will go without hearing a heartbeat before attempting to become leader itself.
+      The value should be at least 10x the value of <heartbeat-interval>, and must not exceed 50000.
+
+  heartbeat-interval:
+    type: int
+    default: 100
+    description: The frequency, in milliseconds, with which the leader will notify followers that it is still the leader. 
+      For best practices, the parameter should be set around round-trip time between members.
+      The value must be between 10 and 5000 at most.
+

--- a/src/charm.py
+++ b/src/charm.py
@@ -274,6 +274,10 @@ class EtcdOperatorCharm(ops.CharmBase):
         for status in self.cluster_manager.compute_component_status():
             event.add_status(status.value.status)
 
+        # compute config status
+        for status in self.config_manager.compute_component_status():
+            event.add_status(status.value.status)
+
         # compute TLS status
         for status in self.tls_manager.compute_component_status():
             event.add_status(status.value.status)

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -11,7 +11,7 @@ import string
 import subprocess
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import List
+from typing import Any, Dict, List
 
 from literals import CONFIG_FILE, TLS_ROOT_DIR
 
@@ -94,6 +94,18 @@ class WorkloadBase(ABC):
         Args:
             content (str): Content to write to the file.
             file (str): Path to the file.
+        """
+        pass
+
+    @abstractmethod
+    def load_yaml_file(self, file: str) -> Dict[str, Any]:
+        """Read yaml content from a file.
+
+        Args:
+            file (str): Path to the file.
+
+        Returns:
+            The content of a YAML file as a dict.
         """
         pass
 

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -196,7 +196,7 @@ class EtcdEvents(Object):
         if not self.charm.workload.alive():
             self.charm.set_status(Status.SERVICE_NOT_RUNNING)
 
-    def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:
+    def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:  # noqa: C901
         """Handle config_changed event."""
         if (
             self.charm.state.cluster.is_restore_in_progress
@@ -238,6 +238,13 @@ class EtcdEvents(Object):
 
         if tls_client_private_key_id := self.charm.config.get(TLS_CLIENT_PRIVATE_KEY_CONFIG):
             self.update_private_key(tls_client_private_key_id)
+
+        if (
+            self.charm.config_manager.tuning_parameters_valid
+            and self.charm.config_manager.requires_restart()
+        ):
+            # apply config and initiate restart
+            self.charm.rolling_restart()
 
         if not self.charm.unit.is_leader():
             return

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -240,7 +240,7 @@ class EtcdEvents(Object):
             self.update_private_key(tls_client_private_key_id)
 
         if (
-            self.charm.config_manager.tuning_parameters_valid
+            self.charm.config_manager.are_tuning_parameters_valid()
             and self.charm.config_manager.requires_restart()
         ):
             # apply config and initiate restart

--- a/src/literals.py
+++ b/src/literals.py
@@ -47,6 +47,9 @@ CLIENT_TLS_RELATION_NAME = "client-certificates"
 TLS_PEER_PRIVATE_KEY_CONFIG = "tls-peer-private-key"
 TLS_CLIENT_PRIVATE_KEY_CONFIG = "tls-client-private-key"
 
+ELECTION_TIMEOUT_CONFIG = "election-timeout"
+HEARTBEAT_INTERVAL_CONFIG = "heartbeat-interval"
+
 S3_RELATION_NAME = "s3-credentials"
 AZURE_RELATION_NAME = "azure-credentials"
 
@@ -141,6 +144,12 @@ class Status(Enum):
             "TLS peer certificates expiring soon. Please ensure new certificates are provided."
         ),
         "WARNING",
+    )
+    TUNING_CONFIG_INVALID = StatusLevel(
+        BlockedStatus(
+            "Invalid values set for the config options: 'election-timeout', 'heartbeat-interval'"
+        ),
+        "ERROR",
     )
     SERVICE_INSTALLING = StatusLevel(MaintenanceStatus("Installing etcd..."), "DEBUG")
     SERVICE_STARTING = StatusLevel(MaintenanceStatus("Waiting for etcd to start..."), "DEBUG")

--- a/src/literals.py
+++ b/src/literals.py
@@ -47,9 +47,6 @@ CLIENT_TLS_RELATION_NAME = "client-certificates"
 TLS_PEER_PRIVATE_KEY_CONFIG = "tls-peer-private-key"
 TLS_CLIENT_PRIVATE_KEY_CONFIG = "tls-client-private-key"
 
-ELECTION_TIMEOUT_CONFIG = "election-timeout"
-HEARTBEAT_INTERVAL_CONFIG = "heartbeat-interval"
-
 S3_RELATION_NAME = "s3-credentials"
 AZURE_RELATION_NAME = "azure-credentials"
 
@@ -213,3 +210,10 @@ class RestoreStep(Enum):
     RESTORE = "restore_backup"
     START = "restart_workload"
     COMPLETED = "completed"
+
+
+class TuningOptions(Enum):
+    """Configuration options for tuning etcd performance."""
+
+    ELECTION_TIMEOUT_CONFIG = "election-timeout"
+    HEARTBEAT_INTERVAL_CONFIG = "heartbeat-interval"

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -85,6 +85,11 @@ class ConfigManager:
             f"http://{self.state.unit_server.ip}:{METRICS_PORT}"
         )
 
+        if self.tuning_parameters_valid:
+            for option in TuningOptions:
+                # take over the config value set by users
+                config_properties[option.value] = self.config.get(option.value)
+
         if self.state.unit_server.tls_client_state in [TLSState.TO_TLS, TLSState.TLS]:
             # replace http with https in listen-client-urls and advertise-client-urls
             config_properties["listen-client-urls"] = self.state.unit_server.client_url.replace(

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -85,7 +85,7 @@ class ConfigManager:
             f"http://{self.state.unit_server.ip}:{METRICS_PORT}"
         )
 
-        if self.tuning_parameters_valid:
+        if self.are_tuning_parameters_valid():
             for option in TuningOptions:
                 # take over the config value set by users
                 config_properties[option.value] = self.config.get(option.value)
@@ -155,8 +155,7 @@ class ConfigManager:
             file=self.config_file,
         )
 
-    @property
-    def tuning_parameters_valid(self) -> bool:
+    def are_tuning_parameters_valid(self) -> bool:
         """Validate configuration values for tuning parameters.
 
         Returns:
@@ -191,7 +190,7 @@ class ConfigManager:
         """Compute the Cluster manager's statuses."""
         status_list = []
 
-        if not self.tuning_parameters_valid:
+        if not self.are_tuning_parameters_valid():
             status_list.append(Status.TUNING_CONFIG_INVALID)
 
         return status_list

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -6,13 +6,22 @@
 
 import logging
 from pathlib import Path
+from typing import List
 
 import yaml
 from ops.model import ConfigData
 
 from core.cluster import ClusterState
 from core.workload import WorkloadBase
-from literals import DATABASE_DIR, METRICS_PORT, RestoreStep, TLSState
+from literals import (
+    DATABASE_DIR,
+    ELECTION_TIMEOUT_CONFIG,
+    HEARTBEAT_INTERVAL_CONFIG,
+    METRICS_PORT,
+    RestoreStep,
+    Status,
+    TLSState,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -140,6 +149,32 @@ class ConfigManager:
             content=self.config_properties,
             file=self.config_file,
         )
+
+    @property
+    def tuning_parameters_valid(self) -> bool:
+        """Validate configuration values for tuning parameters.
+
+        Returns:
+            bool: True if tuning config values are valid, False if invalid.
+        """
+        if heartbeat_interval := self.config.get(HEARTBEAT_INTERVAL_CONFIG):
+            if heartbeat_interval < 10 or heartbeat_interval > 5000:
+                return False
+
+        if election_timeout := self.config.get(ELECTION_TIMEOUT_CONFIG):
+            if election_timeout < heartbeat_interval * 10 or election_timeout > 50000:
+                return False
+
+        return True
+
+    def compute_component_status(self) -> List[Status]:
+        """Compute the Cluster manager's statuses."""
+        status_list = []
+
+        if not self.tuning_parameters_valid:
+            status_list.append(Status.TUNING_CONFIG_INVALID)
+
+        return status_list
 
     def _get_cluster_endpoints(self) -> str:
         """Concatenate peer-urls of all cluster members.

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -14,13 +14,13 @@ from ops.model import ConfigData
 from core.cluster import ClusterState
 from core.workload import WorkloadBase
 from literals import (
+    CONFIG_FILE,
     DATABASE_DIR,
-    ELECTION_TIMEOUT_CONFIG,
-    HEARTBEAT_INTERVAL_CONFIG,
     METRICS_PORT,
     RestoreStep,
     Status,
     TLSState,
+    TuningOptions,
 )
 
 logger = logging.getLogger(__name__)
@@ -157,15 +157,30 @@ class ConfigManager:
         Returns:
             bool: True if tuning config values are valid, False if invalid.
         """
-        if heartbeat_interval := self.config.get(HEARTBEAT_INTERVAL_CONFIG):
+        if heartbeat_interval := self.config.get(TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value):
             if heartbeat_interval < 10 or heartbeat_interval > 5000:
                 return False
 
-        if election_timeout := self.config.get(ELECTION_TIMEOUT_CONFIG):
+        if election_timeout := self.config.get(TuningOptions.ELECTION_TIMEOUT_CONFIG.value):
             if election_timeout < heartbeat_interval * 10 or election_timeout > 50000:
                 return False
 
         return True
+
+    def requires_restart(self) -> bool:
+        """Check current configuration and determine if restart is required."""
+        try:
+            current_config_values = self.workload.load_yaml_file(CONFIG_FILE)
+        except yaml.YAMLError as e:
+            logger.error(f"Error loading current config: {e}")
+            return False
+
+        for option in TuningOptions:
+            if self.config.get(option.value) != current_config_values[option.value]:
+                logger.info(f"Config change to {option.value} requires restart")
+                return True
+
+        return False
 
     def compute_component_status(self) -> List[Status]:
         """Compute the Cluster manager's statuses."""

--- a/src/workload.py
+++ b/src/workload.py
@@ -7,10 +7,12 @@
 import logging
 import platform
 import subprocess
+from os.path import exists
 from pathlib import Path
 from shutil import copyfile, rmtree
-from typing import List
+from typing import Any, Dict, List
 
+import yaml
 from charms.operator_libs_linux.v1.systemd import service_disable, service_enable
 from charms.operator_libs_linux.v2 import snap
 from tenacity import Retrying, retry, stop_after_attempt, wait_fixed
@@ -66,6 +68,14 @@ class EtcdWorkload(WorkloadBase):
         path = Path(file)
         path.parent.mkdir(exist_ok=True, parents=True)
         path.write_text(content)
+
+    @override
+    def load_yaml_file(self, file: str) -> Dict[str, Any]:
+        if not exists(file):
+            return {}
+
+        with open(file, "r") as f:
+            return yaml.safe_load(f)
 
     @override
     def stop(self) -> None:

--- a/tests/integration/ha/test_ha_on_rolling_restart.py
+++ b/tests/integration/ha/test_ha_on_rolling_restart.py
@@ -100,8 +100,8 @@ async def test_tuning_config_options(ops_test: OpsTest) -> None:
     # set tuning parameters to reasonable values in high-latency environments
     await ops_test.model.applications[app_name].set_config(
         {
-            TuningOptions.ELECTION_TIMEOUT_CONFIG.value: 5000,
-            TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value: 500,
+            TuningOptions.ELECTION_TIMEOUT_CONFIG.value: "5000",
+            TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value: "500",
         }
     )
 

--- a/tests/integration/ha/test_ha_on_rolling_restart.py
+++ b/tests/integration/ha/test_ha_on_rolling_restart.py
@@ -8,7 +8,7 @@ import pytest
 from juju.application import Application
 from pytest_operator.plugin import OpsTest
 
-from literals import INTERNAL_USER, PEER_RELATION, TuningOptions
+from literals import INTERNAL_USER, PEER_RELATION, Status, TuningOptions
 
 from ..helpers import (
     APP_NAME,
@@ -107,6 +107,40 @@ async def test_tuning_config_options(ops_test: OpsTest) -> None:
 
     # wait for the rolling restart to apply the config changes
     await wait_until(ops_test, apps=[app_name], wait_for_exact_units=NUM_UNITS)
+
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    stop_continuous_writes()
+    assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+
+@pytest.mark.abort_on_fail
+async def test_invalid_tuning_config_options(ops_test: OpsTest) -> None:
+    """Ensure the cluster keeps running with invalid tuning options."""
+    app_name = (await existing_app(ops_test)) or APP_NAME
+    await wait_until(ops_test, apps=[app_name], wait_for_exact_units=NUM_UNITS)
+
+    # start writing data to the cluster
+    endpoints = get_cluster_endpoints(ops_test, app_name)
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{app_name}.app")
+    password = secret.get(f"{INTERNAL_USER}-password")
+    start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+    # set tuning parameters to invalid values (election timeout must be >= 10x heartbeat interval)
+    await ops_test.model.applications[app_name].set_config(
+        {
+            TuningOptions.ELECTION_TIMEOUT_CONFIG.value: "4000",
+            TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value: "500",
+        }
+    )
+
+    await wait_until(
+        ops_test,
+        apps=[app_name],
+        apps_full_statuses={
+            APP_NAME: {"blocked": [Status.TUNING_CONFIG_INVALID.value.status.message]},
+        },
+        wait_for_exact_units=NUM_UNITS,
+    )
 
     assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
     stop_continuous_writes()

--- a/tests/integration/ha/test_ha_on_rolling_restart.py
+++ b/tests/integration/ha/test_ha_on_rolling_restart.py
@@ -8,7 +8,7 @@ import pytest
 from juju.application import Application
 from pytest_operator.plugin import OpsTest
 
-from literals import INTERNAL_USER, PEER_RELATION
+from literals import INTERNAL_USER, PEER_RELATION, TuningOptions
 
 from ..helpers import (
     APP_NAME,
@@ -79,6 +79,34 @@ async def test_disable_and_enable_peer_tls(ops_test: OpsTest) -> None:
     logger.info("Integrating peer-certificates relations")
     await ops_test.model.integrate(f"{app_name}:peer-certificates", TLS_NAME)
     await wait_until(ops_test, apps=[app_name], timeout=1000)
+
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    stop_continuous_writes()
+    assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+
+@pytest.mark.abort_on_fail
+async def test_tuning_config_options(ops_test: OpsTest) -> None:
+    """Tune the network latency parameters in etcd and ensure the cluster is available."""
+    app_name = (await existing_app(ops_test)) or APP_NAME
+    await wait_until(ops_test, apps=[app_name], wait_for_exact_units=NUM_UNITS)
+
+    # start writing data to the cluster
+    endpoints = get_cluster_endpoints(ops_test, app_name)
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{app_name}.app")
+    password = secret.get(f"{INTERNAL_USER}-password")
+    start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+    # set tuning parameters to reasonable values in high-latency environments
+    await ops_test.model.applications[app_name].set_config(
+        {
+            TuningOptions.ELECTION_TIMEOUT_CONFIG.value: 5000,
+            TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value: 500,
+        }
+    )
+
+    # wait for the rolling restart to apply the config changes
+    await wait_until(ops_test, apps=[app_name], wait_for_exact_units=NUM_UNITS)
 
     assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
     stop_continuous_writes()

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -58,6 +58,10 @@ async def test_build_and_deploy(charm: str, ops_test: OpsTest) -> None:
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000)
 
 
+# known-issue with self-hosted runners: `lxc config device set ... eth0 limits.priority=10`
+# command fails because of wrong kernel version
+# details see: https://warthogs.atlassian.net/browse/ISD-3026
+@pytest.mark.skip()
 @pytest.mark.abort_on_fail
 async def test_network_cut_on_raft_leader_without_ip_change(ops_test: OpsTest) -> None:
     """Make sure the cluster can self-heal and the unit reconfigures after network disconnect."""

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -58,10 +58,6 @@ async def test_build_and_deploy(charm: str, ops_test: OpsTest) -> None:
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000)
 
 
-# known-issue with self-hosted runners: `lxc config device set ... eth0 limits.priority=10`
-# command fails because of wrong kernel version
-# details see: https://warthogs.atlassian.net/browse/ISD-3026
-@pytest.mark.skip()
 @pytest.mark.abort_on_fail
 async def test_network_cut_on_raft_leader_without_ip_change(ops_test: OpsTest) -> None:
     """Make sure the cluster can self-heal and the unit reconfigures after network disconnect."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -25,6 +25,7 @@ from literals import (
     INTERNAL_USER_PASSWORD_CONFIG,
     PEER_RELATION,
     TLSState,
+    TuningOptions,
 )
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
@@ -565,7 +566,10 @@ def test_config_changed():
         leader=True,
     )
 
+    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+
     with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
         patch("subprocess.run"),
         patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
         patch("common.client.EtcdClient.broadcast_peer_url"),
@@ -575,6 +579,116 @@ def test_config_changed():
         state_out = ctx.run(ctx.on.config_changed(), state_in)
         secret_out = state_out.get_secret(label=f"{PEER_RELATION}.{APP_NAME}.app")
         assert secret_out.latest_content.get(f"{INTERNAL_USER}-password") == secret_value
+
+
+def test_set_config_options():
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_unit_data={"private_ip": "my_ip"},
+    )
+    ctx = testing.Context(EtcdOperatorCharm)
+
+    # happy path - leader
+    state_in = testing.State(
+        config={
+            TuningOptions.ELECTION_TIMEOUT_CONFIG.value: 5000,
+            TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value: 500,
+        },
+        relations={relation},
+        leader=True,
+    )
+
+    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
+    ):
+        ctx.run(ctx.on.config_changed(), state_in)
+        rolling_restart.assert_called_once()
+
+    # happy path - non-leader
+    state_in = testing.State(
+        config={
+            TuningOptions.ELECTION_TIMEOUT_CONFIG.value: 5000,
+            TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value: 500,
+        },
+        relations={relation},
+        leader=True,
+    )
+
+    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
+    ):
+        ctx.run(ctx.on.config_changed(), state_in)
+        rolling_restart.assert_called_once()
+
+    # config values are equal to current config -> no restart triggered
+    state_in = testing.State(
+        config={
+            TuningOptions.ELECTION_TIMEOUT_CONFIG.value: 5000,
+            TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value: 500,
+        },
+        relations={relation},
+        leader=True,
+    )
+
+    current_config_file = {"election-timeout": 5000, "heartbeat-interval": 500}
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
+    ):
+        ctx.run(ctx.on.config_changed(), state_in)
+        rolling_restart.assert_not_called()
+
+    # config values are invalid -> no restart triggered, blocked status
+    state_in = testing.State(
+        config={
+            TuningOptions.ELECTION_TIMEOUT_CONFIG.value: 100,
+            TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value: 100,
+        },
+        relations={relation},
+        leader=True,
+    )
+
+    current_config_file = {"election-timeout": 5000, "heartbeat-interval": 500}
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        rolling_restart.assert_not_called()
+        assert state_out.unit_status == ops.BlockedStatus(
+            "Invalid values set for the config options: 'election-timeout', 'heartbeat-interval'"
+        )
+
+    # config values are invalid -> no restart triggered, blocked status
+    state_in = testing.State(
+        config={
+            TuningOptions.ELECTION_TIMEOUT_CONFIG.value: 50001,
+            TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value: 100,
+        },
+        relations={relation},
+        leader=True,
+    )
+
+    current_config_file = {"election-timeout": 5000, "heartbeat-interval": 500}
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        rolling_restart.assert_not_called()
+        assert state_out.unit_status == ops.BlockedStatus(
+            "Invalid values set for the config options: 'election-timeout', 'heartbeat-interval'"
+        )
 
 
 def test_secret_changed():

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -782,6 +782,8 @@ def test_set_tls_private_key():
         {"private-key": private_key},
         label=TLS_PEER_PRIVATE_KEY_CONFIG,
     )
+    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+
     with (
         patch(
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4._cleanup_certificate_requests"
@@ -792,6 +794,7 @@ def test_set_tls_private_key():
         patch(
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4._find_available_certificates"
         ),
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
         patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
         patch("common.client.EtcdClient.broadcast_peer_url"),
         patch("workload.EtcdWorkload.write_file"),
@@ -947,6 +950,7 @@ def test_set_tls_private_key():
         {"private-key": private_key},
         label=TLS_CLIENT_PRIVATE_KEY_CONFIG,
     )
+    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
 
     with (
         patch(
@@ -958,6 +962,7 @@ def test_set_tls_private_key():
         patch(
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4._find_available_certificates"
         ),
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
     ):
         # Configure client private key
         state_in = testing.State(
@@ -1036,14 +1041,16 @@ def test_set_tls_private_key():
         config={TLS_CLIENT_PRIVATE_KEY_CONFIG: secret.id},
         secrets={secret},
     )
+    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
 
     with (
         patch(
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4._cleanup_certificate_requests"
         ) as cleanup,
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
     ):
         # Configure peer private key configured
-        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        ctx.run(ctx.on.config_changed(), state_in)
         cleanup.assert_not_called()
 
 


### PR DESCRIPTION
In high-latency network environments, it could happen that the fixed configuration values we currently use for `heartbeat-interval` and `election-timeout` cause many leader changes. Therefore we should make these values configurable to users.

**UI/UX changes:**
- introduce config options `election-timeout` and `heartbeat-interval`
- add a `BlockedStatus` in case the config options are set to invalid values

**Implementation:**
- add `compute_component_status()` method to the `ConfigManager`
- when running the `config_changed` hook, initiate a rolling restart if the configuration values are valid and different from what is currently configured
- add a `tuning_parameters_valid` property to the `ConfigManager`; this checks the validity of the config values and is used for the `config_changed` event as well as the status computation
- add a `requires_restart()` method to the `ConfigManager` which loads the current config file from the unit and checks if one of the tuning parameters was updated
- adjust the `config_properties()` method of the `ConfigManager` to only apply the config values if they are considered valid
- add a `load_yaml_file()` method to the `EtcdWorkload` class that can be used to load the current config file and returns a dictionary with the configuration parameters

**Architecture decisions:**
- config validation is done by a simple method in the `ConfigManager` instead of introducing a "structured config class" or config model; reasons: keep it simple, avoid possible future backwards incompatibilities for config validation
- config validation is executed (and thereby applied) whenever configuration is written to the unit; this helps to group restarts for different kind of changes (e.g. config change because of new ip address after network disruption + adjusted config values)
- `restart_required` validation happens against the current config file because there is no other way of querying the currently applied values for the tuning parameters (even though "live" query would be best e.g. via metrics, but this is not possible)

**Testing:**
- add unit testing for the `config_changed` event
- add integration testing to `test_ha_on_rolling_restart.py` to ensure the rolling restart is performed maintaining HA when updating these config values