### PR TITLE
[DPE-7732] add config option for certificate-extra-sans

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -33,3 +33,10 @@ options:
       For best practices, the parameter should be set around round-trip time between members.
       The value must be between 10 and 5000 at most.
 
+  certificate-extra-sans:
+    type: string
+    description: |
+      Config options to add extra-sans to the ones used when requesting server certificates.
+      The extra-sans are specified by comma-separated names to be added when requesting signed certificates.
+      Use "{unit}" as a placeholder to be filled with the unit number, e.g. "worker-{unit}" will be translated as 
+      "worker-0" for unit 0 and "worker-1" for unit 1 when requesting the certificate.

--- a/poetry.lock
+++ b/poetry.lock
@@ -2167,6 +2167,21 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "validators"
+version = "0.35.0"
+description = "Python Data Validation for Humans™"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd"},
+    {file = "validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a"},
+]
+
+[package.extras]
+crypto-eth-addresses = ["eth-hash[pycryptodome] (>=0.7.0)"]
+
+[[package]]
 name = "wcwidth"
 version = "0.2.13"
 description = "Measures the displayed width of unicode strings in a terminal"
@@ -2277,4 +2292,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "7c19b5639dcf9613c9a69d6617c4eec12bcf74ff2303aa53c130e7051448772b"
+content-hash = "6f35e35a537ec4e7cab8ee175f1e0eb78d84e4fea0a0c6fe99af3912a9850cea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ boto3 = "^1.37.12"
 mypy-boto3-s3 = "^1.37.0"
 azure-storage-blob = "^12.25.1"
 azure-core = "^1.33.0"
+validators = ">=0.35.0"
 
 [tool.poetry.group.charm-libs.dependencies]
 # data_platform_libs/v0/data_interfaces.py

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -47,6 +47,7 @@ class ClusterState(Object):
             self.model, relation_name=PEER_RELATION, additional_secret_fields=SECRETS_APP
         )
         self.peer_unit_interface = DataPeerUnitData(self.model, relation_name=PEER_RELATION)
+        self.config = charm.config
 
     @property
     def peer_relation(self) -> Relation | None:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -85,7 +85,7 @@ class EtcdServer(RelationState):
 
     @property
     def unit_name(self) -> str:
-        """The id of the unit from the unit name."""
+        """The unit's name."""
         return self.unit.name
 
     @property

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -164,7 +164,7 @@ class WorkloadBase(ABC):
         pass
 
     @abstractmethod
-    def exec(self, command: List[str]) -> None:
+    def exec(self, command: List[str]) -> str:
         """Run a command on the workload substrate."""
         pass
 

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -209,7 +209,7 @@ class WorkloadBase(ABC):
 
         return output.stdout.strip()
 
-    def get_private_ip(self) -> str | None:
+    def get_private_ip(self) -> str:
         """Get the Private IP address of the current unit."""
         cmd = "unit-get private-address"
         try:
@@ -221,14 +221,12 @@ class WorkloadBase(ABC):
                 capture_output=True,
                 timeout=10,
             )
+            if output.returncode == 0:
+                return output.stdout.strip()
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.error(f"Error executing command '{cmd}': {e}")
-            return None
 
-        if output.returncode != 0:
-            return None
-
-        return output.stdout.strip()
+        return socket.gethostbyname(socket.gethostname())
 
     def get_host_mapping(self) -> dict[str, str]:
         """Collect hostname mapping for current unit.

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -41,8 +41,6 @@ from literals import (
     SNAP_GROUP,
     SNAP_LOG_PATH,
     SNAP_USER,
-    TLS_CLIENT_PRIVATE_KEY_CONFIG,
-    TLS_PEER_PRIVATE_KEY_CONFIG,
     Status,
     TLSState,
     TLSType,
@@ -200,7 +198,7 @@ class EtcdEvents(Object):
         else:
             self.charm.set_status(Status.SERVICE_NOT_RUNNING)
 
-    def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:  # noqa: C901
+    def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:
         """Handle config_changed event."""
         if (
             self.charm.state.cluster.is_restore_in_progress
@@ -235,12 +233,6 @@ class EtcdEvents(Object):
                 TLSState.TLS,
             ) or self.charm.state.unit_server.tls_peer_state in (TLSState.TO_TLS, TLSState.TLS):
                 self.charm.tls_events.refresh_tls_certificates_event.emit()
-
-        if tls_peer_private_key_id := self.charm.config.get(TLS_PEER_PRIVATE_KEY_CONFIG):
-            self.update_private_key(tls_peer_private_key_id)
-
-        if tls_client_private_key_id := self.charm.config.get(TLS_CLIENT_PRIVATE_KEY_CONFIG):
-            self.update_private_key(tls_client_private_key_id)
 
         if (
             self.charm.config_manager.are_tuning_parameters_valid()
@@ -420,17 +412,6 @@ class EtcdEvents(Object):
 
     def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
         """Handle the secret_changed event."""
-        if tls_peer_private_key_id := self.charm.config.get(TLS_PEER_PRIVATE_KEY_CONFIG):
-            if tls_peer_private_key_id == event.secret.id:
-                self.update_private_key(tls_peer_private_key_id)
-
-        if tls_client_private_key_id := self.charm.config.get(TLS_CLIENT_PRIVATE_KEY_CONFIG):
-            if tls_client_private_key_id == event.secret.id:
-                self.update_private_key(tls_client_private_key_id)
-
-        if not self.charm.unit.is_leader():
-            return
-
         if (
             self.charm.state.cluster.is_restore_in_progress
             or self.charm.state.cluster.rebuild_cluster_in_progress
@@ -439,6 +420,9 @@ class EtcdEvents(Object):
                 "Cannot update credentials while a restore or cluster-rebuild operation is in progress."
             )
             event.defer()
+            return
+
+        if not self.charm.unit.is_leader():
             return
 
         if admin_secret_id := self.charm.config.get(INTERNAL_USER_PASSWORD_CONFIG):
@@ -528,16 +512,6 @@ class EtcdEvents(Object):
         except (ModelError, SecretNotFoundError) as e:
             logger.error(e)
             self.charm.set_status(Status.PASSWORD_UPDATE_FAILED)
-
-    def update_private_key(self, private_key_id: str) -> None:
-        """Update the private key in etcd."""
-        logger.debug("Updating TLS private key.")
-
-        if self.charm.tls_events.read_and_validate_private_key(private_key_id) is None:
-            self.charm.set_status(Status.TLS_INVALID_PRIVATE_KEY)
-            return
-
-        self.charm.tls_events.refresh_tls_certificates_event.emit()
 
     def _rebuild_cluster(self) -> None:  # noqa: C901
         """Rebuild cluster with new membership configuration, to recover from majority failure.

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -412,6 +412,9 @@ class EtcdEvents(Object):
 
     def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
         """Handle the secret_changed event."""
