### PR TITLE
prepare release workflow for refresh v3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,18 @@ on:
       - "docs/**"
 
 jobs:
+  tag:
+    name: Create charm refresh compatibility version git tag
+    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v32.1.0
+    with:
+      track: 3.6
+    permissions:
+      contents: write  # Needed to create git tag
+
   ci-tests:
     name: Tests
+    needs:
+      - tag
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
     permissions:
@@ -43,7 +53,7 @@ jobs:
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v32.1.0
     with:
-      track: 3.6
+      track: ${{ needs.tag.outputs.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,7 @@ jobs:
   release:
     name: Release charm
     needs:
+      - tag
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v32.1.0
     with:


### PR DESCRIPTION
Charm-refresh v3 requires version tags to be added to Github commits (details see: https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/release_charm_edge.md).

This PR adds the charm-refresh version compatibility tag to the release workflow.