### PR TITLE
Add docs link on Charmhub

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,6 +14,7 @@ description: |
 
   To learn more about its deployment and operation, see the 
   [official Charmed etcd documentation](https://canonical-charmed-etcd.readthedocs-hosted.com/).
+docs: https://canonical-charmed-etcd.readthedocs-hosted.com
 
 peers:
   etcd-peers:


### PR DESCRIPTION
There is a new Charmhub [feature](https://github.com/canonical/charmhub.io/pull/2159) that provides a dedicated button for external documentation links.

I've updated the `metadata.yaml` file to add a `docs:` field with the etd Read The Docs site. It should render on Charmhub next time there's a release.