### PR TITLE
[DPE-7916] Fix restart after vm reboot

### DIFF
--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -196,13 +196,14 @@ class EtcdEvents(Object):
                         # if removing fails, we cannot start the workload or the member would crash
                         raise
 
-                self.charm.status.set_running_status(
-                    EtcdServiceStatuses.SERVICE_STARTING.value,
-                    scope="unit",
-                    component_name=self.charm.cluster_manager.name,
-                    statuses_state=self.charm.state.statuses,
-                )
-                self.charm.cluster_manager.start_member()
+            # if the flag `unit_server.is_started` is missing, this was an uncontrolled reboot
+            self.charm.status.set_running_status(
+                EtcdServiceStatuses.SERVICE_STARTING.value,
+                scope="unit",
+                component_name=self.charm.cluster_manager.name,
+                statuses_state=self.charm.state.statuses,
+            )
+            self.charm.cluster_manager.start_member()
         else:
             # this unit that has not yet been added to the cluster
             # wait for leader to process `relation_joined` event and add the member to the cluster

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -160,3 +160,10 @@ async def remove_database_file(ops_test: OpsTest, unit_name: str) -> None:
     # see: https://etcd.io/docs/v3.5/learning/persistent-storage-files/#logical-content
     await ops_test.juju(*delete_db_cmd.split(), check=True)
     logger.info(f"etcd database file deleted on {unit_name}.")
+
+
+async def reboot_unit(ops_test: OpsTest, unit_name: str) -> None:
+    """Reboot the VM of a unit."""
+    reboot_cmd = f"exec --unit {unit_name} -- sudo reboot"
+    await ops_test.juju(*reboot_cmd.split(), check=True)
+    logger.info(f"Rebooted unit {unit_name}.")

--- a/tests/integration/ha/test_failover.py
+++ b/tests/integration/ha/test_failover.py
@@ -595,3 +595,23 @@ async def test_reboot_raft_leader(etcd_process: str, ops_test: OpsTest) -> None:
     assert_continuous_writes_consistent(
         endpoints=endpoints, user=INTERNAL_USER, password=password, ignore_revision=True
     )
+
+    # continue writing data
+    start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    time.sleep(10)
+
+    # now reboot all units
+    units_count = len(ops_test.model.applications[app].units)
+    for unit in ops_test.model.applications[app].units:
+        await reboot_unit(ops_test, unit_name=unit.name)
+
+    await wait_until(
+        ops_test,
+        apps=[app],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units=units_count,
+    )
+
+    # ensure data is written in the cluster
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)

--- a/tests/integration/ha/test_failover.py
+++ b/tests/integration/ha/test_failover.py
@@ -26,6 +26,7 @@ from .helpers import (
     assert_continuous_writes_increasing,
     existing_app,
     patch_restart_delay,
+    reboot_unit,
     remove_database_file,
     send_process_control_signal,
     start_continuous_writes,
@@ -520,6 +521,71 @@ async def test_restart_raft_leader_after_deleting_database_file(
         f"expected {init_units_count} cluster members, got {len(cluster_members)}"
     )
     logger.info(f"Cluster fully formed again with {len(cluster_members)} members.")
+
+    # ensure data is written in the cluster
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    stop_continuous_writes()
+    # By default, etcd uses a 1s election timeout before attempting to replace a lost leader
+    # that's why we will miss writes here, and therefore ignore the revision of the key
+    assert_continuous_writes_consistent(
+        endpoints=endpoints, user=INTERNAL_USER, password=password, ignore_revision=True
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_reboot_raft_leader(etcd_process: str, ops_test: OpsTest) -> None:
+    """Make sure a unit comes back cleanly after rebooting the VM."""
+    app = (await existing_app(ops_test)) or APP_NAME
+
+    # make sure we have at least two units so we can kill one of them
+    if len(ops_test.model.applications[app].units) < 2:
+        await ops_test.model.applications[app].add_unit(count=1)
+        await wait_until(
+            ops_test,
+            apps=[app],
+            apps_statuses=["active"],
+            units_statuses=["active"],
+            wait_for_exact_units=2,
+        )
+
+    endpoints = get_cluster_endpoints(ops_test, app)
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{app}.app")
+    password = secret.get(f"{INTERNAL_USER}-password")
+
+    # start writing data to the cluster
+    start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    time.sleep(10)
+
+    # get details for the current raft leader in the cluster
+    initial_raft_leader = get_raft_leader(
+        endpoints=endpoints, user=INTERNAL_USER, password=password
+    )
+    logger.info(f"initial raft leader: {initial_raft_leader}")
+    leader_unit = initial_raft_leader.replace(app, f"{app}/")
+
+    # forcefully reboot the unit
+    await reboot_unit(ops_test, unit_name=leader_unit)
+
+    # ensure a new leader was assigned after waiting for the `election timeout`
+    time.sleep(3)
+    unit_endpoint = get_unit_endpoint(ops_test, unit_name=leader_unit, app_name=app)
+    remaining_endpoints = get_remaining_endpoints(endpoints, unit_endpoint)
+    new_raft_leader = get_raft_leader(
+        endpoints=remaining_endpoints, user=INTERNAL_USER, password=password
+    )
+    logger.info(f"new raft leader: {new_raft_leader}")
+    assert new_raft_leader != initial_raft_leader, (
+        "raft leadership not transferred after freeze of leader"
+    )
+
+    # ensure data is written in the cluster
+    assert_continuous_writes_increasing(
+        endpoints=remaining_endpoints, user=INTERNAL_USER, password=password
+    )
+
+    # ensure the stopped unit was restarted
+    assert is_endpoint_up(unit_endpoint, user=INTERNAL_USER, password=password)
+    logger.info(f"{leader_unit} is available again.")
 
     # ensure data is written in the cluster
     assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -243,7 +243,7 @@ def test_start():
         state_out = ctx.run(ctx.on.start(), state_in)
         assert state_out.unit_status == ops.ActiveStatus()
         assert state_out.get_relation(1).local_app_data.get("authentication") == "enabled"
-        start.assert_not_called()
+        start.assert_called_once()
 
     # non leader must not start if auth not enabled
     relation = testing.PeerRelation(


### PR DESCRIPTION
**Issue:**
If a unit is rebooted, the etcd service is not restarted correctly.

**Solution:**
Always restart the etcd service when processing the `on_start` event, no matter if it was a controlled shutdown (flag `unit_server.is_started` gets removed)  or not.

The PR also adds integration test coverage for rebooting the Raft leader and all units of a cluster.