### PR TITLE
Refactor external clients and TLS

### DIFF
--- a/src/common/certificates.py
+++ b/src/common/certificates.py
@@ -1,0 +1,54 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Utility functions related to certificates."""
+
+import logging
+
+from charms.tls_certificates_interface.v4.tls_certificates import Certificate
+from cryptography import x509
+
+logger = logging.getLogger(__name__)
+
+
+def leaf_certificate(certificate_chain: str) -> str:
+    """Extract the leaf certificate from a certificate chain.
+
+    Args:
+        certificate_chain (str): The certificate chain.
+
+    Returns:
+        str: The leaf certificate.
+    """
+    certificates = certificate_chain.split("-----END CERTIFICATE-----")
+    if not certificates or len(certificates) < 2:
+        raise ValueError("Invalid certificate chain provided.")
+    return certificates[0].strip() + "\n-----END CERTIFICATE-----"
+
+
+def is_leaf_certificate_valid(mtls_cert: str) -> bool:
+    """Validate the leaf certificate.
+
+    Args:
+        mtls_cert (str): The mtls chain.
+
+    Returns:
+        (bool): True if the certificate is not a CA.
+    """
+    leaf_cert = leaf_certificate(mtls_cert)
+    logger.debug(f"Leaf certificate is a CA? {Certificate.from_string(leaf_cert).is_ca}")
+    certificate = x509.load_pem_x509_certificate(data=leaf_cert.encode())
+    # check if the certificate is a CA
+    try:
+        basic_constraints = certificate.extensions.get_extension_for_class(
+            x509.BasicConstraints
+        ).value
+    except x509.ExtensionNotFound:
+        return False
+    # check if the certificate can sign other certificates
+    try:
+        key_usage = certificate.extensions.get_extension_for_class(x509.KeyUsage).value
+    except x509.ExtensionNotFound:
+        return not basic_constraints.ca
+
+    return not (key_usage.key_cert_sign or key_usage.crl_sign or basic_constraints.ca)

--- a/src/common/certificates.py
+++ b/src/common/certificates.py
@@ -5,7 +5,6 @@
 
 import logging
 
-from charms.tls_certificates_interface.v4.tls_certificates import Certificate
 from cryptography import x509
 
 logger = logging.getLogger(__name__)
@@ -36,7 +35,6 @@ def is_leaf_certificate_valid(mtls_cert: str) -> bool:
         (bool): True if the certificate is not a CA.
     """
     leaf_cert = leaf_certificate(mtls_cert)
-    logger.debug(f"Leaf certificate is a CA? {Certificate.from_string(leaf_cert).is_ca}")
     certificate = x509.load_pem_x509_certificate(data=leaf_cert.encode())
     # check if the certificate is a CA
     try:

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -30,6 +30,7 @@ from common.exceptions import (
 )
 from common.secrets import get_secret_from_id
 from literals import (
+    CLIENT_PORT,
     DATA_STORAGE,
     DATABASE_DIR,
     INTERNAL_USER,
@@ -193,7 +194,10 @@ class EtcdEvents(Object):
             event.defer()
             return
 
-        if not self.charm.workload.alive():
+        if self.charm.workload.alive():
+            logger.info("Workload started successfully. Opening client port")
+            self.charm.unit.open_port("tcp", CLIENT_PORT)
+        else:
             self.charm.set_status(Status.SERVICE_NOT_RUNNING)
 
     def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:

--- a/src/events/external_clients.py
+++ b/src/events/external_clients.py
@@ -198,6 +198,6 @@ class ExternalClientsEvents(Object):
         """Update the client truststore and Initiate a rolling restart of the cluster."""
         all_cas = self.charm.tls_manager.collect_client_cas()
         if all_cas != self.charm.tls_manager.load_trusted_ca(TLSType.CLIENT):
-            logger.debug("New CA detected, updating client truststore")
+            logger.debug("CAs have changed, updating client truststore")
             self.charm.tls_manager.update_cas(all_cas, TLSType.CLIENT)
             self.charm.rolling_restart()

--- a/src/events/external_clients.py
+++ b/src/events/external_clients.py
@@ -152,9 +152,6 @@ class ExternalClientsEvents(Object):
             logger.error("New user not created yet")
             event.defer()
             return
-        logger.debug(
-            f"ECR|{event.relation.id} updated with user {relation_managed_user} old_mtls_cert {event.old_mtls_cert} new_mtls_cert {event.mtls_cert}"
-        )
         self._update_client_truststore()
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:

--- a/src/events/external_clients.py
+++ b/src/events/external_clients.py
@@ -18,6 +18,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
 )
 from ops import Object, RelationBrokenEvent
 
