### PR TITLE
[DPE-7917] Fix TLS attributes for Vault usage

### DIFF
--- a/docs/how-to/tls/enable-tls.md
+++ b/docs/how-to/tls/enable-tls.md
@@ -26,7 +26,7 @@ This guide will use the [Self-signed Certificates](https://charmhub.io/self-sign
 Check [this guide](https://charmhub.io/topics/security-with-x-509-certificates) for an overview of all the TLS certificates charms available. 
 
 If [Vault](https://charmhub.io/vault-k8s?channel=1.18/edge) is used as TLS provider, it is required in version 1.18 at least. Currently Vault 
-is only supported with the config option `pki_allow_any_name=true`, allowing for any domain name in requested certificates. 
+is only supported with the configuration option `pki_allow_any_name=true`, allowing for any domain name in requested certificates. 
 ```
 
 Deploy the `self-signed-certificates` charm. etcd uses `v4` of the [{spellexception}`tls-certificates` library](https://charmhub.io/tls-certificates-interface/libraries/tls_certificates), which is currently only supported in the `edge` channel.

--- a/docs/how-to/tls/enable-tls.md
+++ b/docs/how-to/tls/enable-tls.md
@@ -24,6 +24,9 @@ This guide will use the [Self-signed Certificates](https://charmhub.io/self-sign
 **[Self-signed certificates](https://en.wikipedia.org/wiki/Self-signed_certificate) are not recommended for a production environment.**
 
 Check [this guide](https://charmhub.io/topics/security-with-x-509-certificates) for an overview of all the TLS certificates charms available. 
+
+If [Vault](https://charmhub.io/vault-k8s?channel=1.18/edge) is used as TLS provider, it is required in version 1.18 at least. Currently Vault 
+is only supported with the config option `pki_allow_any_name=true`, allowing for any domain name in requested certificates. 
 ```
 
 Deploy the `self-signed-certificates` charm. etcd uses `v4` of the [{spellexception}`tls-certificates` library](https://charmhub.io/tls-certificates-interface/libraries/tls_certificates), which is currently only supported in the `edge` channel.

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -72,7 +72,7 @@ class TLSEvents(Object):
     def __init__(self, charm: "EtcdOperatorCharm"):
         super().__init__(charm, "tls")
         self.charm: "EtcdOperatorCharm" = charm
-        common_name = f"{self.charm.unit.name}-{self.charm.model.uuid}"
+        common_name = f"{self.charm.unit.name.replace('/', '')}-{self.charm.model.uuid}"
         peer_private_key = None
         client_private_key = None
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -323,7 +323,7 @@ class TLSManager(ManagerStatusProtocol):
                 if not self._is_ip_address(san)
             }
 
-        sans_dns.add(self.state.unit_server.unit_name)
+        sans_dns.add(self.state.unit_server.unit_name.replace('/', ''))
         sans_dns.add(self.workload.get_host_mapping()["hostname"])
         return frozenset(sans_dns)
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -323,7 +323,7 @@ class TLSManager(ManagerStatusProtocol):
                 if not self._is_ip_address(san)
             }
 
-        sans_dns.add(self.state.unit_server.unit_name.replace('/', ''))
+        sans_dns.add(self.state.unit_server.unit_name.replace("/", ""))
         sans_dns.add(self.workload.get_host_mapping()["hostname"])
         return frozenset(sans_dns)
 

--- a/tests/integration/tls/test_vault_intermediate_ca.py
+++ b/tests/integration/tls/test_vault_intermediate_ca.py
@@ -174,7 +174,11 @@ async def test_tls_enabled(ops_test: OpsTest) -> None:
     logger.info("Integrating peer-certificates and client-certificates relations")
     await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", VAULT_NAME)
     await ops_test.model.integrate(f"{APP_NAME}:client-certificates", VAULT_NAME)
-    await wait_until(ops_test, apps=[APP_NAME, VAULT_NAME], idle_period=60)
+
+    # need to wait for next `update_status`
+    # https://github.com/canonical/vault-k8s-operator/issues/720
+    async with ops_test.fast_forward("5s"):
+        await wait_until(ops_test, apps=[APP_NAME, VAULT_NAME], idle_period=60)
 
     # check if all units have been added to the cluster
     endpoints = get_cluster_endpoints(ops_test, APP_NAME, tls_enabled=True)

--- a/tests/integration/tls/test_vault_intermediate_ca.py
+++ b/tests/integration/tls/test_vault_intermediate_ca.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import base64
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from literals import INTERNAL_USER, PEER_RELATION
+
+from ..helpers import (
+    APP_NAME,
+    TLS_NAME,
+    add_secret,
+    download_client_certificate_from_unit,
+    get_cluster_endpoints,
+    get_cluster_members,
+    get_key,
+    get_secret_by_label,
+    put_key,
+)
+from ..helpers_deployment import wait_until
+
+logger = logging.getLogger(__name__)
+
+NUM_UNITS = 3
+TEST_KEY = "test_key"
+TEST_VALUE = "42"
+CERTIFICATE_EXPIRY_TIME = 250
+VAULT_NAME = "vault"
+DOMAIN_NAME = "mydomain.com"
+
+
+def _install_dependencies() -> None:
+    """Install dependencies for the test."""
+    # Install TLS Certificates interface library
+    subprocess.run(
+        ["sudo", "snap", "install", "vault"], check=True, text=True, capture_output=True
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy_with_tls(charm: str, ops_test: OpsTest) -> None:
+    """Set up the TLS provider charms and etcd."""
+    _install_dependencies()
+
+    # Deploy the charm and wait for active/idle status
+    logger.info("Deploying the charm")
+    await ops_test.model.deploy(charm, num_units=NUM_UNITS)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+
+    # Deploy the TLS charms
+    tls_config = {"ca-common-name": "etcd"}
+    await ops_test.model.deploy(TLS_NAME, channel="1/edge", config=tls_config)
+    await ops_test.model.deploy(
+        VAULT_NAME,
+        channel="1.18/edge",
+        config={
+            "pki_ca_common_name": DOMAIN_NAME,
+            "pki_allow_any_name": True,
+            "pki_allow_ip_sans": True,
+        },
+    )
+    await ops_test.model.integrate(f"{VAULT_NAME}:tls-certificates-pki", TLS_NAME)
+    await ops_test.model.wait_for_idle(apps=[VAULT_NAME], status="blocked", timeout=1000)
+
+
+@pytest.mark.abort_on_fail
+async def test_initialize_vault(ops_test: OpsTest) -> None:
+    """Initialize Vault and wait for it to be ready."""
+    vault_app = ops_test.model.applications[VAULT_NAME]
+    vault_unit = vault_app.units[0]
+    vault_ip = vault_unit.public_address
+    secrets = await ops_test.model.list_secrets(show_secrets=True)
+    logger.info("Initializing Vault")
+
+    vault_ca = None
+    for secret in secrets:
+        if secret.label == "self-signed-vault-ca-certificate":
+            vault_ca = secret.value.data.get("certificate")
+
+    assert vault_ca, "Vault CA certificate not found in secrets"
+    vault_ca = base64.b64decode(vault_ca).decode("utf-8")
+    Path("./vault_ca.pem").write_text(vault_ca)
+
+    vault_env = os.environ.copy()
+    vault_env["VAULT_CACERT"] = "./vault_ca.pem"
+    vault_env["VAULT_ADDR"] = f"https://{vault_ip}:8200"
+
+    # operator init
+    logger.info("Running vault operator init")
+    init_cmd = [
+        "vault",
+        "operator",
+        "init",
+        "-key-shares=1",
+        "-key-threshold=1",
+    ]
+    init_result = subprocess.run(
+        init_cmd, check=True, text=True, capture_output=True, env=vault_env
+    )
+    logger.info(f"Vault operator init output: {init_result.stdout}")
+    init_results_list = [line.strip() for line in init_result.stdout.splitlines() if line.strip()]
+    unseal_key = init_results_list[0].split(":")[1].strip()
+    root_token = init_results_list[1].split(":")[1].strip()
+    vault_env["VAULT_TOKEN"] = root_token
+
+    # operator unseal
+    logger.info("Running vault operator unseal")
+    unseal_cmd = [
+        "vault",
+        "operator",
+        "unseal",
+        unseal_key,
+    ]
+    unseal_result = subprocess.run(
+        unseal_cmd, check=True, text=True, capture_output=True, env=vault_env
+    )
+    logger.info(f"Vault operator unseal output: {unseal_result.stdout}")
+
+    # authorise vault charm
+    # create vault token
+    logger.info("Creating Vault token for the vault charm")
+    create_token_cmd = [
+        "vault",
+        "token",
+        "create",
+        "-ttl=60m",
+    ]
+    create_token_result = subprocess.run(
+        create_token_cmd, check=True, text=True, capture_output=True, env=vault_env
+    )
+    logger.info(f"Vault token create output: {create_token_result.stdout}")
+    token_regex = r"token\s+([\w\.]+)"
+
+    # extract token using regex
+    match = re.search(token_regex, create_token_result.stdout)
+    assert match, "Failed to extract token from Vault token create output"
+    charm_vault_token = match.group(1)
+    secret_id = await add_secret(
+        ops_test,
+        "vault-token",
+        {
+            "token": charm_vault_token,
+        },
+    )
+
+    assert secret_id, "Failed to create vault-token secret"
+
+    await ops_test.model.grant_secret("vault-token", VAULT_NAME)
+
+    action = await vault_unit.run_action(
+        "authorize-charm",
+        **{
+            "secret-id": secret_id,
+        },
+    )
+
+    action = await action.wait()
+    assert action.status == "completed", "Action should succeed"
+
+    await ops_test.model.wait_for_idle(apps=[VAULT_NAME], status="active", timeout=1000)
+
+
+@pytest.mark.abort_on_fail
+async def test_tls_enabled(ops_test: OpsTest) -> None:
+    """Check if the TLS has been enabled on app startup."""
+    logger.info("Integrating peer-certificates and client-certificates relations")
+    await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", VAULT_NAME)
+    await ops_test.model.integrate(f"{APP_NAME}:client-certificates", VAULT_NAME)
+    await wait_until(ops_test, apps=[APP_NAME, VAULT_NAME], idle_period=60)
+
+    # check if all units have been added to the cluster
+    endpoints = get_cluster_endpoints(ops_test, APP_NAME, tls_enabled=True)
+    await download_client_certificate_from_unit(ops_test, APP_NAME)
+
+    # make sure data can be written to the cluster
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
+    assert secret, f"failed to get secret for {PEER_RELATION}.{APP_NAME}.app"
+    password = secret.get(f"{INTERNAL_USER}-password")
+
+    cluster_members = get_cluster_members(
+        endpoints, user=INTERNAL_USER, password=password, tls_enabled=True
+    )
+    assert len(cluster_members) == NUM_UNITS, f"Cluster members are not equal to {NUM_UNITS}"
+
+    for cluster_member in cluster_members:
+        assert cluster_member["clientURLs"][0].startswith("https://"), "Client URL is not https"
+        assert cluster_member["peerURLs"][0].startswith("https://"), "Peer URL is not https"
+
+    logger.info("All cluster members have HTTPS peerURLs and clientURLs")
+
+    logger.info("Reading and writing keys with HTTPS peerURLs and clientURLs")
+
+    assert (
+        put_key(
+            endpoints,
+            user=INTERNAL_USER,
+            password=password,
+            key=TEST_KEY,
+            value=TEST_VALUE,
+            tls_enabled=True,
+        )
+        == "OK"
+    ), "Failed to write key"
+    assert (
+        get_key(
+            endpoints,
+            user=INTERNAL_USER,
+            password=password,
+            key=TEST_KEY,
+            tls_enabled=True,
+        )
+        == TEST_VALUE
+    ), "Failed to read key"

--- a/tests/integration/tls/test_vault_intermediate_ca.py
+++ b/tests/integration/tls/test_vault_intermediate_ca.py
@@ -175,10 +175,7 @@ async def test_tls_enabled(ops_test: OpsTest) -> None:
     await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", VAULT_NAME)
     await ops_test.model.integrate(f"{APP_NAME}:client-certificates", VAULT_NAME)
 
-    # need to wait for next `update_status`
-    # https://github.com/canonical/vault-k8s-operator/issues/720
-    async with ops_test.fast_forward("5s"):
-        await wait_until(ops_test, apps=[APP_NAME, VAULT_NAME], idle_period=60)
+    await wait_until(ops_test, apps=[APP_NAME, VAULT_NAME], idle_period=60)
 
     # check if all units have been added to the cluster
     endpoints = get_cluster_endpoints(ops_test, APP_NAME, tls_enabled=True)

--- a/tests/integration/tls/test_vault_intermediate_ca.py
+++ b/tests/integration/tls/test_vault_intermediate_ca.py
@@ -175,7 +175,10 @@ async def test_tls_enabled(ops_test: OpsTest) -> None:
     await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", VAULT_NAME)
     await ops_test.model.integrate(f"{APP_NAME}:client-certificates", VAULT_NAME)
 
-    await wait_until(ops_test, apps=[APP_NAME, VAULT_NAME], idle_period=60)
+    # need to wait for next `update_status`
+    # https://github.com/canonical/vault-k8s-operator/issues/720
+    async with ops_test.fast_forward("60s"):
+        await wait_until(ops_test, apps=[APP_NAME, VAULT_NAME], idle_period=15)
 
     # check if all units have been added to the cluster
     endpoints = get_cluster_endpoints(ops_test, APP_NAME, tls_enabled=True)

--- a/tests/integration/tls/test_vault_intermediate_ca.py
+++ b/tests/integration/tls/test_vault_intermediate_ca.py
@@ -175,10 +175,7 @@ async def test_tls_enabled(ops_test: OpsTest) -> None:
     await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", VAULT_NAME)
     await ops_test.model.integrate(f"{APP_NAME}:client-certificates", VAULT_NAME)
 
-    # need to wait for next `update_status`
-    # https://github.com/canonical/vault-k8s-operator/issues/720
-    async with ops_test.fast_forward("60s"):
-        await wait_until(ops_test, apps=[APP_NAME, VAULT_NAME], idle_period=15)
+    await wait_until(ops_test, apps=[APP_NAME, VAULT_NAME])
 
     # check if all units have been added to the cluster
     endpoints = get_cluster_endpoints(ops_test, APP_NAME, tls_enabled=True)

--- a/tests/spread/test_vault_intermediate_ca.py/task.yaml
+++ b/tests/spread/test_vault_intermediate_ca.py/task.yaml
@@ -1,0 +1,11 @@
+summary: test_vault_intermediate_ca.py
+environment:
+  TEST_MODULE: tls/test_vault_intermediate_ca.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
+  # no vault arm 1.18
+  # - self-hosted-linux-arm64-noble-medium
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1642,7 +1642,7 @@ def test_set_extra_sans_config_option():
         relations={relation},
     )
 
-    current_sans_value = "X509v3 Subject Alternative Name: \n    DNS:myhostname, DNS:charmed-etcd/0, IP Address:127.0.1.1, IP Address:192.168.1.100"
+    current_sans_value = "X509v3 Subject Alternative Name: \n    DNS:myhostname, DNS:charmed-etcd0, IP Address:127.0.1.1, IP Address:192.168.1.100"
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),


### PR DESCRIPTION
**Issue**

In order to use Vault as TLS provider, it is required to omit `/` in TLS names such as common name or DNS sans. Otherwise Vault will not generate TLS certificates for issued certificate requests.

**Solution**
Adjust the TLS common name and DNS sans to remove the `/`.

This PR also adds: 
- an integration test for using Vault as TLS provider (based on the draft from @skourta in #77)
- a disclaimer to the docs with explanations about required Vault version and configuration