### PR TITLE
[DPE-7734] [DPE-7786] Add tuning docs and migration guide

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -55,6 +55,8 @@ URI
 URIs
 programmatically
 GCP
+GCS
+MinIO
 CSR
 CSRs
 TLS

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -6,9 +6,11 @@ cjk
 cryptographically
 CSR
 etcd
+etcd's
 dvipng
 defragmentation
 defragment
+failover
 fonts
 freefont
 fsync
@@ -16,6 +18,8 @@ github
 GPG
 gRPC
 gyre
+hostname
+hostnames
 https
 Intersphinx
 IPv
@@ -43,6 +47,8 @@ wordlist
 txt
 checksum
 checksums
+SAN
+SANs
 SHA
 durations
 URI
@@ -52,5 +58,6 @@ GCP
 CSR
 CSRs
 TLS
+mTLS
 CIS
 RadosGateway

--- a/docs/how-to/backup-and-restore/index.md
+++ b/docs/how-to/backup-and-restore/index.md
@@ -7,5 +7,5 @@
 Configure object storage provider <configure-object-storage-provider>
 Create backup <create-backup>
 Restore backup <restore-backup>
-Migrate a cluster <migrate-etcd>
+Migrate an etcd cluster <migrate-etcd>
 ```

--- a/docs/how-to/backup-and-restore/index.md
+++ b/docs/how-to/backup-and-restore/index.md
@@ -7,5 +7,5 @@
 Configure object storage provider <configure-object-storage-provider>
 Create backup <create-backup>
 Restore backup <restore-backup>
-Migrate to charmed etcd <migrate-etcd>
+Migrate a cluster <migrate-etcd>
 ```

--- a/docs/how-to/backup-and-restore/migrate-etcd.md
+++ b/docs/how-to/backup-and-restore/migrate-etcd.md
@@ -1,4 +1,4 @@
-# How To migrate an etcd cluster
+# How to migrate an etcd cluster
 This guide will show how to restore a backup that was made from a different etcd cluster (i.e. cluster migration via restore).
 
 You can migrate different types of etcd clusters to charmed etcd:

--- a/docs/how-to/backup-and-restore/migrate-etcd.md
+++ b/docs/how-to/backup-and-restore/migrate-etcd.md
@@ -1,4 +1,4 @@
-# How To migrate to charmed etcd
+# How To migrate an etcd cluster
 This guide will show how to restore a backup that was made from a different etcd cluster (i.e. cluster migration via restore).
 
 You can migrate different types of etcd clusters to charmed etcd:

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -11,5 +11,6 @@ Enable monitoring <enable-monitoring>
 Integrate with an application <client-relations>
 TLS encryption <tls/index>
 Back up and restore <backup-and-restore/index>
+Tuning in Production <tuning>
 Disaster recovery <disaster-recovery>
 ```

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -13,4 +13,5 @@ TLS encryption <tls/index>
 Back up and restore <backup-and-restore/index>
 Tuning in Production <tuning>
 Disaster recovery <disaster-recovery>
+Migrate to charmed etcd <migrate-to-charmed-etcd>
 ```

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -11,7 +11,7 @@ Enable monitoring <enable-monitoring>
 Integrate with an application <client-relations>
 TLS encryption <tls/index>
 Back up and restore <backup-and-restore/index>
-Tuning in Production <tuning>
+Tune etcd settings <tune-settings>
 Disaster recovery <disaster-recovery>
 Migrate to charmed etcd <migrate-to-charmed-etcd>
 ```

--- a/docs/how-to/migrate-to-charmed-etcd.md
+++ b/docs/how-to/migrate-to-charmed-etcd.md
@@ -1,4 +1,4 @@
-# How To migrate to charmed etcd
+# How to migrate to charmed etcd
 
 This guide outlines the steps required to migrate an existing etcd cluster to a charmed etcd cluster.
 
@@ -116,7 +116,7 @@ s3-integrator/0*             active    idle   4        10.143.229.157
 self-signed-certificates/0*  active    idle   3        10.143.229.160
 ```
 
-## Integrate with object storage provider
+## Integrate charmed etcd with an object storage provider
 
 After charmed etcd has been deployed, integrate it with the deployed object storage provider to provide access 
 the object storage. In our case, this happens with `s3-integrator` over the `s3-credentials` interface.
@@ -141,7 +141,7 @@ s3-integrator:s3-credentials       charmed-etcd:s3-credentials        s3        
 s3-integrator:s3-integrator-peers  s3-integrator:s3-integrator-peers  s3-integrator-peers  peer     
 ```
 
-## Integrate with TLS provider
+## Integrate charmed etcd with a TLS provider
 
 Because charmed etcd relies on mTLS for client authentication and authorisation, it is mandatory to set up client TLS in 
 charmed etcd. To do so, integrate with the deployed TLS provider over the `tls-certificates` interface. In our case, 
@@ -203,7 +203,7 @@ self-signed-certificates:certificates  charmed-etcd:client-certificates   tls-ce
 self-signed-certificates:certificates  charmed-etcd:peer-certificates     tls-certificates     regular  
 ```
 
-## Optional: apply cluster credentials to charmed etcd
+## [_optional_]: Apply cluster credentials
 
 If your previous etcd cluster did not have authentication enabled, this step can be skipped.
 

--- a/docs/how-to/migrate-to-charmed-etcd.md
+++ b/docs/how-to/migrate-to-charmed-etcd.md
@@ -157,7 +157,7 @@ s3-integrator:s3-integrator-peers  s3-integrator:s3-integrator-peers  s3-integra
 
 ### Integrate with TLS provider
 