+from common.certificates import is_leaf_certificate_valid
 from common.exceptions import EtcdUserManagementError
 from literals import (
     CERTIFICATE_TRANSFER_RELATION,
@@ -97,7 +98,7 @@ class ExternalClientsEvents(Object):
         )
 
         # validate leaf certificate
-        if not self.charm.external_clients_manager.is_leaf_certificate_valid(event.mtls_cert):
+        if not is_leaf_certificate_valid(event.mtls_cert):
             logger.error("Invalid end-entity certificate")
             # clean the old user if exists
             if old_common_name:
@@ -151,7 +152,9 @@ class ExternalClientsEvents(Object):
             logger.error("New user not created yet")
             event.defer()
             return
-
+        logger.debug(
+            f"ECR|{event.relation.id} updated with user {relation_managed_user} old_mtls_cert {event.old_mtls_cert} new_mtls_cert {event.mtls_cert}"
+        )
         self._update_client_truststore()
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
@@ -180,10 +183,7 @@ class ExternalClientsEvents(Object):
             event.defer()
             return
 
-        cas = self.certificate_transfer.get_all_certificates()
-        if self.certificate_transfer and self.charm.tls_manager.is_new_ca(
-            "\n".join(cas), TLSType.CLIENT
-        ):
+        if self.certificate_transfer.get_all_certificates():
             self._update_client_truststore()
 
     def _on_certificates_removed(self, event: CertificatesRemovedEvent) -> None:
@@ -199,7 +199,8 @@ class ExternalClientsEvents(Object):
 
     def _update_client_truststore(self) -> None:
         """Update the client truststore and Initiate a rolling restart of the cluster."""
-        self.charm.tls_manager.update_cas(
-            self.charm.tls_manager.collect_client_cas(), TLSType.CLIENT
-        )
-        self.charm.rolling_restart()
+        all_cas = self.charm.tls_manager.collect_client_cas()
+        if all_cas != self.charm.tls_manager.load_trusted_ca(TLSType.CLIENT):
+            logger.debug("New CA detected, updating client truststore")
+            self.charm.tls_manager.update_cas(all_cas, TLSType.CLIENT)
+            self.charm.rolling_restart()

--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -141,6 +141,10 @@ class ExternalClientsManager:
         server_ca = self.state.tls_client_certificate.ca.raw
 
         for relation in self.state.etcd_provides.relations:
+            if not self.state.etcd_provides.fetch_relation_field(relation.id, "prefix"):
+                # Skip relations that are not ready yet
+                continue
+
             relation_data = self.state.etcd_provides.fetch_my_relation_data(
                 [relation.id], ["uris", "endpoints", "tls-ca", "version"]
             )[relation.id]

--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -144,8 +144,10 @@ class ExternalClientsManager:
         server_ca = self.state.tls_client_certificate.ca.raw
 
         for relation in self.state.etcd_provides.relations:
-            if not self.state.etcd_provides.fetch_relation_field(relation.id, "prefix"):
-                # Skip relations that have not requested a prefix yet
+            if not self.state.etcd_provides.fetch_relation_field(
+                relation.id, "prefix"
+            ) or not self.state.etcd_provides.fetch_relation_field(relation.id, "mtls-cert"):
+                # Skip relations with invalid paylods
                 continue
 
             relation_data = self.state.etcd_provides.fetch_my_relation_data(

--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -147,7 +147,8 @@ class ExternalClientsManager:
             if not self.state.etcd_provides.fetch_relation_field(
                 relation.id, "prefix"
             ) or not self.state.etcd_provides.fetch_relation_field(relation.id, "mtls-cert"):
-                # Skip relations with invalid paylods
+                # Skip relations with invalid payloads
+                logger.warning(f"Skipping relation {relation.id} with invalid payloads.")
                 continue
 
             relation_data = self.state.etcd_provides.fetch_my_relation_data(

--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -13,7 +13,7 @@ from cryptography import x509
 
 from core.cluster import ClusterState
 from core.workload import WorkloadBase
-from literals import CLIENT_PORT, SUBSTRATES, Status
+from literals import CLIENT_PORT, SUBSTRATES, Status, TLSState
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +132,10 @@ class ExternalClientsManager:
             uri.split("=")[0] for uri in self.state.cluster.cluster_members.split(",")
         }
         cluster_servers = {
-            server for server in self.state.servers if server.member_name in cluster_server_names
+            server
+            for server in self.state.servers
+            if server.member_name in cluster_server_names
+            and server.tls_client_state == TLSState.TLS
         }
 
         uris = {server.client_url for server in cluster_servers}

--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -145,7 +145,7 @@ class ExternalClientsManager:
 
         for relation in self.state.etcd_provides.relations:
             if not self.state.etcd_provides.fetch_relation_field(relation.id, "prefix"):
-                # Skip relations that are not ready yet
+                # Skip relations that have not requested a prefix yet
                 continue
 
             relation_data = self.state.etcd_provides.fetch_my_relation_data(

--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -9,8 +9,8 @@ import logging
 from pathlib import Path
 
 from charms.tls_certificates_interface.v4.tls_certificates import Certificate
-from cryptography import x509
 
+from common.certificates import is_leaf_certificate_valid
 from core.cluster import ClusterState
 from core.workload import WorkloadBase
 from literals import CLIENT_PORT, SUBSTRATES, Status, TLSState
@@ -89,36 +89,6 @@ class ExternalClientsManager:
         cert = raw_cas[0].strip() + "\n-----END CERTIFICATE-----"
         return Certificate.from_string(cert).common_name
 
-    def is_leaf_certificate_valid(self, mtls_cert: str) -> bool:
-        """Validate the leaf certificate.
-
-        Args:
-            mtls_cert (str): The mtls chain.
-
-        Returns:
-            (bool): True if the certificate is not a CA.
-        """
-        # split the certificates by the end of the certificate marker and keep the marker in the cert
-        raw_cas = mtls_cert.split("-----END CERTIFICATE-----")
-        # add the marker back to the certificate
-        leaf_cert = raw_cas[0].strip() + "\n-----END CERTIFICATE-----"
-        logger.debug(f"Leaf certificate is a CA? {Certificate.from_string(leaf_cert).is_ca}")
-        certificate = x509.load_pem_x509_certificate(data=leaf_cert.encode())
-        # check if the certificate is a CA
-        try:
-            basic_constraints = certificate.extensions.get_extension_for_class(
-                x509.BasicConstraints
-            ).value
-        except x509.ExtensionNotFound:
-            return False
-        # check if the certificate can sign other certificates
-        try:
-            key_usage = certificate.extensions.get_extension_for_class(x509.KeyUsage).value
-        except x509.ExtensionNotFound:
-            return not basic_constraints.ca
-
-        return not (key_usage.key_cert_sign or key_usage.crl_sign or basic_constraints.ca)
-
     def update_client_relations_data(self, etcd_version: str) -> None:
         """Update the ECR data."""
         if not self.state.etcd_provides.relations:
@@ -176,7 +146,7 @@ class ExternalClientsManager:
             # for client relation created hook
             if not mtls_cert:
                 continue
-            if not self.is_leaf_certificate_valid(mtls_cert):
+            if not is_leaf_certificate_valid(mtls_cert):
                 status_list.append(Status.EC_INVALID_CERTIFICATE)
 
         return status_list

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -7,12 +7,14 @@
 import logging
 import socket
 from pathlib import Path
+from typing import Iterable
 
 from charms.tls_certificates_interface.v4.tls_certificates import (
     PrivateKey,
     ProviderCertificate,
 )
 
+from common.certificates import is_leaf_certificate_valid, leaf_certificate
 from core.cluster import ClusterState
 from core.workload import WorkloadBase
 from literals import SUBSTRATES, Status, TLSCARotationState, TLSState, TLSType
@@ -66,18 +68,18 @@ class TLSManager:
         self.workload.write_file(certificate.certificate.raw, certificate_path)
         self.set_cert_state(cert_type, is_ready=True)
 
-    def is_new_ca(self, ca_chain: str, tls_type: TLSType) -> bool:
-        """Check if all certificates in the CA chain are trusted.
+    def is_new_ca(self, certificate: str, tls_type: TLSType) -> bool:
+        """Check if the certificate is a new CA.
 
         Args:
-            ca_chain (str): The CA certificate.
+            certificate (str): The certificate to check.
             tls_type (TLSType): The TLS type.
 
         Returns:
-            bool: True if the CA is new, False otherwise.
+            bool: True if the certificate is not stored in the client trusted CA store, False otherwise.
         """
         trusted_cas = self.load_trusted_ca(tls_type)
-        return any(ca_cert not in trusted_cas for ca_cert in self.separate_certificates(ca_chain))
+        return certificate not in trusted_cas
 
     def add_trusted_ca(self, ca_cert: str, tls_type: TLSType = TLSType.PEER) -> None:
         """Add trusted CA to the system.
@@ -93,10 +95,10 @@ class TLSManager:
 
         cas = self.load_trusted_ca(tls_type)
         if ca_cert not in cas:
-            cas.append(ca_cert)
+            cas.add(ca_cert)
             self.workload.write_file("\n".join(cas), ca_certs_path)
 
-    def load_trusted_ca(self, tls_type) -> list[str]:
+    def load_trusted_ca(self, tls_type: TLSType) -> set[str]:
         """Load trusted CA from the system.
 
         Args:
@@ -108,7 +110,7 @@ class TLSManager:
             ca_certs_path = Path(self.workload.paths.tls.peer_ca)
 
         if not ca_certs_path.exists():
-            return []
+            return set()
 
         return self.separate_certificates(ca_certs_path.read_text())
 
@@ -182,25 +184,25 @@ class TLSManager:
                 return False
         return True
 
-    def separate_certificates(self, concatenated_certs: str) -> list[str]:
+    def separate_certificates(self, concatenated_certs: str) -> set[str]:
         """Separate certificates from the concatenated certificates.
 
         Args:
             concatenated_certs (str): The concatenated certificates.
 
         Returns:
-            list[str]: The list of certificates.
+            set[str]: The set of certificates.
         """
         # split the certificates by the end of the certificate marker and keep the marker in the cert
         raw_cas = concatenated_certs.split("-----END CERTIFICATE-----")
         # add the marker back to the certificate
-        return [cert.strip() + "\n-----END CERTIFICATE-----" for cert in raw_cas if cert.strip()]
+        return {cert.strip() + "\n-----END CERTIFICATE-----" for cert in raw_cas if cert.strip()}
 
-    def update_cas(self, cas: list[str], tls_type: TLSType) -> None:
+    def update_cas(self, cas: Iterable[str], tls_type: TLSType) -> None:
         """Update the CAs.
 
         Args:
-            cas (list[str]): The list of CAs.
+            cas (Iterable[str]): The list/set of CAs.
             tls_type (TLSType): The TLS type.
         """
         self.workload.write_file(
@@ -291,13 +293,13 @@ class TLSManager:
         logger.debug(f"Using only private IP {private_ip} for SANs IP.")
         return frozenset({private_ip})
 
-    def collect_client_cas(self) -> list[str]:
+    def collect_client_cas(self) -> set[str]:
         """Collect client CAs.
 
         Returns:
-            list[str]: The client CAs.
+            set[str]: The client CAs.
         """
-        cas: list[str] = [self.state.tls_client_certificate.ca.raw]
+        cas: set[str] = {self.state.tls_client_certificate.ca.raw}
 
         # managed users cas
         for relation in self.state.etcd_provides.relations:
@@ -305,11 +307,11 @@ class TLSManager:
             logger.debug(
                 f"Collecting CA from relation {relation.id}, chain exists: {bool(mtls_cert)}"
             )
-            if mtls_cert:
-                cas.extend(self.separate_certificates(mtls_cert))
+            if mtls_cert and is_leaf_certificate_valid(mtls_cert):
+                cas.add(leaf_certificate(mtls_cert))
 
         # certificate transfer cas
-        cas.extend(self.state.tls_certificate_transfer_certificates)
+        cas.update(self.state.tls_certificate_transfer_certificates)
 
         return cas
 

--- a/tests/integration/client_relations/test_client_relations.py
+++ b/tests/integration/client_relations/test_client_relations.py
@@ -49,7 +49,15 @@ def requirer_charm(platform: str) -> str:
     return f"./tests/integration/client_relations/requirer-charm/requirer-charm_ubuntu@24.04-{platform}.charm"
 
 
-def generate_mtls_chain(common_name: str) -> str:
+def generate_mtls_chain(common_name: str) -> tuple[str, str]:
+    """Generate a mtls certificate chain with a CA and an end-entity certificate.
+
+    Args:
+        common_name (str): The common name for the end-entity certificate.
+
+    Returns:
+        tuple[str, str]: The end-entity certificate and the CA certificate.
+    """
     ca_private_key = generate_private_key()
     ca_cert = generate_ca(
         private_key=ca_private_key, validity=timedelta(days=365), common_name="ca_common_name"
@@ -60,7 +68,7 @@ def generate_mtls_chain(common_name: str) -> str:
     client_cert = generate_certificate(
         client_csr, ca_cert, ca_private_key, validity=timedelta(days=365)
     )
-    return "\n".join([client_cert.raw, ca_cert.raw])
+    return (client_cert.raw, ca_cert.raw)
 
 
 async def get_requirer_common_name(ops_test: OpsTest) -> str:
@@ -76,8 +84,8 @@ async def get_requirer_common_name(ops_test: OpsTest) -> str:
     raise ValueError("Failed to get common name from requirer charm")
 
 
-async def get_requirer_leaf_certificate(ops_test: OpsTest) -> str | None:
-    """Get the ca chain from the requirer TLS provider."""
+async def get_requirer_mtls_certificate(ops_test: OpsTest) -> str | None:
+    """Get the mtls certificate from the requirer TLS provider."""
     requirer_app: Application = ops_test.model.applications[REQUIRER_NAME]
     requirer_unit: Unit = requirer_app.units[0]
 
@@ -111,7 +119,7 @@ async def test_build_and_deploy(charm: str, requirer_charm: str, ops_test: OpsTe
 
 @pytest.mark.abort_on_fail
 async def test_relate_client_charm(ops_test: OpsTest) -> None:
-    """Relate the client charm."""
+    """Test normal client charm relation."""
     await ops_test.model.integrate(APP_NAME, REQUIRER_NAME)
     await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME], idle_period=10)
 
@@ -141,20 +149,20 @@ async def test_relate_client_charm(ops_test: OpsTest) -> None:
         assert permission["permType"] == 2, "permission is not read and write"
         assert permission["key"] == key_prefix, "permission is not for the key prefix"
 
-    # get client ca from every unit and check if it includes the ca_chain
+    # get client ca from every unit and check if it includes the mtls cert
 
     model = ops_test.model_full_name
-    ca_chain = await get_requirer_leaf_certificate(ops_test)
-    assert ca_chain, "failed to get ca chain from requirer TLS provider"
+    mtls_cert = await get_requirer_mtls_certificate(ops_test)
+    assert mtls_cert, "failed to get mtls cert from requirer TLS provider"
     for unit in ops_test.model.applications[APP_NAME].units:
         client_cas = get_certificate_from_unit(model, unit.name, TLSType.CLIENT, is_ca=True)
         assert client_cas, f"failed to get client CAs for {unit.name}"
-        assert ca_chain in client_cas, f"CA chain not in trusted CAs for {unit.name}"
+        assert mtls_cert in client_cas, f"mtls cert not in trusted CAs for {unit.name}"
 
 
 @pytest.mark.abort_on_fail
 async def test_write_read_with_requirer(ops_test: OpsTest) -> None:
-    """Write and read to the key prefix with the requirer charm."""
+    """Test write and read to the key prefix with the requirer charm."""
     requirer_app: Application = ops_test.model.applications[REQUIRER_NAME]
     requirer_unit: Unit = requirer_app.units[0]
 
@@ -180,13 +188,16 @@ async def test_write_read_with_requirer(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.abort_on_fail
-async def test_update_chain(ops_test: OpsTest) -> None:
-    """Update the common name used by the requirer app."""
-    # generate new ca chain
-    new_ca = generate_mtls_chain("new-common-name")
+async def test_update_mtls_cert(ops_test: OpsTest) -> None:
+    """Test updating the common name used by the requirer app."""
+    # generate new mtls cert
+    mtls_cert, mtls_ca = generate_mtls_chain("new-common-name")
     # run juju action to update the common name
     requirer_unit: Unit = ops_test.model.applications[REQUIRER_NAME].units[0]
-    action = await requirer_unit.run_action("update-common-name", **{"chain": new_ca})
+    # we send all chain to test that etcd only stores the leaf certificate
+    action = await requirer_unit.run_action(
+        "update-common-name", **{"chain": "\n".join([mtls_cert, mtls_ca])}
+    )
     action = await action.wait()
 
     # wait for model to settle
@@ -201,13 +212,16 @@ async def test_update_chain(ops_test: OpsTest) -> None:
     common_name = await get_requirer_common_name(ops_test)
     assert common_name == "new-common-name", "common name not updated"
 
-    ca_chain = await get_requirer_leaf_certificate(ops_test)
-    assert ca_chain, "failed to get ca chain from requirer TLS provider"
+    old_mtls_cert = await get_requirer_mtls_certificate(ops_test)
+    assert old_mtls_cert, "failed to get the old mtls cert from requirer TLS provider"
     for unit in ops_test.model.applications[APP_NAME].units:
         client_cas = get_certificate_from_unit(model, unit.name, TLSType.CLIENT, is_ca=True)
         assert client_cas, f"failed to get client CAs for {unit.name}"
-        assert new_ca in client_cas, f"CA chain not in trusted CAs for {unit.name}"
-        assert ca_chain not in client_cas, f"old CA chain still in trusted CAs for {unit.name}"
+        assert mtls_cert in client_cas, f"new mtls cert not in trusted CAs for {unit.name}"
+        assert mtls_ca not in client_cas, f"new mtls ca is in trusted CAs for {unit.name}"
+        assert old_mtls_cert not in client_cas, (
+            f"old mtls certificate still in trusted CAs for {unit.name}"
+        )
 
 
 @pytest.mark.abort_on_fail
@@ -245,10 +259,10 @@ async def test_etcd_updates_ca(ops_test: OpsTest) -> None:
 
 @pytest.mark.abort_on_fail
 async def test_remove_client_relation(ops_test: OpsTest) -> None:
-    """Remove the client relation and check if the user and role are removed."""
+    """Test removing the client relation and check if the user and role are removed."""
     common_name = "new-common-name"
-    ca_chain = await get_requirer_leaf_certificate(ops_test)
-    assert ca_chain, "failed to get ca chain from requirer TLS provider"
+    mtls_cert = await get_requirer_mtls_certificate(ops_test)
+    assert mtls_cert, "failed to get mtls cert from requirer TLS provider"
     etcd_app: Application = ops_test.model.applications[APP_NAME]
 
     logger.info("Removing client relation")
@@ -284,12 +298,12 @@ async def test_remove_client_relation(ops_test: OpsTest) -> None:
     for unit in ops_test.model.applications[APP_NAME].units:
         client_cas = get_certificate_from_unit(model, unit.name, TLSType.CLIENT, is_ca=True)
         assert client_cas, f"failed to get client CAs for {unit.name}"
-        assert ca_chain not in client_cas, f"old CA chain still in trusted CAs for {unit.name}"
+        assert mtls_cert not in client_cas, f"old mtls cert still in trusted CAs for {unit.name}"
 
 
 @pytest.mark.abort_on_fail
 async def test_certificate_transfer(ops_test: OpsTest) -> None:
-    """Test if the requirer charm sends a ca certificate instead of an end-entity."""
+    """Test if the certificate transfer interface works correctly."""
     # integrate etcd with requirer tls provider on certificate_transfer relation
     await ops_test.model.integrate(f"{APP_NAME}:client-cas", REQUIRER_TLS_NAME)
 
@@ -317,7 +331,7 @@ async def test_certificate_transfer(ops_test: OpsTest) -> None:
 
 @pytest.mark.abort_on_fail
 async def test_requirer_sends_ca(ops_test: OpsTest) -> None:
-    """Test if the requirer charm sends a ca certificate instead of an end-entity."""
+    """Test when the requirer charm sends a ca certificate instead of an end-entity."""
     # configure the requirer charm to send a ca certificate
     requirer_app: Application = ops_test.model.applications[REQUIRER_NAME]
     await requirer_app.set_config({"send-ca-cert": "True"})

--- a/tests/unit/test_external_client_relations.py
+++ b/tests/unit/test_external_client_relations.py
@@ -872,6 +872,7 @@ def test_ecr_relation_broken_leader(cluster_tls_context, mtls_cert):
         patch("managers.tls.TLSManager.collect_client_cas") as collect_client_cas,
         patch("managers.tls.TLSManager.update_cas") as update_cas,
         patch("charm.EtcdOperatorCharm._restart") as restart,
+        patch("managers.tls.TLSManager.load_trusted_ca", return_value={mtls_cert}),
     ):
         charm: EtcdOperatorCharm = manager.charm
         manager.run()
@@ -1173,10 +1174,10 @@ def test_update_client_relations_data_no_external_clients(cluster_tls_context):
         get_assigned_certificates.assert_not_called()
 
 
-def test_add_ecr_invalid_cert(cluster_tls_context, mtls_cert):
+def test_add_ecr_invalid_cert(cluster_tls_context, ca_cert):
     """Test adding an external client relation to the charm."""
     ctx, relations = cluster_tls_context
-    secret = Secret({"mtls-cert": mtls_cert}, owner="app")
+    secret = Secret({"mtls-cert": ca_cert}, owner="app")
     ecr_relation = testing.Relation(
         id=5,
         endpoint=EXTERNAL_CLIENTS_RELATION,
@@ -1200,10 +1201,6 @@ def test_add_ecr_invalid_cert(cluster_tls_context, mtls_cert):
         patch(
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
             return_value=([server_cert], MagicMock()),
-        ),
-        patch(
-            "managers.external_clients.ExternalClientsManager.is_leaf_certificate_valid",
-            return_value=False,
         ),
     ):
         charm: EtcdOperatorCharm = manager.charm
@@ -1374,10 +1371,6 @@ def test_certificate_transfer_new_ca(cluster_tls_context, ca_cert):
 def test_certificate_transfer_old_ca(cluster_tls_context, ca_cert):
     ctx, relations = cluster_tls_context
 
-    peer_relation = relations[0]
-    old_common_name = CLIENT_COMMON_NAME
-    peer_relation.local_app_data["managed_users"] = f'{{"5":"{old_common_name}"}}'
-
     certificate_transfer_relation = testing.Relation(
         id=5,
         endpoint=CERTIFICATE_TRANSFER_RELATION,
@@ -1390,14 +1383,18 @@ def test_certificate_transfer_old_ca(cluster_tls_context, ca_cert):
         relations=relations + [certificate_transfer_relation],
         leader=True,
     )
-
     with (
         patch("common.client.EtcdClient._run_etcdctl", return_value="success"),
         patch("workload.EtcdWorkload.write_file"),
-        patch("managers.tls.TLSManager.collect_client_cas", return_value=["test_ca", "test_ca1"]),
+        patch(
+            "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
+            return_value=([server_cert], MagicMock()),
+        ),
         patch("managers.cluster.ClusterManager.restart_member"),
         patch("managers.tls.TLSManager.update_cas") as update_cas,
-        patch("managers.tls.TLSManager.is_new_ca", return_value=False),
+        patch(
+            "managers.tls.TLSManager.load_trusted_ca", return_value={server_cert.ca.raw, ca_cert}
+        ),
     ):
         with (
             ctx(ctx.on.relation_changed(certificate_transfer_relation), state_in) as manager,

--- a/tests/unit/test_external_client_relations.py
+++ b/tests/unit/test_external_client_relations.py
@@ -155,7 +155,7 @@ def test_add_ecr_new_user_leader(cluster_tls_context, mtls_cert):
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
             "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
-            "provided-secrets": '["mtls-cert"]'
+            "provided-secrets": '["mtls-cert"]',
         },
     )
 
@@ -933,7 +933,7 @@ def test_etcd_rotates_ca(cluster_tls_context, mtls_cert):
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
             "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
-            "provided-secrets": '["mtls-cert"]'
+            "provided-secrets": '["mtls-cert"]',
         },
     )
 
@@ -1015,7 +1015,7 @@ def test_etcd_updates_endpoints(cluster_tls_context, mtls_cert):
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
             "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
-            "provided-secrets": '["mtls-cert"]'
+            "provided-secrets": '["mtls-cert"]',
         },
     )
 
@@ -1095,7 +1095,7 @@ def test_etcd_updates_version(cluster_tls_context, mtls_cert):
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
             "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
-            "provided-secrets": '["mtls-cert"]'
+            "provided-secrets": '["mtls-cert"]',
         },
     )
 

--- a/tests/unit/test_external_client_relations.py
+++ b/tests/unit/test_external_client_relations.py
@@ -154,7 +154,8 @@ def test_add_ecr_new_user_leader(cluster_tls_context, mtls_cert):
         remote_app_data={
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
-            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "mtls-cert"]',
+            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
+            "provided-secrets": '["mtls-cert"]'
         },
     )
 
@@ -931,7 +932,8 @@ def test_etcd_rotates_ca(cluster_tls_context, mtls_cert):
         remote_app_data={
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
-            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "mtls-cert"]',
+            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
+            "provided-secrets": '["mtls-cert"]'
         },
     )
 
@@ -1012,7 +1014,8 @@ def test_etcd_updates_endpoints(cluster_tls_context, mtls_cert):
         remote_app_data={
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
-            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "mtls-cert"]',
+            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
+            "provided-secrets": '["mtls-cert"]'
         },
     )
 
@@ -1091,7 +1094,8 @@ def test_etcd_updates_version(cluster_tls_context, mtls_cert):
         remote_app_data={
             "secret-mtls": secret.id,
             "prefix": "/test/keys",
-            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "mtls-cert"]',
+            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
+            "provided-secrets": '["mtls-cert"]'
         },
     )
 


### PR DESCRIPTION
- **`src/common/certificates.py`**: Added utility functions `leaf_certificate` and `is_leaf_certificate_valid` to extract and validate leaf certificates, ensuring proper handling of certificate chains and CA constraints.
- **`src/events/external_clients.py`**: Refactored validation logic to use the newly added `is_leaf_certificate_valid` function for verifying certificates in event handlers. [[1]](diffhunk://#diff-41d3b0e68fba8bc44a83df27841cc482ba1df8a5cfe8e476397765673f46f446R21) [[2]](diffhunk://#diff-41d3b0e68fba8bc44a83df27841cc482ba1df8a5cfe8e476397765673f46f446L100-R101) Fc8edb36L176R146)
- **`src/managers/external_clients.py`**: Removed the redundant `is_leaf_certificate_valid` method and replaced its usage with the utility function from `common.certificates`. [[1]](diffhunk://#diff-7cf18beef6c6df0f0e1a46e25a3b1bdb9aec8f5a433fb89bd09549560bfca7bfL12-R13) [[2]](diffhunk://#diff-7cf18beef6c6df0f0e1a46e25a3b1bdb9aec8f5a433fb89bd09549560bfca7bfL92-L121) [[3]](diffhunk://#diff-7cf18beef6c6df0f0e1a46e25a3b1bdb9aec8f5a433fb89bd09549560bfca7bfL179-R149)
- **`src/managers/tls.py`**: Refactored `separate_certificates` and related methods to use `set` instead of `list`, improving efficiency and ensuring uniqueness of certificates. Updated `collect_client_cas` to validate certificates using the new utility functions. [[1]](diffhunk://#diff-a2c036f44ae9bbab595aad84b23bc3106a342c5ab12f7b0cf3d26268b51cdc83L185-R205) [[2]](diffhunk://#diff-a2c036f44ae9bbab595aad84b23bc3106a342c5ab12f7b0cf3d26268b51cdc83L294-R314)
- **`tests/unit/test_external_client_relations.py`**: Updated unit tests to align with the refactored certificate validation logic and new utility functions. Adjusted mock setups for `load_trusted_ca` and certificate-related methods. [[1]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176R875) [[2]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L1176-R1180) [[3]](diffhunk://#diff-edaedf3cd01fca82517ddbcfe990ec19bc075d556273efc7d3eb9c269c77e176L1377-L1380)