### PR TITLE
[DPE-7822]: Add additional safeguards in update status and creating external clients

### DIFF
--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -375,7 +375,8 @@ class EtcdEvents(Object):
     def _on_update_status(self, event: ops.UpdateStatusEvent) -> None:
         """Handle update_status event."""
         if (
-            self.charm.state.cluster.is_restore_in_progress
+            not self.charm.state.cluster.cluster_state
+            or self.charm.state.cluster.is_restore_in_progress
             or self.charm.state.cluster.rebuild_cluster_in_progress
         ):
             return

--- a/src/events/external_clients.py
+++ b/src/events/external_clients.py
@@ -65,11 +65,13 @@ class ExternalClientsEvents(Object):
             logger.error("CA chain, keys prefix, or common name not provided")
             self.charm.set_status(Status.EC_MISSING_CREDENTIALS)
             return
+
         if self.charm.state.unit_server.tls_client_state in [TLSState.NO_TLS, TLSState.TO_NO_TLS]:
             logger.error("TLS is not enabled")
             self.charm.set_status(Status.EC_TLS_IS_DISABLED)
             event.defer()
             return
+
         if self.charm.state.unit_server.tls_client_state == TLSState.TO_TLS:
             logger.error("TLS is not ready")
             self.charm.set_status(Status.TLS_NOT_READY)
@@ -82,6 +84,12 @@ class ExternalClientsEvents(Object):
         ):
             logger.debug("CA rotation is in progress")
             self.charm.set_status(Status.TLS_CLIENT_CA_ROTATING)
+            event.defer()
+            return
+
+        if not self.charm.state.cluster.auth_enabled:
+            logger.error("Cluster authentication is not enabled")
+            self.charm.set_status(Status.CLUSTER_NOT_INITIALIZED)
             event.defer()
             return
 


### PR DESCRIPTION
### Cluster state and authentication handling:

* [`src/events/etcd.py`](diffhunk://#diff-4d4b45129d72bf79a08e70009a59f4ebe0a016b4727117155249c864ae4a1b49L378-R379): Updated the `_on_update_status` method to ensure the event handler checks if the cluster state is unavailable (`not self.charm.state.cluster.cluster_state`) before proceeding. 
* [`src/events/external_clients.py`](diffhunk://#diff-41d3b0e68fba8bc44a83df27841cc482ba1df8a5cfe8e476397765673f46f446R90-R95): Added a new condition in the `_on_mtls_cert_updated` method to verify that cluster authentication is enabled (`self.charm.state.cluster.auth_enabled`) before proceeding. If authentication is not enabled, an error is logged, the status is updated to `CLUSTER_NOT_INITIALIZED`, and the event is deferred.