-Because charmed etcd relies on mTLS for client authentication and authorization, it is mandatory to set up client TLS in 
+Because charmed etcd relies on mTLS for client authentication and authorisation, it is mandatory to set up client TLS in 
 charmed etcd. To do so, integrate with the deployed TLS provider over the `tls-certificates` interface. In our case, 
 this is with the `self-signed-certificates` operator.
 

--- a/docs/how-to/migrate-to-charmed-etcd.md
+++ b/docs/how-to/migrate-to-charmed-etcd.md
@@ -1,38 +1,40 @@
 # How To migrate to charmed etcd
 
-This guide outlines the steps required to migrate an existing etcd to charmed etcd.
+This guide outlines the steps required to migrate an existing etcd cluster to a charmed etcd cluster.
 
 ## Prerequisites
 
-- a Juju VM controller with a model
-- TLS Provider deployed to that model, in our case we use `self-signed-certificates` (see [](tls/enable-tls.md))
-- Object Storage Provider deployed to that model, in our case we use `s3-integrator` (see [](backup-and-restore/configure-object-storage-provider.md))
-- your existing etcd cluster must be at least of version 3.0
+- A Juju VM controller with a model
+- A TLS Provider deployed to that model, in our case we use `self-signed-certificates` (see [](tls/enable-tls.md))
+- An Object Storage Provider deployed to that model, in our case we use `s3-integrator` (see [](backup-and-restore/configure-object-storage-provider.md))
+- Your existing etcd cluster must be at least of version 3.0
 
-## Migration Guide
+## Summary
 
-Migrating to charmed etcd includes the following steps:
-- create a backup of your existing cluster
-- upload the backup to object storage
-- deploy charmed etcd
-- integrate charmed etcd with object storage provider
-- integrate charmed etcd with TLS provider
-- optional: apply cluster credentials
-- restore the backup to charmed etcd
-- switch your application over to charmed etcd
+These are the steps you will need to follow to migrate to charmed etcd:
+- Create a backup of your existing cluster
+- Upload the backup to an object storage (s3-compatible or Azure blob storage)
+- Deploy charmed etcd
+- Integrate charmed etcd with an object storage provider
+- Integrate charmed etcd with a TLS provider
+- [_optional_]: Apply cluster credentials
+- Restore the backup to charmed etcd
+- Switch your application over to charmed etcd
 
-### Create a backup
+## Create a backup
 