+        if not self.charm.unit.is_leader():
+            return
+
         if (
             self.charm.state.cluster.is_restore_in_progress
             or self.charm.state.cluster.rebuild_cluster_in_progress
@@ -420,9 +423,6 @@ class EtcdEvents(Object):
                 "Cannot update credentials while a restore or cluster-rebuild operation is in progress."
             )
             event.defer()
-            return
-
-        if not self.charm.unit.is_leader():
             return
 
         if admin_secret_id := self.charm.config.get(INTERNAL_USER_PASSWORD_CONFIG):

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -333,20 +333,12 @@ class TLSEvents(Object):
         if self.charm.tls_manager.extra_sans_config_is_valid():
             if (
                 self.charm.state.unit_server.tls_client_state == TLSState.TLS
+                and self.charm.tls_manager.certificate_sans_updated(TLSType.CLIENT)
+                or self.charm.state.unit_server.tls_peer_state == TLSState.TLS
                 and self.charm.tls_manager.certificate_sans_updated(TLSType.PEER)
             ):
-                logger.debug(
-                    "Config change for `certificate-extra-sans` - request new TLS peer certificates"
-                )
+                logger.debug("Config change for certificate-extra-sans, refresh TLS certificates")
                 self.refresh_tls_certificates_event.emit()
-
-            if (
-                self.charm.state.unit_server.tls_peer_state == TLSState.TLS
-                and self.charm.tls_manager.certificate_sans_updated(TLSType.CLIENT)
-            ):
-                logger.debug(
-                    "Config change for `certificate-extra-sans` - request new TLS client certificates"
-                )
 
     def _on_secret_changed(self, event: SecretChangedEvent) -> None:
         """Handle TLS related secret changes."""

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -331,6 +331,24 @@ class TLSEvents(Object):
         if tls_client_private_key_id := self.charm.config.get(TLS_CLIENT_PRIVATE_KEY_CONFIG):
             self.update_private_key(tls_client_private_key_id)
 
+        if self.charm.tls_manager.extra_sans_config_is_valid():
+            if (
+                self.charm.state.unit_server.tls_client_state == TLSState.TLS
+                and self.charm.tls_manager.certificate_sans_updated(TLSType.PEER)
+            ):
+                logger.debug(
+                    "Config change for `certificate-extra-sans` - request new TLS peer certificates"
+                )
+                self.refresh_tls_certificates_event.emit()
+
+            if (
+                self.charm.state.unit_server.tls_peer_state == TLSState.TLS
+                and self.charm.tls_manager.certificate_sans_updated(TLSType.CLIENT)
+            ):
+                logger.debug(
+                    "Config change for `certificate-extra-sans` - request new TLS client certificates"
+                )
+
     def _on_secret_changed(self, event: SecretChangedEvent) -> None:
         """Handle TLS related secret changes."""
         if tls_peer_private_key_id := self.charm.config.get(TLS_PEER_PRIVATE_KEY_CONFIG):

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -78,7 +78,6 @@ class TLSEvents(Object):
     def __init__(self, charm: "EtcdOperatorCharm"):
         super().__init__(charm, "tls")
         self.charm: "EtcdOperatorCharm" = charm
-        host_mapping = self.charm.workload.get_host_mapping()
         common_name = f"{self.charm.unit.name}-{self.charm.model.uuid}"
         peer_private_key = None
         client_private_key = None
@@ -101,8 +100,8 @@ class TLSEvents(Object):
             certificate_requests=[
                 CertificateRequestAttributes(
                     common_name=common_name,
-                    sans_ip=self.charm.tls_manager.get_sans_ip(TLSType.PEER),
-                    sans_dns=frozenset({self.charm.unit.name, host_mapping["hostname"]}),
+                    sans_ip=self.charm.tls_manager.build_sans_ip(TLSType.PEER),
+                    sans_dns=self.charm.tls_manager.build_sans_dns(),
                 ),
             ],
             private_key=peer_private_key,
@@ -114,8 +113,8 @@ class TLSEvents(Object):
             certificate_requests=[
                 CertificateRequestAttributes(
                     common_name=common_name,
-                    sans_ip=self.charm.tls_manager.get_sans_ip(TLSType.CLIENT),
-                    sans_dns=frozenset({self.charm.unit.name, host_mapping["hostname"]}),
+                    sans_ip=self.charm.tls_manager.build_sans_ip(TLSType.CLIENT),
+                    sans_dns=self.charm.tls_manager.build_sans_dns(),
                 ),
             ],
             private_key=client_private_key,

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -333,9 +333,9 @@ class TLSEvents(Object):
         if self.charm.tls_manager.extra_sans_config_is_valid():
             if (
                 self.charm.state.unit_server.tls_client_state == TLSState.TLS
-                and self.charm.tls_manager.certificate_sans_updated(TLSType.CLIENT)
+                and self.charm.tls_manager.certificate_sans_require_update(TLSType.CLIENT)
                 or self.charm.state.unit_server.tls_peer_state == TLSState.TLS
-                and self.charm.tls_manager.certificate_sans_updated(TLSType.PEER)
+                and self.charm.tls_manager.certificate_sans_require_update(TLSType.PEER)
             ):
                 logger.debug("Config change for certificate-extra-sans, refresh TLS certificates")
                 self.refresh_tls_certificates_event.emit()

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -16,11 +16,13 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
     TLSCertificatesRequiresV4,
 )
 from ops import (
+    ConfigChangedEvent,
     EventSource,
     Handle,
     ModelError,
     RelationBrokenEvent,
     RelationCreatedEvent,
+    SecretChangedEvent,
     SecretNotFoundError,
 )
 from ops.framework import EventBase, Object
