### PR TITLE
[DPE-7889] Fix cluster-status computation

### DIFF
--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -384,6 +384,18 @@ class ClusterManager(ManagerStatusProtocol):
             if not self.state.cluster.auth_enabled:
                 status_list.append(ClusterStatuses.AUTHENTICATION_NOT_ENABLED.value)
 
+            try:
+                if self.is_cluster_failed:
+                    status_list.append(ClusterStatuses.CLUSTER_FAILED.value)
+                else:
+                    self.state.statuses.delete(
+                        ClusterStatuses.CLUSTER_FAILED.value,
+                        scope=scope,
+                        component=self.name,
+                    )
+            except RequestException as e:
+                logger.error(f"Could not determine if cluster failed: {e}")
+
         if not self.state.peer_relation:
             status_list.append(EtcdServiceStatuses.SERVICE_INSTALLING.value)
         else:
@@ -398,18 +410,6 @@ class ClusterManager(ManagerStatusProtocol):
 
             if self.state.cluster.learning_member and self.state.unit_server.is_juju_leader:
                 status_list.append(ClusterStatuses.CLUSTER_MEMBER_NOT_PROMOTED.value)
-
-            try:
-                if self.is_cluster_failed:
-                    status_list.append(ClusterStatuses.CLUSTER_FAILED.value)
-                else:
-                    self.state.statuses.delete(
-                        ClusterStatuses.CLUSTER_FAILED.value,
-                        scope=scope,
-                        component=self.name,
-                    )
-            except RequestException as e:
-                logger.error(f"Could not determine if cluster failed: {e}")
 
         return status_list if status_list else [CharmStatuses.ACTIVE_IDLE.value]
 

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -396,7 +396,11 @@ class ClusterManager(ManagerStatusProtocol):
             if not self.state.cluster.cluster_state:
                 status_list.append(ClusterStatuses.CLUSTER_INITIALIZING.value)
 
-            if self.state.unit_server.member_endpoint not in self.state.cluster.cluster_members:
+            if (
+                self.state.unit_server.member_endpoint not in self.state.cluster.cluster_members
+                and self.state.unit_server.tls_peer_state
+                not in [TLSState.TO_TLS, TLSState.TO_NO_TLS]
+            ):
                 status_list.append(ClusterStatuses.CLUSTER_NOT_JOINED.value)
 
             if self.state.cluster.rebuild_cluster_in_progress:

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -387,14 +387,8 @@ class ClusterManager(ManagerStatusProtocol):
             try:
                 if self.is_cluster_failed:
                     status_list.append(ClusterStatuses.CLUSTER_FAILED.value)
-                else:
-                    self.state.statuses.delete(
-                        ClusterStatuses.CLUSTER_FAILED.value,
-                        scope=scope,
-                        component=self.name,
-                    )
             except RequestException as e:
-                logger.error(f"Could not determine if cluster failed: {e}")
+                logger.warning(f"Could not determine if cluster failed: {e}")
 
         if not self.state.peer_relation:
             status_list.append(EtcdServiceStatuses.SERVICE_INSTALLING.value)

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -373,6 +373,10 @@ class ClusterManager(ManagerStatusProtocol):
         ):
             return [EtcdServiceStatuses.SERVICE_NOT_INSTALLED.value]
 
+        if not self.state.peer_relation:
+            status_list.append(EtcdServiceStatuses.SERVICE_INSTALLING.value)
+            return status_list
+
         if self.state.unit_server.is_started:
             if (
                 self.state.cluster.cluster_state != EtcdClusterState.EXISTING.value
@@ -390,24 +394,20 @@ class ClusterManager(ManagerStatusProtocol):
             except RequestException as e:
                 logger.warning(f"Could not determine if cluster failed: {e}")
 
-        if not self.state.peer_relation:
-            status_list.append(EtcdServiceStatuses.SERVICE_INSTALLING.value)
-        else:
-            if not self.state.cluster.cluster_state:
-                status_list.append(ClusterStatuses.CLUSTER_INITIALIZING.value)
+        if not self.state.cluster.cluster_state:
+            status_list.append(ClusterStatuses.CLUSTER_INITIALIZING.value)
 
-            if (
-                self.state.unit_server.member_endpoint not in self.state.cluster.cluster_members
-                and self.state.unit_server.tls_peer_state
-                not in [TLSState.TO_TLS, TLSState.TO_NO_TLS]
-            ):
+        if self.state.unit_server.member_endpoint not in self.state.cluster.cluster_members:
+            if self.state.unit_server.tls_peer_state in [TLSState.TO_TLS, TLSState.TO_NO_TLS]:
+                status_list.append(ClusterStatuses.CLUSTER_MEMBER_RECONFIGURATION.value)
+            else:
                 status_list.append(ClusterStatuses.CLUSTER_NOT_JOINED.value)
 
-            if self.state.cluster.rebuild_cluster_in_progress:
-                status_list.append(ClusterStatuses.CLUSTER_REBUILD_IN_PROGRESS.value)
+        if self.state.cluster.rebuild_cluster_in_progress:
+            status_list.append(ClusterStatuses.CLUSTER_REBUILD_IN_PROGRESS.value)
 
-            if self.state.cluster.learning_member and self.state.unit_server.is_juju_leader:
-                status_list.append(ClusterStatuses.CLUSTER_MEMBER_NOT_PROMOTED.value)
+        if self.state.cluster.learning_member and self.state.unit_server.is_juju_leader:
+            status_list.append(ClusterStatuses.CLUSTER_MEMBER_NOT_PROMOTED.value)
 
         return status_list if status_list else [CharmStatuses.ACTIVE_IDLE.value]
 

--- a/src/statuses.py
+++ b/src/statuses.py
@@ -67,6 +67,9 @@ class ClusterStatuses(Enum):
     CLUSTER_MEMBER_NOT_PROMOTED = StatusObject(
         status="maintenance", message="Waiting to promote learning member"
     )
+    CLUSTER_MEMBER_RECONFIGURATION = StatusObject(
+        status="maintenance", message="Refreshing cluster membership information"
+    )
     CLUSTER_REBUILD_IN_PROGRESS = StatusObject(
         status="blocked", message="Rebuilding with new cluster configuration..."
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -488,7 +488,7 @@ def test_cluster_majority_failure():
             "cluster_state": "existing",
             "cluster_members": "charmed-etcd0=http://ip0:2380",
         },
-        local_unit_data={"private_ip": "ip0"},
+        local_unit_data={"private_ip": "ip0", "state": "started"},
     )
     status_peer_relation = testing.PeerRelation(
         id=2,


### PR DESCRIPTION
**Issues**

With #124 the computation of cluster statuses has been reworked. This leads to lots of errors when deploying charmed etcd, because on every hook, the etcd-internal metrics server is queried for the `cluster_failed` metric, even though the etcd server has not been started yet.

Furthermore, if the cluster is not failed, the operator tries to delete the status, even though it wasn't set as a running status previously.

Another inconsistency is on enabling or disabling peer TLS, where `Waiting to join cluster` is displayed as a status message even though the unit is already a cluster member.

**Fixes**

- The check for `cluster_failed` should only be executed if the etcd server has already been started.
- This status does not have to be deleted as it is not a running status.
- Consider peer TLS transition for checking cluster membership status.