### PR TITLE
Revert #136

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,18 +10,8 @@ on:
       - "docs/**"
 
 jobs:
-  tag:
-    name: Create charm refresh compatibility version git tag
-    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v32.1.0
-    with:
-      track: 3.6
-    permissions:
-      contents: write  # Needed to create git tag
-
   ci-tests:
     name: Tests
-    needs:
-      - tag
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
     permissions:
@@ -50,11 +40,10 @@ jobs:
   release:
     name: Release charm
     needs:
-      - tag
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v32.1.0
     with:
-      track: ${{ needs.tag.outputs.track }}
+      track: 3.6
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit 5096962c4244f6f6de9cd73dfd6c2e8702d7f568.

I'm sorry, seems like the changes to the workflow for refresh v3 can not be merged separately, as they depend on the config files to be present. Seems like a chicken-and-egg problem and I will have to find a way to work around it instead.

Edit: I think I've found a workaround by manually adding a tag with the required format to our previous `3.6/edge` merge, see [here](https://github.com/canonical/charmed-etcd-operator/releases/tag/v3.6%2F1.0.0).