@@ -134,6 +136,8 @@ class TLSEvents(Object):
             self.framework.observe(
                 self.charm.on[relation].relation_broken, self._on_certificates_broken
             )
+        self.framework.observe(self.charm.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.charm.on.secret_changed, self._on_secret_changed)
 
     def _on_relation_created(self, event: RelationCreatedEvent) -> None:
         """Handle the `relation-created` event.
@@ -318,6 +322,34 @@ class TLSEvents(Object):
                 "Waiting for all servers to update certificates before cleaning up old CAs"
             )
             event.defer()
+
+    def _on_config_changed(self, event: ConfigChangedEvent) -> None:
+        """Handle TLS related config changes."""
+        if tls_peer_private_key_id := self.charm.config.get(TLS_PEER_PRIVATE_KEY_CONFIG):
+            self.update_private_key(tls_peer_private_key_id)
+
+        if tls_client_private_key_id := self.charm.config.get(TLS_CLIENT_PRIVATE_KEY_CONFIG):
+            self.update_private_key(tls_client_private_key_id)
+
+    def _on_secret_changed(self, event: SecretChangedEvent) -> None:
+        """Handle TLS related secret changes."""
+        if tls_peer_private_key_id := self.charm.config.get(TLS_PEER_PRIVATE_KEY_CONFIG):
+            if tls_peer_private_key_id == event.secret.id:
+                self.update_private_key(tls_peer_private_key_id)
+
+        if tls_client_private_key_id := self.charm.config.get(TLS_CLIENT_PRIVATE_KEY_CONFIG):
+            if tls_client_private_key_id == event.secret.id:
+                self.update_private_key(tls_client_private_key_id)
+
+    def update_private_key(self, private_key_id: str) -> None:
+        """Update the private key in etcd."""
+        logger.debug("Updating TLS private key.")
+
+        if self.read_and_validate_private_key(private_key_id) is None:
+            self.charm.set_status(Status.TLS_INVALID_PRIVATE_KEY)
+            return
+
+        self.refresh_tls_certificates_event.emit()
 
     def read_and_validate_private_key(
         self, private_key_secret_id: str | None

--- a/src/literals.py
+++ b/src/literals.py
@@ -148,6 +148,10 @@ class Status(Enum):
         ),
         "ERROR",
     )
+    SANS_CONFIG_INVALID = StatusLevel(
+        BlockedStatus("Invalid value set for the config options 'certificate-extra-sans'"),
+        "ERROR",
+    )
     SERVICE_INSTALLING = StatusLevel(MaintenanceStatus("Installing etcd..."), "DEBUG")
     SERVICE_STARTING = StatusLevel(MaintenanceStatus("Waiting for etcd to start..."), "DEBUG")
     SERVICE_NOT_INSTALLED = StatusLevel(BlockedStatus("unable to install etcd snap"), "ERROR")

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -388,7 +388,7 @@ class TLSManager:
 
         return {"sans_ip": sans_ip, "sans_dns": sans_dns}
 
-    def certificate_sans_updated(self, tls_type: TLSType) -> bool:
+    def certificate_sans_require_update(self, tls_type: TLSType) -> bool:
         """Check current certificate sans and determine if certificate requires update.
 
         Returns:

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -324,7 +324,6 @@ class TLSManager:
 
         sans_dns.add(self.state.unit_server.unit_name)
         sans_dns.add(self.workload.get_host_mapping()["hostname"])
-        logger.info(sans_dns)
         return frozenset(sans_dns)
 
     def extra_sans_config_is_valid(self) -> bool:

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -9,7 +9,7 @@ import re
 import socket
 from ipaddress import ip_address
 from pathlib import Path
