### PR TITLE
[DPE-7811] Error handling for backup/restore setup

### DIFF
--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -114,7 +114,12 @@ class BackupEvents(Object):
         s3_parameters["path"] = s3_parameters["path"].strip("/")
         s3_parameters["bucket"] = s3_parameters["bucket"].strip("/")
 
-        self.charm.backup_manager.create_bucket(s3_parameters)
+        try:
+            self.charm.backup_manager.create_bucket(s3_parameters)
+        except EtcdBackupError:
+            logger.error("Cannot setup s3 object storage - check credentials and permissions")
+            return
+
         self.charm.state.cluster.update({"s3-credentials": json.dumps(s3_parameters)})
 
     def _on_s3_credentials_gone(self, event: CredentialsGoneEvent) -> None:
@@ -165,7 +170,12 @@ class BackupEvents(Object):
         azure_parameters["path"] = azure_parameters["path"].strip("/")
         azure_parameters["container"] = azure_parameters["container"].strip("/")
 
-        self.charm.backup_manager.create_container(azure_parameters)
+        try:
+            self.charm.backup_manager.create_container(azure_parameters)
+        except EtcdBackupError:
+            logger.error("Cannot setup azure object storage - check credentials and permissions")
+            return
+
         self.charm.state.cluster.update({"azure-credentials": json.dumps(azure_parameters)})
 
     def _on_azure_credentials_gone(self, event: StorageConnectionInfoGoneEvent) -> None:

--- a/src/literals.py
+++ b/src/literals.py
@@ -75,10 +75,10 @@ class Status(Enum):
     )
     BACKUP_IN_PROGRESS = StatusLevel(MaintenanceStatus("Creating database backup..."), "DEBUG")
     BACKUP_S3_PARAMETERS_MISSING = StatusLevel(
-        BlockedStatus("Missing required parameters in the s3 relation."), "ERROR"
+        BlockedStatus("Missing or invalid s3 credentials."), "ERROR"
     )
     BACKUP_AZURE_PARAMETERS_MISSING = StatusLevel(
-        BlockedStatus("Missing required parameters in the azure relation."), "ERROR"
+        BlockedStatus("Missing or invalid azure credentials."), "ERROR"
     )
     CLUSTER_INITIALIZING = StatusLevel(MaintenanceStatus("Initializing etcd cluster..."), "DEBUG")
     CLUSTER_FAILED = StatusLevel(

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import List
 
 import boto3
-from azure.core.exceptions import ResourceExistsError
+from azure.core.exceptions import AzureError, ResourceExistsError
 from azure.storage.blob import ContainerClient
 from botocore.client import Config
 from botocore.exceptions import ClientError
@@ -124,6 +124,9 @@ class BackupManager:
             logger.info(f"Container {azure_parameters['container']} created")
         except ResourceExistsError:
             logger.info(f"Container {azure_parameters['container']} already exists")
+        except AzureError as e:
+            logger.error(e)
+            raise EtcdBackupError(e)
 
     def create_backup(self) -> str:
         """Create a backup of etcd and upload it to object storage.

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -93,7 +93,9 @@ class BackupManager:
         bucket = self._get_bucket_resource(s3_parameters)
 
         try:
-            if region:
+            # setting the `LocationConstraint` to the default value of us-east-1 will fail
+            # https://github.com/aws/aws-sdk-js/issues/3647
+            if region and region != "us-east-1":
                 bucket.create(CreateBucketConfiguration={"LocationConstraint": region})
             else:
                 bucket.create()


### PR DESCRIPTION
**Issues**
- If setting up object storage for backup/restore fails, the operator currently does not catch the error but leaves the charm in error state.
- When using S3 storage, it is not possible to provide a `LocationConstraint` when using the default S3 region of AWS.

Solves #121 and #122 

**Solution**
- add error handling for errors when creating an S3 bucket or Azure storage container
- do not set a `LocationConstraint` when setting up the S3 bucket if the region is set to AWS default `us-east-1`