-Migrating your existing etcd cluster to charmed etcd happens via backup and restore. First, create a backup of your
-existing etcd cluster. The following command is an example for a snap-based installation of [etcd](https://snapcraft.io/etcd)
-in version `3.4.36`. It connects to etcd via `localhost` and creates a backup file called `etcd-backup.db` in the current
-working directory:
+Migrating your existing etcd cluster to charmed etcd happens via backup and restore.
+
+First, create a backup of your existing etcd cluster. The following command is an example for a snap-based installation 
+of [etcd](https://snapcraft.io/etcd) in version `3.4.36`. It connects to etcd via `localhost` and creates a backup file 
+called `etcd-backup.db` in the current working directory:
 
 ```text
 etcdctl snapshot save etcd-backup.db
 ```
 
 This will prompt the following output (or similar):
+
 ```text
 {"level":"info","ts":1754036152.734727,"caller":"snapshot/v3_snapshot.go:119","msg":"created temporary db file","path":"etcd-backup.db.part"}
 {"level":"info","ts":"2025-08-01T08:15:52.736886Z","caller":"clientv3/maintenance.go:212","msg":"opened snapshot stream; downloading"}
@@ -43,7 +45,7 @@ This will prompt the following output (or similar):
 Snapshot saved at etcd-backup.db
 ```
 
-### Upload the backup to object storage
+## Upload the backup to object storage
 
 For restoring backup files, charmed etcd supports S3-compatible (for example AWS, GCS, MinIO or MicroCeph) or Azure 
 object storage. In our example, we upload the backup file that we just created to S3-storage by using the `S3cmd` tool.
@@ -62,6 +64,7 @@ s3cmd ls s3://etcd-backups-test-bucket/ --access_key=<your-access-key> --secret_
 ```
 
 You should see your bucket listing all available directories:
+
 ```text
 DIR  s3://etcd-backups-test-bucket/etcd-backups/
 ```
@@ -73,7 +76,7 @@ If the storage bucket you want to use does not exist yet, create a bucket `etcd-
 s3cmd mb s3://etcd-backups-test-bucket/ --access_key=<your-access-key> --secret_key=<your-secret>
 ```
 
-With the following command, you can upload the backup file `etcd-backup.db` to the just created bucket 
+With the following command, you can upload the backup file `etcd-backup.db` to the newly created bucket 
 (replace placeholders with your credentials again):
 
 ```text
@@ -86,7 +89,7 @@ Ensure your backup file was uploaded correctly by repeating the `s3cmd ls s3://e
 2025-08-01 08:24        20512  s3://etcd-backups-test-bucket/etcd-backups/etcd-backup.db
 ```
 
-### Deploy charmed etcd
+## Deploy charmed etcd
 
 Now it's time to deploy charmed etcd. Run the following command to deploy a 3-unit cluster:
 
@@ -113,7 +116,7 @@ s3-integrator/0*             active    idle   4        10.143.229.157
 self-signed-certificates/0*  active    idle   3        10.143.229.160
 ```
 
-### Integrate with object storage provider
+## Integrate with object storage provider
 
 After charmed etcd has been deployed, integrate it with the deployed object storage provider to provide access 
 the object storage. In our case, this happens with `s3-integrator` over the `s3-credentials` interface.
@@ -128,26 +131,9 @@ juju integrate s3-integrator charmed-etcd
 Ensure s3-integrator is configured correctly. Please refer to [](backup-and-restore/configure-object-storage-provider.md) for more information.
 ```
 
-Shortly after the relation between them should be established:
+Shortly after, the relation between them should be established:
 
 ```text
-Model          Controller      Cloud/Region         Version  SLA          Timestamp
-backend-store  dev-controller  localhost/localhost  3.6.5    unsupported  08:38:22Z
-
-App                       Version  Status  Scale  Charm                     Channel   Rev  Exposed  Message
-charmed-etcd                       active      3  charmed-etcd              3.6/edge   68  no       
-s3-integrator                      active      1  s3-integrator             1/stable  145  no       
-self-signed-certificates           active      1  self-signed-certificates  1/stable  317  no       
-
-Unit                         Workload  Agent  Machine  Public address  Ports     Message
-charmed-etcd/0*              active    idle   0        10.143.229.222  2379/tcp  
-charmed-etcd/1               active    idle   1        10.143.229.119  2379/tcp  
-charmed-etcd/2               active    idle   2        10.143.229.81   2379/tcp  
-s3-integrator/0*             active    idle   4        10.143.229.157            
-self-signed-certificates/0*  active    idle   3        10.143.229.160            
-
-[...]
-
 Integration provider               Requirer                           Interface            Type     Message
 charmed-etcd:etcd-peers            charmed-etcd:etcd-peers            etcd_peers           peer     
 charmed-etcd:restart               charmed-etcd:restart               rolling_op           peer     
@@ -155,7 +141,7 @@ s3-integrator:s3-credentials       charmed-etcd:s3-credentials        s3        
 s3-integrator:s3-integrator-peers  s3-integrator:s3-integrator-peers  s3-integrator-peers  peer     
 ```
 
-### Integrate with TLS provider
+## Integrate with TLS provider
 
 Because charmed etcd relies on mTLS for client authentication and authorisation, it is mandatory to set up client TLS in 
 charmed etcd. To do so, integrate with the deployed TLS provider over the `tls-certificates` interface. In our case, 
@@ -208,23 +194,6 @@ Charmed etcd will enable peer TLS on all units with a rolling restart. After a f
 established and charmed etcd should be settled again:
 
 ```text
-Model          Controller      Cloud/Region         Version  SLA          Timestamp
-backend-store  dev-controller  localhost/localhost  3.6.5    unsupported  08:46:21Z
-
-App                       Version  Status  Scale  Charm                     Channel   Rev  Exposed  Message
-charmed-etcd                       active      3  charmed-etcd              3.6/edge   68  no       
-s3-integrator                      active      1  s3-integrator             1/stable  145  no       
-self-signed-certificates           active      1  self-signed-certificates  1/stable  317  no       
-
-Unit                         Workload  Agent  Machine  Public address  Ports     Message
-charmed-etcd/0*              active    idle   0        10.143.229.222  2379/tcp  
-charmed-etcd/1               active    idle   1        10.143.229.119  2379/tcp  
-charmed-etcd/2               active    idle   2        10.143.229.81   2379/tcp  
-s3-integrator/0*             active    idle   4        10.143.229.157            
-self-signed-certificates/0*  active    idle   3        10.143.229.160            
-
-[...]
-
 Integration provider                   Requirer                           Interface            Type     Message
 charmed-etcd:etcd-peers                charmed-etcd:etcd-peers            etcd_peers           peer     
 charmed-etcd:restart                   charmed-etcd:restart               rolling_op           peer     
@@ -234,7 +203,7 @@ self-signed-certificates:certificates  charmed-etcd:client-certificates   tls-ce
 self-signed-certificates:certificates  charmed-etcd:peer-certificates     tls-certificates     regular  
 ```
 
-### Optional: apply cluster credentials to charmed etcd
+## Optional: apply cluster credentials to charmed etcd
 
 If your previous etcd cluster did not have authentication enabled, this step can be skipped.
 
@@ -263,7 +232,7 @@ you noted earlier:
 juju config charmed-etcd system-users=secret:<your-secret-URI>
 ```
 
-After a few moments, charmed etcd will have updated the credentials internally. Check the status:
+After a few moments, charmed etcd will have updated the credentials internally and be `active/idle` again. Check the status:
 
 ```text
 Model          Controller      Cloud/Region         Version  SLA          Timestamp
@@ -282,7 +251,7 @@ s3-integrator/0*             active    idle   4        10.143.229.157
 self-signed-certificates/0*  active    idle   3        10.143.229.160            
 ```
 
-### Restore the backup to charmed etcd
+## Restore the backup to charmed etcd
 
 After applying your cluster credentials (if needed), it is time to migrate your data to charmed etcd by restoring the 
 previously taken backup.
@@ -343,7 +312,7 @@ s3-integrator/0*             active       idle       4        10.143.229.157
 self-signed-certificates/0*  active       idle       3        10.143.229.160            
 ```
 
-After the restore was completed, the status will be `active/idle` again:
+Once the restore is complete, the status will be `active/idle` again:
 
 ```text
 Model          Controller      Cloud/Region         Version  SLA          Timestamp
@@ -364,7 +333,7 @@ self-signed-certificates/0*  active    idle   3        10.143.229.160
 
 Congratulations: You have migrated your etcd data to charmed etcd!
 
-### Switch your application over to charmed etcd
+## Switch your application over to charmed etcd
 
 Now it's time to connect your application to charmed etcd. This happens over the `etcd_client` interface by integrating
 the applications:

--- a/docs/how-to/migrate-to-charmed-etcd.md
+++ b/docs/how-to/migrate-to-charmed-etcd.md
@@ -1,0 +1,380 @@
+# How To migrate to charmed etcd
+
+This guide outlines the steps required to migrate an existing etcd to charmed etcd.
+
+## Prerequisites
+
+- a Juju VM controller with a model
+- TLS Provider deployed to that model, in our case we use `self-signed-certificates` (see: [](tls/enable-tls.md))
+- Object Storage Provider deployed to that model, in our case we use `s3-integrator` (see [](backup-and-restore/configure-object-storage-provider.md))
+- your existing etcd cluster must be at least of version 3.0
+
+## Migration Guide
+
+Migrating to charmed etcd includes the following steps:
+- create a backup of your existing cluster
+- upload the backup to object storage
+- deploy charmed etcd
+- integrate charmed etcd with object storage provider
+- integrate charmed etcd with TLS provider
+- optional: apply cluster credentials
+- restore the backup to charmed etcd
+- switch your application over to charmed etcd
+
+### Create a backup
+
+Migrating your existing etcd cluster to charmed etcd happens via backup and restore. First, create a backup of your
+existing etcd cluster. The following command is an example for a snap-based installation of [etcd](https://snapcraft.io/etcd)
+in version `3.4.36`. It connects to etcd via `localhost` and creates a backup file called `etcd-backup.db` in the current
+working directory:
+
+```text
+etcdctl snapshot save etcd-backup.db
+```
+
+This will prompt the following output (or similar):
+```text
+{"level":"info","ts":1754036152.734727,"caller":"snapshot/v3_snapshot.go:119","msg":"created temporary db file","path":"etcd-backup.db.part"}
+{"level":"info","ts":"2025-08-01T08:15:52.736886Z","caller":"clientv3/maintenance.go:212","msg":"opened snapshot stream; downloading"}
+{"level":"info","ts":1754036152.7369702,"caller":"snapshot/v3_snapshot.go:127","msg":"fetching snapshot","endpoint":"127.0.0.1:2379"}
+{"level":"info","ts":"2025-08-01T08:15:52.738103Z","caller":"clientv3/maintenance.go:220","msg":"completed snapshot read; closing"}
+{"level":"info","ts":1754036152.7385268,"caller":"snapshot/v3_snapshot.go:142","msg":"fetched snapshot","endpoint":"127.0.0.1:2379","size":"20 kB","took":0.003674558}
+{"level":"info","ts":1754036152.738597,"caller":"snapshot/v3_snapshot.go:152","msg":"saved","path":"etcd-backup.db"}
+Snapshot saved at etcd-backup.db
+```
+
+### Upload the backup to object storage
+
+For restoring backup files, charmed etcd supports S3-compatible or Azure object storage. In our example, we upload the
+backup file that we just created to a self-hosted MicroCeph (S3-compatible) by using the `S3cmd` tool.
+
+If not yet installed, execute the following command to install `S3cmd`:
+
+```text
+sudo apt-get install s3cmd
+```
+
+Ensure the bucket for uploading your backup file exists (replace the placeholders with your credentials). In this case
+we want to use a bucket called `etcd-backups-test-bucket`:
+
+```text
+s3cmd ls s3://etcd-backups-test-bucket/ --access_key=<your-access-key> --secret_key=<your-secret>
+```
+
+You should see your bucket listing all available directories:
+```text
+DIR  s3://etcd-backups-test-bucket/etcd-backups/
+```
+
+If the storage bucket you want to use does not exist yet, create a bucket `etcd-backups` with the following command 
+(replace the placeholders with your credentials):
+
+```text
+s3cmd mb s3://etcd-backups-test-bucket/ --access_key=<your-access-key> --secret_key=<your-secret>
+```
+
+With the following command, you can upload the backup file `etcd-backup.db` to the just created bucket 
+(replace placeholders with your credentials again):
+
+```text
+s3cmd put etcd-backup.db s3://etcd-backups-test-bucket/etcd-backups/ --access_key=<your-access-key> --secret_key=<your-secret>
+```
+
+Ensure your backup file was uploaded correctly by repeating the `s3cmd ls s3://etcd-backups-test-bucket/etcd-backups/` command:
+
+```text
+2025-08-01 08:24        20512  s3://etcd-backups-test-bucket/etcd-backups/etcd-backup.db
+```
+
+### Deploy charmed etcd
+
+Now it's time to deploy charmed etcd. Run the following command to deploy a 3-unit cluster:
+
+```text
+juju deploy charmed-etcd --channel 3.6/edge -n 3
+```
+
+Wait for the deployment to become available by checking `watch juju status --color`:
+
+```text
+Model          Controller      Cloud/Region         Version  SLA          Timestamp
+backend-store  dev-controller  localhost/localhost  3.6.5    unsupported  08:34:43Z
+
+App                       Version  Status  Scale  Charm                     Channel   Rev  Exposed  Message
+charmed-etcd                       active      3  charmed-etcd              3.6/edge   68  no       
+s3-integrator                      active      1  s3-integrator             1/stable  145  no       
+self-signed-certificates           active      1  self-signed-certificates  1/stable  317  no       
+
+Unit                         Workload  Agent  Machine  Public address  Ports     Message
+charmed-etcd/0*              active    idle   0        10.143.229.222  2379/tcp  
+charmed-etcd/1               active    idle   1        10.143.229.119  2379/tcp  
+charmed-etcd/2               active    idle   2        10.143.229.81   2379/tcp  
+s3-integrator/0*             active    idle   4        10.143.229.157            
+self-signed-certificates/0*  active    idle   3        10.143.229.160
+```
+
+### Integrate with object storage provider
+
+After charmed etcd has been deployed, integrate it with the deployed object storage provider to provide access 
+the object storage. In our case, this happens with `s3-integrator` over the `s3-credentials` interface.
+
+Run the following command:
+
+```text
+juju integrate s3-integrator charmed-etcd
+```
+
+```{caution}
+Ensure s3-integrator is configured correctly. Please refer to [](backup-and-restore/configure-object-storage-provider.md) for more information.
+```
+
+Shortly after the relation between them should be established:
+
+```text
+Model          Controller      Cloud/Region         Version  SLA          Timestamp
+backend-store  dev-controller  localhost/localhost  3.6.5    unsupported  08:38:22Z
+
+App                       Version  Status  Scale  Charm                     Channel   Rev  Exposed  Message
+charmed-etcd                       active      3  charmed-etcd              3.6/edge   68  no       
+s3-integrator                      active      1  s3-integrator             1/stable  145  no       
+self-signed-certificates           active      1  self-signed-certificates  1/stable  317  no       
+
+Unit                         Workload  Agent  Machine  Public address  Ports     Message
+charmed-etcd/0*              active    idle   0        10.143.229.222  2379/tcp  
+charmed-etcd/1               active    idle   1        10.143.229.119  2379/tcp  
+charmed-etcd/2               active    idle   2        10.143.229.81   2379/tcp  
+s3-integrator/0*             active    idle   4        10.143.229.157            
+self-signed-certificates/0*  active    idle   3        10.143.229.160            
+
+[...]
+
+Integration provider               Requirer                           Interface            Type     Message
+charmed-etcd:etcd-peers            charmed-etcd:etcd-peers            etcd_peers           peer     
+charmed-etcd:restart               charmed-etcd:restart               rolling_op           peer     
+s3-integrator:s3-credentials       charmed-etcd:s3-credentials        s3                   regular  
+s3-integrator:s3-integrator-peers  s3-integrator:s3-integrator-peers  s3-integrator-peers  peer     
+```
+
+### Integrate with TLS provider
+
+Because charmed etcd relies on mTLS for client authentication and authorization, it is mandatory to set up client TLS in 
+charmed etcd. To do so, integrate with the deployed TLS provider over the `tls-certificates` interface. In our case, 
+this is with the `self-signed-certificates` operator.
+
+Run the following command:
+
+```text
+juju integrate self-signed-certificates:certificates charmed-etcd:client-certificates
+```
+
+Charmed etcd will enable client TLS on all units with a rolling restart. After a few moments, the relation should be 
+established and charmed etcd should be settled again:
+
+```text
+Model          Controller      Cloud/Region         Version  SLA          Timestamp
+backend-store  dev-controller  localhost/localhost  3.6.5    unsupported  08:43:12Z
+
+App                       Version  Status  Scale  Charm                     Channel   Rev  Exposed  Message
+charmed-etcd                       active      3  charmed-etcd              3.6/edge   68  no       
+s3-integrator                      active      1  s3-integrator             1/stable  145  no       
+self-signed-certificates           active      1  self-signed-certificates  1/stable  317  no       
+
+Unit                         Workload  Agent  Machine  Public address  Ports     Message
+charmed-etcd/0*              active    idle   0        10.143.229.222  2379/tcp  
+charmed-etcd/1               active    idle   1        10.143.229.119  2379/tcp  
+charmed-etcd/2               active    idle   2        10.143.229.81   2379/tcp  
+s3-integrator/0*             active    idle   4        10.143.229.157            
+self-signed-certificates/0*  active    idle   3        10.143.229.160            
+
+[...]
+
+Integration provider                   Requirer                           Interface            Type     Message
+charmed-etcd:etcd-peers                charmed-etcd:etcd-peers            etcd_peers           peer     
+charmed-etcd:restart                   charmed-etcd:restart               rolling_op           peer     
+s3-integrator:s3-credentials           charmed-etcd:s3-credentials        s3                   regular  
+s3-integrator:s3-integrator-peers      s3-integrator:s3-integrator-peers  s3-integrator-peers  peer     
+self-signed-certificates:certificates  charmed-etcd:client-certificates   tls-certificates     regular  
+```
+
+Though it is optional, it is also recommended to enable peer TLS for encryption between the etcd cluster members.
+
+Run the following command to enable peer TLS:
+
+```text
+juju integrate self-signed-certificates:certificates charmed-etcd:peer-certificates
+```
+
+Charmed etcd will enable peer TLS on all units with a rolling restart. After a few moments, the relation should be 
+established and charmed etcd should be settled again:
+
+```text
+Model          Controller      Cloud/Region         Version  SLA          Timestamp
+backend-store  dev-controller  localhost/localhost  3.6.5    unsupported  08:46:21Z
+
+App                       Version  Status  Scale  Charm                     Channel   Rev  Exposed  Message
+charmed-etcd                       active      3  charmed-etcd              3.6/edge   68  no       
+s3-integrator                      active      1  s3-integrator             1/stable  145  no       
+self-signed-certificates           active      1  self-signed-certificates  1/stable  317  no       
+
+Unit                         Workload  Agent  Machine  Public address  Ports     Message
+charmed-etcd/0*              active    idle   0        10.143.229.222  2379/tcp  
+charmed-etcd/1               active    idle   1        10.143.229.119  2379/tcp  
+charmed-etcd/2               active    idle   2        10.143.229.81   2379/tcp  
+s3-integrator/0*             active    idle   4        10.143.229.157            
+self-signed-certificates/0*  active    idle   3        10.143.229.160            
+
+[...]
+
+Integration provider                   Requirer                           Interface            Type     Message
+charmed-etcd:etcd-peers                charmed-etcd:etcd-peers            etcd_peers           peer     
+charmed-etcd:restart                   charmed-etcd:restart               rolling_op           peer     
+s3-integrator:s3-credentials           charmed-etcd:s3-credentials        s3                   regular  
+s3-integrator:s3-integrator-peers      s3-integrator:s3-integrator-peers  s3-integrator-peers  peer     
+self-signed-certificates:certificates  charmed-etcd:client-certificates   tls-certificates     regular  
+self-signed-certificates:certificates  charmed-etcd:peer-certificates     tls-certificates     regular  
+```
+
+### Optional: apply cluster credentials to charmed etcd
+
+If your previous etcd cluster did not have authentication enabled, this step can be skipped.
+
+If your previous etcd cluster uses authentication, it is required to apply the password of the `admin` user to charmed etcd.
+Otherwise, restoring the backup will fail.
+
+First, create a Juju secret with the admin password. Run the following command to create a secret called `etcd-credentials`,
+ replacing the placeholder with your correct admin password:
+
+```text
+juju add-secret etcd-credentials root=<your-admin-password>
+```
+
+Take a note on the prompted secret URI, as this will later be configured to charmed etcd:
+
+```text
+secret:d268gfktvobctdg3loe0
+```
+
+Now allow charmed etcd access to this secret by running `juju grant-secret etcd-credentials charmed-etcd`.
+
+Next step is to configure the secret to charmed etcd. Run the following command, replacing the secret URI with the one 
+you noted earlier:
+
+```text
+juju config charmed-etcd system-users=secret:<your-secret-URI>
+```
+
+After a few moments, charmed etcd will have updated the credentials internally. Check the status:
+
+```text
+Model          Controller      Cloud/Region         Version  SLA          Timestamp
+backend-store  dev-controller  localhost/localhost  3.6.5    unsupported  09:29:50Z
+
+App                       Version  Status  Scale  Charm                     Channel   Rev  Exposed  Message
+charmed-etcd                       active      3  charmed-etcd              3.6/edge   68  no       
+s3-integrator                      active      1  s3-integrator             1/stable  145  no       
+self-signed-certificates           active      1  self-signed-certificates  1/stable  317  no       
+
+Unit                         Workload  Agent  Machine  Public address  Ports     Message
+charmed-etcd/0*              active    idle   0        10.143.229.222  2379/tcp  
+charmed-etcd/1               active    idle   1        10.143.229.119  2379/tcp  
+charmed-etcd/2               active    idle   2        10.143.229.81   2379/tcp  
+s3-integrator/0*             active    idle   4        10.143.229.157            
+self-signed-certificates/0*  active    idle   3        10.143.229.160            
+```
+
+### Restore the backup to charmed etcd
+
+After applying your cluster credentials (if needed), it is time to migrate your data to charmed etcd by restoring the 
+previously taken backup.
+
+First, list the available backups in the object storage with this command:
+
+```text
+juju run charmed-etcd/leader list-backups
+```
+
+It should list the backup file `etcd-backup.db` in the output:
+
+```text
+Running operation 3 with 1 task
+  - task 4 on unit-charmed-etcd-0
+
+Waiting for task 4...
+backups: |-
+  backup-id             | backup-status
+  -------------------------------------
+  etcd-backup.db        | finished
+```
+
+Now restore this backup to your charmed etcd cluster by running:
+
+```text
+juju run charmed-etcd/leader restore backup-id="etcd-backup.db"
+```
+
+The restore will be initiated on all units of the charmed etcd application:
+
+```text
+Running operation 5 with 1 task
+  - task 6 on unit-charmed-etcd-0
+
+Waiting for task 6...
+09:34:41 Initiating restore process for backup-id etcd-backup.db
+
+success: restore initiated for etcd-backup.db
+```
+
+You can follow the progress by running `watch juju status --color`:
+
+```text
+Model          Controller      Cloud/Region         Version  SLA          Timestamp
+backend-store  dev-controller  localhost/localhost  3.6.5    unsupported  09:34:57Z
+
+App                       Version  Status       Scale  Charm                     Channel   Rev  Exposed  Message
+charmed-etcd                       maintenance      3  charmed-etcd              3.6/edge   68  no       Database restore is in progress
+s3-integrator                      active           1  s3-integrator             1/stable  145  no       
+self-signed-certificates           active           1  self-signed-certificates  1/stable  317  no       
+
+Unit                         Workload     Agent      Machine  Public address  Ports     Message
+charmed-etcd/0*              maintenance  executing  0        10.143.229.222  2379/tcp  Database restore is in progress
+charmed-etcd/1               maintenance  executing  1        10.143.229.119  2379/tcp  Database restore is in progress
+charmed-etcd/2               maintenance  executing  2        10.143.229.81   2379/tcp  Database restore is in progress
+s3-integrator/0*             active       idle       4        10.143.229.157            
+self-signed-certificates/0*  active       idle       3        10.143.229.160            
+```
+
+After the restore was completed, the status will be `active/idle` again:
+
+```text
+Model          Controller      Cloud/Region         Version  SLA          Timestamp
+backend-store  dev-controller  localhost/localhost  3.6.5    unsupported  09:37:01Z
+
+App                       Version  Status  Scale  Charm                     Channel   Rev  Exposed  Message
+charmed-etcd                       active      3  charmed-etcd              3.6/edge   68  no       
+s3-integrator                      active      1  s3-integrator             1/stable  145  no       
+self-signed-certificates           active      1  self-signed-certificates  1/stable  317  no       
+
+Unit                         Workload  Agent  Machine  Public address  Ports     Message
+charmed-etcd/0*              active    idle   0        10.143.229.222  2379/tcp  
+charmed-etcd/1               active    idle   1        10.143.229.119  2379/tcp  
+charmed-etcd/2               active    idle   2        10.143.229.81   2379/tcp  
+s3-integrator/0*             active    idle   4        10.143.229.157            
+self-signed-certificates/0*  active    idle   3        10.143.229.160            
+```
+
+Congratulations: You have migrated your etcd data to charmed etcd!
+
+### Switch your application over to charmed etcd
+
+Now it's time to connect your application to charmed etcd. This happens over the `etcd_client` interface by integrating
+the applications:
+
+```text
+juju integrate charmed-etcd <your-charm>
+```
+
+The interface requires you to provide a key prefix (the key space in the etcd database you will need access to) and a 
+client certificate (for mTLS authentication). Please refer to [charm-relation-interfaces/etcd_client](https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/etcd_client/v0)
+for detailed information.
+
+For further information about how to enable your charm to integrate over the `etcd_client` interface, please refer to [](client-relations.md).

--- a/docs/how-to/migrate-to-charmed-etcd.md
+++ b/docs/how-to/migrate-to-charmed-etcd.md
@@ -5,7 +5,7 @@ This guide outlines the steps required to migrate an existing etcd to charmed et
 ## Prerequisites
 
 - a Juju VM controller with a model
-- TLS Provider deployed to that model, in our case we use `self-signed-certificates` (see: [](tls/enable-tls.md))
+- TLS Provider deployed to that model, in our case we use `self-signed-certificates` (see [](tls/enable-tls.md))
 - Object Storage Provider deployed to that model, in our case we use `s3-integrator` (see [](backup-and-restore/configure-object-storage-provider.md))
 - your existing etcd cluster must be at least of version 3.0
 
@@ -45,8 +45,8 @@ Snapshot saved at etcd-backup.db
 
 ### Upload the backup to object storage
 
-For restoring backup files, charmed etcd supports S3-compatible or Azure object storage. In our example, we upload the
-backup file that we just created to a self-hosted MicroCeph (S3-compatible) by using the `S3cmd` tool.
+For restoring backup files, charmed etcd supports S3-compatible (for example AWS, GCS, MinIO or MicroCeph) or Azure 
+object storage. In our example, we upload the backup file that we just created to S3-storage by using the `S3cmd` tool.
 
 If not yet installed, execute the following command to install `S3cmd`:
 
@@ -373,7 +373,7 @@ the applications:
 juju integrate charmed-etcd <your-charm>
 ```
 
-The interface requires you to provide a key prefix (the key space in the etcd database you will need access to) and a 
+The interface requires you to provide a key prefix (the key space in the etcd database you request access to) and a 
 client certificate (for mTLS authentication). Please refer to [charm-relation-interfaces/etcd_client](https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/etcd_client/v0)
 for detailed information.
 

--- a/docs/how-to/tune-settings.md
+++ b/docs/how-to/tune-settings.md
@@ -1,4 +1,4 @@
-# How to tune in production
+# How to tune etcd settings
 
 Charmed etcd includes default configuration settings that work well in most deployment settings. In some cases though,
 it might be required to adjust the configuration. This guide will show how to tune charmed etcd to match specific requirements.

--- a/docs/how-to/tuning.md
+++ b/docs/how-to/tuning.md
@@ -101,4 +101,4 @@ those.
 
 If it is required to include the unit number of each unit, this can be done by using the `{unit}` placeholder. For example,
 a configuration of `certificate-extra-sans="etcd{unit}.my-external-domain.com"` would result in `etcd0.my-external-domain.com`
-as an addition SAN in the TLS certificates for unit `charmed-etcd/0`.
+as an additional SAN in the TLS certificates for unit `charmed-etcd/0`.

--- a/docs/how-to/tuning.md
+++ b/docs/how-to/tuning.md
@@ -82,7 +82,7 @@ to decide the correct adjustments to the parameters for your specific requiremen
 ## Certificate SANs configuration
 
 In X.509 TLS certificates, a `Subject Alternative Name` (SAN) allows a certificate subject to be associated with the 
-service name and domain name components of a DNS Record. If charmed etcd is deployed in an environment where the DNS 
+service name and domain name components of a DNS record. If charmed etcd is deployed in an environment where the DNS 
 resolution on the client side does not correspond to the DNS resolution on the server side, it might be required to add 
 custom SANs to the TLS certificates used for client- and/or peer-communication.
 

--- a/docs/how-to/tuning.md
+++ b/docs/how-to/tuning.md
@@ -1,0 +1,84 @@
+# How to tune in production
+
+Charmed etcd includes default configuration settings that work well in most deployment settings. In some cases though,
+it might be required to adjust the configuration. This guide will show how to tune charmed etcd to match specific requirements.
+
+## Network latency
+
+In networks with high latency or across regions, the default configuration can trigger unnecessary leader elections and disrupt the cluster. 
+On the other hand, in deployments where fast failover matters, a longer election timeout can delay recovery when a leader fails.
+
+Charmed etcd lets you adjust the settings for `heartbeat-interval` and `election-timeout`, in order to:
+- Tolerate slower networks without constant leader re-elections
+- Reduce overhead in resource-constrained environments by lowering heartbeat frequency
+- Speed up failover when low latency is critical
+
+In the following example, we will set `heartbeat-interval` to 300 milliseconds and `election-timeout` to 3 seconds.
+
+You can either configure these settings at deploy time by adding the configuration to your deploy-command, for example:
+
+```text
+juju deploy charmed-etcd --channel 3.6/edge -n 3 --config heartbeat-interval=300 --config election-timeout=3000
+```
+
+Or you can set them on your existing charmed etcd application by running `juju config <application-name>...`, for example:
+
+```text
+juju config charmed-etcd heartbeat-interval=300 election-timeout=3000 
+```
+
+Charmed etcd will validate the configuration values and apply them to all units in the deployment (with a rolling restart
+in case of an existing deployment). 
+
+For more information about the allowed values, you can inspect the description of these settings by running `juju config charmed-etcd:`
+
+```text
+[...]
+charm: charmed-etcd
+settings: 
+  election-timeout: 
+    default: 1000
+    description: How long, in milliseconds, a follower node will go without hearing
+      a heartbeat before attempting to become leader itself. The value should be at
+      least 10x the value of <heartbeat-interval>, and must not exceed 50000.
+    source: user
+    type: int
+    value: 3000
+  heartbeat-interval: 
+    default: 100
+    description: The frequency, in milliseconds, with which the leader will notify
+      followers that it is still the leader. For best practices, the parameter should
+      be set around round-trip time between members. The value must be between 10
+      and 5000 at most.
+    source: user
+    type: int
+    value: 300
+[...]
+```
+
+If the configuration values are invalid, charmed etcd will display a status message in `juju status`:
+
+```text
+Model  Controller      Cloud/Region         Version  SLA          Timestamp
+etcd   dev-controller  localhost/localhost  3.6.5    unsupported  11:23:13Z
+
+App           Version  Status   Scale  Charm         Channel   Rev  Exposed  Message
+charmed-etcd           blocked      3  charmed-etcd  3.6/edge   66  no       Invalid values set for the config options: 'election-timeout', 'heartbeat-interval'
+
+Unit             Workload  Agent  Machine  Public address  Ports     Message
+charmed-etcd/0*  blocked   idle   9        10.136.16.209   2379/tcp  Invalid values set for the config options: 'election-timeout', 'heartbeat-interval'
+charmed-etcd/1   blocked   idle   10       10.136.16.121   2379/tcp  Invalid values set for the config options: 'election-timeout', 'heartbeat-interval'
+charmed-etcd/2   blocked   idle   11       10.136.16.41    2379/tcp  Invalid values set for the config options: 'election-timeout', 'heartbeat-interval'
+
+Machine  State    Address        Inst id         Base          AZ  Message
+9        started  10.136.16.209  juju-335dd8-9   ubuntu@24.04      Running
+10       started  10.136.16.121  juju-335dd8-10  ubuntu@24.04      Running
+11       started  10.136.16.41   juju-335dd8-11  ubuntu@24.04      Running
+```
+
+Please refer to the [official etcd docs](https://etcd.io/docs/v3.6/tuning/#time-parameters) for more information on how
+to decide the correct adjustments to the parameters for your specific requirements.
+
+## Certificate SANs configuration
+
+...

--- a/docs/how-to/tuning.md
+++ b/docs/how-to/tuning.md
@@ -99,6 +99,10 @@ juju config charmed-etcd certificate-extra-sans="10.241.9.34, etcd-production-cl
 If the configured sans are valid and not yet included in charmed etcd's certificates, it will automatically refresh
 those.
 
+```{caution}
+Wildcards (`*`) are not allowed as part of the `certificate-extra-sans` configuration.
+```
+
 If it is required to include the unit number of each unit, this can be done by using the `{unit}` placeholder. For example,
 a configuration of `certificate-extra-sans="etcd{unit}.my-external-domain.com"` would result in `etcd0.my-external-domain.com`
 as an additional SAN in the TLS certificates for unit `charmed-etcd/0`.

--- a/docs/how-to/tuning.md
+++ b/docs/how-to/tuning.md
@@ -81,4 +81,24 @@ to decide the correct adjustments to the parameters for your specific requiremen
 
 ## Certificate SANs configuration
 
-...
+In X.509 TLS certificates, a `Subject Alternative Name` (SAN) allows a certificate subject to be associated with the 
+service name and domain name components of a DNS Record. If charmed etcd is deployed in an environment where the DNS 
+resolution on the client side does not correspond to the DNS resolution on the server side, it might be required to add 
+custom SANs to the TLS certificates used for client- and/or peer-communication.
+
+See more about TLS in charmed etcd: [TLS encryption](tls/index.md)
+
+To add different IP addresses or hostnames to the SANs of charmed etcd's TLS certificates, configure the `certificate-extra-sans`
+option. It is possible to add a comma-separated list of multiple values, as long as each of them is a valid IP address 
+or hostname:
+
+```text
+juju config charmed-etcd certificate-extra-sans="10.241.9.34, etcd-production-cluster.mycompany.com"
+```
+
+If the configured sans are valid and not yet included in charmed etcd's certificates, it will automatically refresh
+those.
+
+If it is required to include the unit number of each unit, this can be done by using the `{unit}` placeholder. For example,
+a configuration of `certificate-extra-sans="etcd{unit}.my-external-domain.com"` would result in `etcd0.my-external-domain.com`
+as an addition SAN in the TLS certificates for unit `charmed-etcd/0`.


### PR DESCRIPTION
This PR adds user documentation for newly implemented features and a migration guide to help users migrate to charmed etcd.
- a `How-to` for Tuning in production
- a `How-to` for migrating to charmed etcd

The existing guide for migration an etcd cluster, that is part of the backup-and-restore documentation, has been renamed. The two guides have different scopes, the newly added one is a deployment guide for administrators moving from e.g. legacy etcd to charmed etcd.

The feature PR's are:
- make leader/timeout parameters configurable https://github.com/canonical/charmed-etcd-operator/pull/119
- add config option for certificate-extra-sans https://github.com/canonical/charmed-etcd-operator/pull/126