-from typing import Iterable
+from typing import Dict, Iterable
 
 from charms.tls_certificates_interface.v4.tls_certificates import (
     PrivateKey,
@@ -275,28 +275,58 @@ class TLSManager:
 
         return status_list
 
-    def get_sans_ip(self, tls_type: TLSType) -> frozenset[str]:
-        """Get the SANs IP for the TLS certificate.
+    def build_sans_ip(self, tls_type: TLSType) -> frozenset[str]:
+        """Build the SANs IP for the TLS certificate.
 
         Returns:
             frozenset[str]: The SANs IP.
         """
-        private_ip = self.workload.get_private_ip()
-        if not private_ip:
+        sans_ip = set()
+        if self.extra_sans_config_is_valid() and (
+            extra_sans_config := self.state.config.get("certificate-extra-sans")
+        ):
+            extra_sans = [san.strip() for san in extra_sans_config.split(",")]
+            sans_ip = {san for san in extra_sans if len(san.split(".")) == 4}
+
+        if private_ip := self.workload.get_private_ip():
+            sans_ip.add(private_ip)
+        else:
             logger.warning("No private IP found using unit-get. Using socket instead.")
-            return frozenset({socket.gethostbyname(socket.gethostname())})
+            sans_ip.add(socket.gethostbyname(socket.gethostname()))
 
         if tls_type == TLSType.PEER:
             logger.debug(f"Using private IP {private_ip} for peer SANs IP.")
-            return frozenset({private_ip})
+            return frozenset(sans_ip)
 
         # For client TLS, we use both private and public IPs if available
         if public_ip := self.workload.get_public_ip():
             logger.debug("Using public and private IPs for SANs.")
-            return frozenset({private_ip, public_ip})
+            sans_ip.add(public_ip)
 
-        logger.debug(f"Using only private IP {private_ip} for SANs IP.")
-        return frozenset({private_ip})
+        logger.info(sans_ip)
+        return frozenset(sans_ip)
+
+    def build_sans_dns(self) -> frozenset[str]:
+        """Build the SANs DNS for the TLS certificate.
+
+        Returns:
+            frozenset[str]: The SANs DNS.
+        """
+        sans_dns = set()
+        if self.extra_sans_config_is_valid() and (
+            extra_sans_config := self.state.config.get("certificate-extra-sans")
+        ):
+            extra_sans = [san.strip() for san in extra_sans_config.split(",")]
+            sans_dns = {
+                san.replace("{unit}", str(self.state.unit_server.unit_id))
+                for san in extra_sans
+                if len(san.split(".")) != 4
+            }
+
+        sans_dns.add(self.state.unit_server.unit_name)
+        sans_dns.add(self.workload.get_host_mapping()["hostname"])
+        logger.info(sans_dns)
+        return frozenset(sans_dns)
 
     def extra_sans_config_is_valid(self) -> bool:
         """Validate configuration value for certificate-extra-sans option.
@@ -325,13 +355,55 @@ class TLSManager:
 
         return True
 
+    def get_current_sans(self, tls_type: TLSType) -> Dict[str, set[str]]:
+        """Get the current SANs for a unit's cert."""
+        if tls_type == TLSType.CLIENT:
+            cert_file = self.workload.paths.tls.client_cert
+        else:
+            cert_file = self.workload.paths.tls.peer_cert
+
+        if not (
+            san_lines := self.workload.exec(
+                [
+                    "openssl",
+                    "x509",
+                    "-ext",
+                    "subjectAltName",
+                    "-noout",
+                    "-in",
+                    cert_file,
+                ]
+            ).splitlines()
+        ):
+            return {"sans_ip": set(), "sans_dns": set()}
+
+        sans_ip = []
+        sans_dns = []
+        for line in san_lines:
+            for sans in line.split(", "):
+                san_type, san_value = sans.split(":")
+
+                if san_type.strip() == "DNS":
+                    sans_dns.append(san_value)
+                if san_type.strip() == "IP Address":
+                    sans_ip.append(san_value)
+
+        return {"sans_ip": set(sans_ip), "sans_dns": set(sans_dns)}
+
     def certificate_sans_updated(self, tls_type: TLSType) -> bool:
         """Check current certificate sans and determine if certificate requires update.
 
         Returns:
             bool: True if certificate sans have changed, False if they are still the same.
         """
-        return True
+        current_sans = self.get_current_sans(tls_type)
+        new_sans_ip = self.build_sans_ip(tls_type)
+        new_sans_dns = self.build_sans_dns()
+
+        if new_sans_ip ^ current_sans["sans_ip"] or new_sans_dns ^ current_sans["sans_dns"]:
+            return True
+
+        return False
 
     def collect_client_cas(self) -> set[str]:
         """Collect client CAs.

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -5,7 +5,6 @@
 """Manager for handling TLS related events."""
 
 import logging
-import socket
 from ipaddress import ip_address
 from pathlib import Path
 from typing import Dict, Iterable
@@ -310,14 +309,10 @@ class TLSManager:
             extra_sans = [san.strip() for san in extra_sans_config.split(",")]
             sans_ip = {san for san in extra_sans if self._is_ip_address(san)}
 
-        if private_ip := self.workload.get_private_ip():
-            sans_ip.add(private_ip)
-        else:
-            logger.warning("No private IP found using unit-get. Using socket instead.")
-            sans_ip.add(socket.gethostbyname(socket.gethostname()))
+        sans_ip.add(self.workload.get_private_ip())
 
         if tls_type == TLSType.PEER:
-            logger.debug(f"Using private IP {private_ip} for peer SANs IP.")
+            logger.debug("Using private IP for peer SANs IP.")
             return frozenset(sans_ip)
 
         # For client TLS, we use both private and public IPs if available

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -5,7 +5,6 @@
 """Manager for handling TLS related events."""
 
 import logging
-import re
 import socket
 from ipaddress import ip_address
 from pathlib import Path
@@ -15,6 +14,7 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
     PrivateKey,
     ProviderCertificate,
 )
+from validators import ValidationError, hostname
 
 from common.certificates import is_leaf_certificate_valid, leaf_certificate
 from core.cluster import ClusterState
@@ -275,6 +275,28 @@ class TLSManager:
 
         return status_list
 
+    def _is_ip_address(self, input_value: str) -> bool:
+        """Validate a given str and return True if it is an IP address, False if not."""
+        try:
+            ip_address(input_value)
+            return True
+        except ValueError:
+            return False
+
+    def _is_hostname(self, input_value: str) -> bool:
+        """Validate a given str and return True if it is a hostname, False if not."""
+        try:
+            # Hostname string may only be hyphens and alpha-numerals.
+            return hostname(
+                input_value,
+                skip_ipv4_addr=True,
+                skip_ipv6_addr=True,
+                may_have_port=False,
+                maybe_simple=True,
+            )
+        except ValidationError:
+            return False
+
     def build_sans_ip(self, tls_type: TLSType) -> frozenset[str]:
         """Build the SANs IP for the TLS certificate.
 
@@ -286,7 +308,7 @@ class TLSManager:
             extra_sans_config := self.state.config.get("certificate-extra-sans")
         ):
             extra_sans = [san.strip() for san in extra_sans_config.split(",")]
-            sans_ip = {san for san in extra_sans if len(san.split(".")) == 4}
+            sans_ip = {san for san in extra_sans if self._is_ip_address(san)}
 
         if private_ip := self.workload.get_private_ip():
             sans_ip.add(private_ip)
@@ -319,7 +341,7 @@ class TLSManager:
             sans_dns = {
                 san.replace("{unit}", str(self.state.unit_server.unit_id))
                 for san in extra_sans
-                if len(san.split(".")) != 4
+                if not self._is_ip_address(san)
             }
 
         sans_dns.add(self.state.unit_server.unit_name)
