### PR TITLE
[DPE-7735] add tag to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,18 @@ on:
       - "docs/**"
 
 jobs:
+  tag:
+    name: Create charm refresh compatibility version git tag
+    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v32.1.0
+    with:
+      track: 3.6
+    permissions:
+      contents: write  # Needed to create git tag
+
   ci-tests:
     name: Tests
+    needs:
+      - tag
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
     permissions:
@@ -40,10 +50,11 @@ jobs:
   release:
     name: Release charm
     needs:
+      - tag
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v32.1.0
     with:
-      track: 3.6
+      track: ${{ needs.tag.outputs.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}


### PR DESCRIPTION
Using the `charm-refresh` lib requires adding specific tags to our releases. For more information see [Set up charm compatibility version](https://canonical-charm-refresh.readthedocs-hosted.com/latest/add-to-charm/charm-version/#workflow).

The release workflow in Github actions is adjusted by this PR to include a `tag` job and add a tag to the release.