### PR TITLE
chore: Update path for TLS cert in docs

### DIFF
--- a/docs/how-to/tls/enable-tls.md
+++ b/docs/how-to/tls/enable-tls.md
@@ -155,9 +155,9 @@ You can use the `etcdctl` command to connect to the server using the `https` end
 Let's grab the client certificate and key from one of the units and provide them to the server via `etcdctl`:
 ```{terminal}
 :scroll:
-:input: juju ssh charmed-etcd/0 "cat /var/snap/charmed-etcd/common/tls/client.key" > ./client.key
+:input: juju ssh charmed-etcd/0 "cat /var/snap/charmed-etcd/current/tls/client.key" > ./client.key
 
-:input: juju ssh charmed-etcd/0 "cat /var/snap/charmed-etcd/common/tls/client.pem" > ./client.pem
+:input: juju ssh charmed-etcd/0 "cat /var/snap/charmed-etcd/current/tls/client.pem" > ./client.pem
 
 :input: etcdctl member list --endpoints https://10.73.32.122:2379 -w table --cacert ca.crt --cert ./client.pem --key ./client.key
 


### PR DESCRIPTION
 * [`docs/how-to/tls/enable-tls.md`](diffhunk://#diff-a83f206044e95d53802335e848f31c55fea33ec5e486a60fd08e3c0c3ef9d5c7L158-R160): Updated paths from `/var/snap/charmed-etcd/common/tls/` to `/var/snap/charmed-etcd/current/tls/` for the client certificate (`client.pem`) and key (`client.key`) in the `etcdctl` usage example.