@@ -336,20 +358,14 @@ class TLSManager:
             return True
 
         extra_sans = [san.strip() for san in extra_sans_config.split(",")]
-        allowed = re.compile(r"(?!-)[A-Z0-9-{}]{1,63}(?<!-)$", re.IGNORECASE)
 
         for san in extra_sans:
-            # validation for ip addresses
-            if len(san.split(".")) == 4:
-                try:
-                    ip_address(san)
-                except ValueError:
-                    logger.error(f"certificate-extra-sans configuration is invalid for ip {san}")
+            if not self._is_ip_address(san):
+                if not self._is_hostname(
+                    san.replace("{unit}", str(self.state.unit_server.unit_id))
+                ):
+                    logger.error(f"certificate-extra-sans configuration is invalid for {san}")
                     return False
-            # validation for dns names
-            elif not all(allowed.match(x) for x in san.split(".")):
-                logger.error(f"certificate-extra-sans configuration is invalid for dns {san}")
-                return False
 
         return True
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -360,6 +360,8 @@ class TLSManager:
         else:
             cert_file = self.workload.paths.tls.peer_cert
 
+        sans_ip = set()
+        sans_dns = set()
         if not (
             san_lines := self.workload.exec(
                 [
@@ -373,20 +375,18 @@ class TLSManager:
                 ]
             ).splitlines()
         ):
-            return {"sans_ip": set(), "sans_dns": set()}
+            return {"sans_ip": sans_ip, "sans_dns": sans_dns}
 
-        sans_ip = []
-        sans_dns = []
         for line in san_lines:
             for sans in line.split(", "):
                 san_type, san_value = sans.split(":")
 
                 if san_type.strip() == "DNS":
-                    sans_dns.append(san_value)
+                    sans_dns.add(san_value)
                 if san_type.strip() == "IP Address":
-                    sans_ip.append(san_value)
+                    sans_ip.add(san_value)
 
-        return {"sans_ip": set(sans_ip), "sans_dns": set(sans_dns)}
+        return {"sans_ip": sans_ip, "sans_dns": sans_dns}
 
     def certificate_sans_updated(self, tls_type: TLSType) -> bool:
         """Check current certificate sans and determine if certificate requires update.

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -308,7 +308,7 @@ class TLSManager:
             return True
 
         extra_sans = [san.strip() for san in extra_sans_config.split(",")]
-        allowed = re.compile(r"(?!-)[A-Z0-9-\{\}]{1,63}(?<!-)$", re.IGNORECASE)
+        allowed = re.compile(r"(?!-)[A-Z0-9-{}]{1,63}(?<!-)$", re.IGNORECASE)
 
         for san in extra_sans:
             # validation for ip addresses

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -303,7 +303,6 @@ class TLSManager:
             logger.debug("Using public and private IPs for SANs.")
             sans_ip.add(public_ip)
 
-        logger.info(sans_ip)
         return frozenset(sans_ip)
 
     def build_sans_dns(self) -> frozenset[str]:

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -5,7 +5,9 @@
 """Manager for handling TLS related events."""
 
 import logging
+import re
 import socket
+from ipaddress import ip_address
 from pathlib import Path
 from typing import Iterable
 
@@ -268,6 +270,9 @@ class TLSManager:
         if self.state.unit_server.tls_peer_certs_expiring:
             status_list.append(Status.TLS_PEER_CERTS_EXPIRING)
 
+        if not self.extra_sans_config_is_valid():
+            status_list.append(Status.SANS_CONFIG_INVALID)
+
         return status_list
 
     def get_sans_ip(self, tls_type: TLSType) -> frozenset[str]:
@@ -292,6 +297,41 @@ class TLSManager:
 
         logger.debug(f"Using only private IP {private_ip} for SANs IP.")
         return frozenset({private_ip})
+
+    def extra_sans_config_is_valid(self) -> bool:
+        """Validate configuration value for certificate-extra-sans option.
+
+        Returns:
+            bool: True if config value is valid, False if invalid.
+        """
+        if not (extra_sans_config := self.state.config.get("certificate-extra-sans")):
+            return True
+
+        extra_sans = [san.strip() for san in extra_sans_config.split(",")]
+        allowed = re.compile(r"(?!-)[A-Z0-9-\{\}]{1,63}(?<!-)$", re.IGNORECASE)
+
+        for san in extra_sans:
+            # validation for ip addresses
+            if len(san.split(".")) == 4:
+                try:
+                    ip_address(san)
+                except ValueError:
+                    logger.error(f"certificate-extra-sans configuration is invalid for ip {san}")
+                    return False
+            # validation for dns names
+            elif not all(allowed.match(x) for x in san.split(".")):
+                logger.error(f"certificate-extra-sans configuration is invalid for dns {san}")
+                return False
+
+        return True
+
+    def certificate_sans_updated(self, tls_type: TLSType) -> bool:
+        """Check current certificate sans and determine if certificate requires update.
+
+        Returns:
+            bool: True if certificate sans have changed, False if they are still the same.
+        """
+        return True
 
     def collect_client_cas(self) -> set[str]:
         """Collect client CAs.

--- a/src/workload.py
+++ b/src/workload.py
@@ -111,7 +111,7 @@ class EtcdWorkload(WorkloadBase):
         return False
 
     @override
-    def exec(self, command: List[str]) -> None:
+    def exec(self, command: List[str]) -> str:
         try:
             output = subprocess.run(
                 command,
@@ -121,6 +121,7 @@ class EtcdWorkload(WorkloadBase):
                 timeout=10,
             ).stdout.strip()
             logger.debug(output)
+            return output
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.error(e)
             raise

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 import logging
+import subprocess
 from time import sleep
 
 import pytest
@@ -216,6 +217,66 @@ async def test_enable_tls(ops_test: OpsTest) -> None:
         )
         == TEST_VALUE
     ), "Failed to read new key"
+
+
+@pytest.mark.abort_on_fail
+async def test_extra_sans_config_option(ops_test: OpsTest) -> None:
+    """Configure extra sans for the TLS certificates."""
+    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME])
+
+    logger.info("Set config to invalid sans value")
+    config_value = "-my.hostname"
+    await ops_test.model.applications[APP_NAME].set_config(
+        {"certificates-extra-sans": config_value}
+    )
+
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME, TLS_NAME],
+        apps_full_statuses={
+            APP_NAME: {"blocked": [Status.SANS_CONFIG_INVALID.value.status.message]},
+        },
+        wait_for_exact_units=NUM_UNITS,
+    )
+
+    await download_client_certificate_from_unit(ops_test, APP_NAME)
+    client_cert_sans = subprocess.getoutput(
+        "openssl x509 -noout -ext subjectAltName -in client.pem "
+    )
+    assert config_value not in client_cert_sans, (
+        f"config value {config_value} found in certificate sans {client_cert_sans}"
+    )
+
+    logger.info("Configure valid extra-sans")
+    config_value = "server-{unit}.etcd-cluster"
+    await ops_test.model.applications[APP_NAME].set_config(
+        {"certificates-extra-sans": config_value}
+    )
+
+    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME], wait_for_exact_units=NUM_UNITS)
+
+    await download_client_certificate_from_unit(ops_test, APP_NAME)
+    client_cert_sans = subprocess.getoutput(
+        "openssl x509 -noout -ext subjectAltName -in client.pem "
+    )
+    unit = ops_test.model.applications[APP_NAME].units[0].name
+    expected_sans = config_value.replace("{unit}", unit.id)
+    assert expected_sans in client_cert_sans, (
+        f"expected sans {expected_sans} not found in certificate sans {client_cert_sans}"
+    )
+
+    logger.info("Resetting configuration for extra-sans")
+    await ops_test.model.applications[APP_NAME].reset_config(["certificates-extra-sans"])
+
+    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME], wait_for_exact_units=NUM_UNITS)
+
+    await download_client_certificate_from_unit(ops_test, APP_NAME)
+    client_cert_sans = subprocess.getoutput(
+        "openssl x509 -noout -ext subjectAltName -in client.pem "
+    )
+    assert expected_sans not in client_cert_sans, (
+        f"expected sans {expected_sans} found in certificate sans {client_cert_sans}"
+    )
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -255,12 +255,13 @@ async def test_extra_sans_config_option(ops_test: OpsTest) -> None:
 
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
+    # this will download the client cert from application.units[0]
     await download_client_certificate_from_unit(ops_test, APP_NAME)
     client_cert_sans = subprocess.getoutput(
         "openssl x509 -noout -ext subjectAltName -in client.pem "
     )
     unit = ops_test.model.applications[APP_NAME].units[0]
-    expected_sans = config_value.replace("{unit}", unit.id)
+    expected_sans = config_value.replace("{unit}", unit.name.split("/")[-1])
     assert expected_sans in client_cert_sans, (
         f"expected sans {expected_sans} not found in certificate sans {client_cert_sans}"
     )

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -232,7 +232,7 @@ async def test_extra_sans_config_option(ops_test: OpsTest) -> None:
 
     await wait_until(
         ops_test,
-        apps=[APP_NAME, TLS_NAME],
+        apps=[APP_NAME],
         apps_full_statuses={
             APP_NAME: {"blocked": [Status.SANS_CONFIG_INVALID.value.status.message]},
         },
@@ -253,7 +253,7 @@ async def test_extra_sans_config_option(ops_test: OpsTest) -> None:
         {"certificate-extra-sans": config_value}
     )
 
-    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME], wait_for_exact_units=NUM_UNITS)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
     await download_client_certificate_from_unit(ops_test, APP_NAME)
     client_cert_sans = subprocess.getoutput(
@@ -268,7 +268,7 @@ async def test_extra_sans_config_option(ops_test: OpsTest) -> None:
     logger.info("Resetting configuration for extra-sans")
     await ops_test.model.applications[APP_NAME].reset_config(["certificate-extra-sans"])
 
-    await wait_until(ops_test, apps=[APP_NAME, TLS_NAME], wait_for_exact_units=NUM_UNITS)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
     await download_client_certificate_from_unit(ops_test, APP_NAME)
     client_cert_sans = subprocess.getoutput(

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -259,7 +259,7 @@ async def test_extra_sans_config_option(ops_test: OpsTest) -> None:
     client_cert_sans = subprocess.getoutput(
         "openssl x509 -noout -ext subjectAltName -in client.pem "
     )
-    unit = ops_test.model.applications[APP_NAME].units[0].name
+    unit = ops_test.model.applications[APP_NAME].units[0]
     expected_sans = config_value.replace("{unit}", unit.id)
     assert expected_sans in client_cert_sans, (
         f"expected sans {expected_sans} not found in certificate sans {client_cert_sans}"

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -227,7 +227,7 @@ async def test_extra_sans_config_option(ops_test: OpsTest) -> None:
     logger.info("Set config to invalid sans value")
     config_value = "-my.hostname"
     await ops_test.model.applications[APP_NAME].set_config(
-        {"certificates-extra-sans": config_value}
+        {"certificate-extra-sans": config_value}
     )
 
     await wait_until(
@@ -250,7 +250,7 @@ async def test_extra_sans_config_option(ops_test: OpsTest) -> None:
     logger.info("Configure valid extra-sans")
     config_value = "server-{unit}.etcd-cluster"
     await ops_test.model.applications[APP_NAME].set_config(
-        {"certificates-extra-sans": config_value}
+        {"certificate-extra-sans": config_value}
     )
 
     await wait_until(ops_test, apps=[APP_NAME, TLS_NAME], wait_for_exact_units=NUM_UNITS)
@@ -266,7 +266,7 @@ async def test_extra_sans_config_option(ops_test: OpsTest) -> None:
     )
 
     logger.info("Resetting configuration for extra-sans")
-    await ops_test.model.applications[APP_NAME].reset_config(["certificates-extra-sans"])
+    await ops_test.model.applications[APP_NAME].reset_config(["certificate-extra-sans"])
 
     await wait_until(ops_test, apps=[APP_NAME, TLS_NAME], wait_for_exact_units=NUM_UNITS)
 

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1638,11 +1638,13 @@ def test_set_extra_sans_config_option():
         relations={relation},
     )
 
-    current_sans_value = "X509v3 Subject Alternative Name: \n    DNS:myhostname, DNS:my_hostname, DNS:charmed-etcd/0, IP Address:127.0.1.1, IP Address:192.168.1.100"
+    current_sans_value = "X509v3 Subject Alternative Name: \n    DNS:myhostname, DNS:charmed-etcd/0, IP Address:127.0.1.1, IP Address:192.168.1.100"
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
         patch("workload.EtcdWorkload.exec", return_value=current_sans_value),
+        patch("workload.EtcdWorkload.get_host_mapping", return_value={"hostname": "myhostname"}),
+        patch("workload.EtcdWorkload.get_private_ip", return_value="127.0.1.1"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
         # no RefreshTLSCertificatesEvent must be emitted

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -27,6 +27,7 @@ from scenario import Secret
 
 from charm import EtcdOperatorCharm
 from core.models import Member
+from events.tls import RefreshTLSCertificatesEvent
 from literals import (
     CLIENT_TLS_RELATION_NAME,
     PEER_RELATION,
@@ -1475,7 +1476,7 @@ def test_ca_client_rotation(certificate_available_context):
             event.defer.assert_not_called()
 
 
-def test_set_extra_sans_config_options():
+def test_set_extra_sans_config_option():
     relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
@@ -1483,12 +1484,16 @@ def test_set_extra_sans_config_options():
             "authentication": "enabled",
             "cluster_state": "existing",
         },
-        local_unit_data={"private_ip": "my_ip"},
+        local_unit_data={
+            "private_ip": "my_ip",
+            "tls_peer_state": TLSState.TLS.value,
+            "tls_client_state": TLSState.TLS.value,
+        },
     )
     current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
-    ctx = testing.Context(EtcdOperatorCharm)
 
     # happy path
+    ctx = testing.Context(EtcdOperatorCharm)
     state_in = testing.State(
         config={
             "certificate-extra-sans": "192.168.1.100, myhostname",
@@ -1500,9 +1505,11 @@ def test_set_extra_sans_config_options():
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
+        assert isinstance(ctx.emitted_events[1], RefreshTLSCertificatesEvent)
         assert state_out.unit_status == ActiveStatus()
 
     # allow {unit} placeholder
+    ctx = testing.Context(EtcdOperatorCharm)
     state_in = testing.State(
         config={
             "certificate-extra-sans": "192.168.1.100, etcd-{unit}.hostname",
@@ -1514,9 +1521,11 @@ def test_set_extra_sans_config_options():
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
+        assert isinstance(ctx.emitted_events[1], RefreshTLSCertificatesEvent)
         assert state_out.unit_status == ActiveStatus()
 
     # invalid ip address
+    ctx = testing.Context(EtcdOperatorCharm)
     state_in = testing.State(
         config={
             "certificate-extra-sans": "192.168.257.100, myhostname",
@@ -1531,11 +1540,14 @@ def test_set_extra_sans_config_options():
         assert state_out.unit_status == BlockedStatus(
             "Invalid value set for the config options 'certificate-extra-sans'"
         )
+        # no RefreshTLSCertificatesEvent must be emitted
+        assert len(ctx.emitted_events) == 1
 
     # invalid dns name
+    ctx = testing.Context(EtcdOperatorCharm)
     state_in = testing.State(
         config={
-            "certificate-extra-sans": "my hostname",
+            "certificate-extra-sans": "-myhostname",
         },
         relations={relation},
     )
@@ -1547,8 +1559,30 @@ def test_set_extra_sans_config_options():
         assert state_out.unit_status == BlockedStatus(
             "Invalid value set for the config options 'certificate-extra-sans'"
         )
+        # no RefreshTLSCertificatesEvent must be emitted
+        assert len(ctx.emitted_events) == 1
+
+    # another invalid dns name
+    ctx = testing.Context(EtcdOperatorCharm)
+    state_in = testing.State(
+        config={
+            "certificate-extra-sans": "myhostname-",
+        },
+        relations={relation},
+    )
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        assert state_out.unit_status == BlockedStatus(
+            "Invalid value set for the config options 'certificate-extra-sans'"
+        )
+        # no RefreshTLSCertificatesEvent must be emitted
+        assert len(ctx.emitted_events) == 1
 
     # first ip address valid, second one invalid
+    ctx = testing.Context(EtcdOperatorCharm)
     state_in = testing.State(
         config={
             "certificate-extra-sans": "192.168.1.100, myhostname, 999.1.2.3",
@@ -1563,8 +1597,11 @@ def test_set_extra_sans_config_options():
         assert state_out.unit_status == BlockedStatus(
             "Invalid value set for the config options 'certificate-extra-sans'"
         )
+        # no RefreshTLSCertificatesEvent must be emitted
+        assert len(ctx.emitted_events) == 1
 
     # special characters in dns name
+    ctx = testing.Context(EtcdOperatorCharm)
     state_in = testing.State(
         config={
             "certificate-extra-sans": "192.168.1.100, my$*hostname",
@@ -1579,3 +1616,5 @@ def test_set_extra_sans_config_options():
         assert state_out.unit_status == BlockedStatus(
             "Invalid value set for the config options 'certificate-extra-sans'"
         )
+        # no RefreshTLSCertificatesEvent must be emitted
+        assert len(ctx.emitted_events) == 1

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -22,7 +22,7 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
-from ops import testing
+from ops import ActiveStatus, BlockedStatus, testing
 from scenario import Secret
 
 from charm import EtcdOperatorCharm
@@ -1473,3 +1473,109 @@ def test_ca_client_rotation(certificate_available_context):
                 == TLSCARotationState.NO_ROTATION.value
             )
             event.defer.assert_not_called()
+
+
+def test_set_extra_sans_config_options():
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={
+            "authentication": "enabled",
+            "cluster_state": "existing",
+        },
+        local_unit_data={"private_ip": "my_ip"},
+    )
+    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+    ctx = testing.Context(EtcdOperatorCharm)
+
+    # happy path
+    state_in = testing.State(
+        config={
+            "certificate-extra-sans": "192.168.1.100, myhostname",
+        },
+        relations={relation},
+    )
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        assert state_out.unit_status == ActiveStatus()
+
+    # allow {unit} placeholder
+    state_in = testing.State(
+        config={
+            "certificate-extra-sans": "192.168.1.100, etcd-{unit}.hostname",
+        },
+        relations={relation},
+    )
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        assert state_out.unit_status == ActiveStatus()
+
+    # invalid ip address
+    state_in = testing.State(
+        config={
+            "certificate-extra-sans": "192.168.257.100, myhostname",
+        },
+        relations={relation},
+    )
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        assert state_out.unit_status == BlockedStatus(
+            "Invalid value set for the config options 'certificate-extra-sans'"
+        )
+
+    # invalid dns name
+    state_in = testing.State(
+        config={
+            "certificate-extra-sans": "my hostname",
+        },
+        relations={relation},
+    )
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        assert state_out.unit_status == BlockedStatus(
+            "Invalid value set for the config options 'certificate-extra-sans'"
+        )
+
+    # first ip address valid, second one invalid
+    state_in = testing.State(
+        config={
+            "certificate-extra-sans": "192.168.1.100, myhostname, 999.1.2.3",
+        },
+        relations={relation},
+    )
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        assert state_out.unit_status == BlockedStatus(
+            "Invalid value set for the config options 'certificate-extra-sans'"
+        )
+
+    # special characters in dns name
+    state_in = testing.State(
+        config={
+            "certificate-extra-sans": "192.168.1.100, my$*hostname",
+        },
+        relations={relation},
+    )
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        assert state_out.unit_status == BlockedStatus(
+            "Invalid value set for the config options 'certificate-extra-sans'"
+        )

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -806,6 +806,7 @@ def test_set_tls_private_key():
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4._find_available_certificates"
         ),
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
         patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
         patch("common.client.EtcdClient.broadcast_peer_url"),
         patch("workload.EtcdWorkload.write_file"),
@@ -974,6 +975,7 @@ def test_set_tls_private_key():
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4._find_available_certificates"
         ),
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
     ):
         # Configure client private key
         state_in = testing.State(
@@ -1059,6 +1061,7 @@ def test_set_tls_private_key():
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4._cleanup_certificate_requests"
         ) as cleanup,
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
     ):
         # Configure peer private key configured
         ctx.run(ctx.on.config_changed(), state_in)
@@ -1503,6 +1506,7 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
         assert isinstance(ctx.emitted_events[1], RefreshTLSCertificatesEvent)
@@ -1519,6 +1523,7 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
         assert isinstance(ctx.emitted_events[1], RefreshTLSCertificatesEvent)
@@ -1535,6 +1540,7 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
         assert state_out.unit_status == BlockedStatus(
@@ -1554,6 +1560,7 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
         assert state_out.unit_status == BlockedStatus(
@@ -1573,6 +1580,7 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
         assert state_out.unit_status == BlockedStatus(
@@ -1592,6 +1600,7 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
         assert state_out.unit_status == BlockedStatus(
@@ -1611,6 +1620,7 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
         assert state_out.unit_status == BlockedStatus(
@@ -1618,3 +1628,23 @@ def test_set_extra_sans_config_option():
         )
         # no RefreshTLSCertificatesEvent must be emitted
         assert len(ctx.emitted_events) == 1
+
+    # no update -> no certificate refresh
+    ctx = testing.Context(EtcdOperatorCharm)
+    state_in = testing.State(
+        config={
+            "certificate-extra-sans": "192.168.1.100, myhostname",
+        },
+        relations={relation},
+    )
+
+    current_sans_value = "X509v3 Subject Alternative Name: \n    DNS:myhostname, DNS:my_hostname, DNS:charmed-etcd/0, IP Address:127.0.1.1, IP Address:192.168.1.100"
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("workload.EtcdWorkload.exec", return_value=current_sans_value),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        # no RefreshTLSCertificatesEvent must be emitted
+        assert len(ctx.emitted_events) == 1
+        assert state_out.unit_status == ActiveStatus()


### PR DESCRIPTION
**UI/UX changes:**

- introduce config option `certificate-extra-sans` to configure DNS names or IP addresses to be added as `SubjectAlternativeName` to the certificates used by etcd for client- and peer-communication
- add a BlockedStatus in case the config option is set to an invalid value (invalid IP address or invalid DNS name)

**Implementation:**
- when running the `config_changed` hook, refresh TLS certificates if TLS is enabled, the configuration value is valid and the `SubjectAlternativeNames` are different from the current certificates
- add methods to `TLSManager`: `extra_sans_config_is_valid`, `build_sans_dns`, `get_current_sans` and `certificate_sans_updated` to handle the processing and update-check for certificate sans
- add helper methods `_is_ip_address()` and `_is_hostname()` to `TLSManager` for validation of the config values
- check validity of `certificate-extra-sans` configuration value in TLS status computation

**Testing:**
- add unit test coverage for the various validation checks on DNS names and IP addresses
- add integration test coverage for setting the `certificate-extra-sans` config to valid and invalid values as well as resetting it

**Refactoring:**
- move TLS related parts of `config_changed` and `secret_changed` event handlers from `EtcdEvents` class to `TLSEvents` class
- rename TLS-manager's `get_sans_ip()` to `build_sans_ip` and refactor it internally
- add a return value to `EtcdWorkload.exec()` to capture the output of `openssl` commands needed to inspect the currently installed TLS certificates
- added the fallback for retrieval of the private ip to `EtcdWorkload.get_private_ip()` instead of handling it outside of the method