### PR TITLE
[DPE-7826] Upgrades basic integration tests

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -1,13 +1,13 @@
 # https://canonical-charm-refresh.readthedocs-hosted.com/latest/refresh-versions-toml/
 
 charm_major = 1
-workload = "3.6.1"
+workload = "3.6.2"
 
 [snap]
 name = "charmed-etcd"
 
 [snap.revisions]
 # amd64
-x86_64 = "15"
+x86_64 = "17"
 # arm64
-aarch64 = "16"
+aarch64 = "18"

--- a/src/charm.py
+++ b/src/charm.py
@@ -35,7 +35,6 @@ from managers.config import ConfigManager
 from managers.external_clients import ExternalClientsManager
 from managers.tls import TLSManager
 from managers.upgrades import UpgradesManager
-from statuses import ClusterStatuses
 from workload import EtcdWorkload
 
 logger = logging.getLogger(__name__)
@@ -81,19 +80,15 @@ class EtcdOperatorCharm(ops.CharmBase):
         )
 
         # --- STATUS HANDLER ---
-        # `higher_priority` statuses from refresh must be of higher priority than any other status
-        # `lower_priority` statuses should only be set it if there is no other status at all.
-        # We achieve this by having `upgrades_manager` last in the component priority order,
-        # but setting the field `approved_critical_component` for `higher priority` statuses.
-        # This approach needs to be changed if any other critical status is added.
+        # statuses from charm-refresh must be of higher priority than any other status
         self.status = StatusHandler(  # priority order
             self,
+            self.upgrades_manager,
             self.cluster_manager,
             self.config_manager,
             self.tls_manager,
             self.external_clients_manager,
             self.backup_manager,
-            self.upgrades_manager,
         )
 
         # --- EVENT HANDLERS ---
@@ -137,11 +132,6 @@ class EtcdOperatorCharm(ops.CharmBase):
         """Handle post-snap refresh health checks and set next_unit_allowed_to_refresh."""
         if not self.refresh.in_progress:
             self.refresh.next_unit_allowed_to_refresh = True
-            self.state.statuses.delete(
-                ClusterStatuses.HEALTH_CHECK_FAILED.value,
-                scope="unit",
-                component=self.cluster_manager.name,
-            )
             return
 
         logger.info("Restarting workload after snap refresh")
@@ -150,11 +140,6 @@ class EtcdOperatorCharm(ops.CharmBase):
             return
 
         self.refresh.next_unit_allowed_to_refresh = True
-        self.state.statuses.delete(
-            ClusterStatuses.HEALTH_CHECK_FAILED.value,
-            scope="unit",
-            component=self.cluster_manager.name,
-        )
 
     def _restart(self, _) -> None:
         """Restart callback for the rolling ips lib."""

--- a/src/events/refresh.py
+++ b/src/events/refresh.py
@@ -12,7 +12,6 @@ import charm_refresh
 
 from common.exceptions import EtcdUpgradeError
 from literals import TLSCARotationState, TLSState
-from statuses import ClusterStatuses
 
 if TYPE_CHECKING:
     from charm import EtcdOperatorCharm
@@ -88,13 +87,6 @@ class MachinesEtcdRefresh(charm_refresh.CharmSpecificMachines):
         self.charm.workload.start()
         if self.charm.cluster_manager.is_healthy():
             refresh.next_unit_allowed_to_refresh = True
-        else:
-            self.charm.status.set_running_status(
-                ClusterStatuses.HEALTH_CHECK_FAILED.value,
-                scope="unit",
-                component_name="upgrades",
-                statuses_state=self.charm.state.statuses,
-            )
 
     def run_pre_refresh_checks_after_1_unit_refreshed(self) -> None:
         """Implement pre-refresh checks."""

--- a/src/managers/upgrades.py
+++ b/src/managers/upgrades.py
@@ -50,12 +50,13 @@ class UpgradesManager(ManagerStatusProtocol):
         if not self.refresh:
             return [CharmStatuses.ACTIVE_IDLE.value]
 
-        if self.refresh.in_progress and not self.refresh.next_unit_allowed_to_refresh:
-            status_list.append(ClusterStatuses.HEALTH_CHECK_FAILED.value)
-
-        if refresh_app_status := self.refresh.app_status_higher_priority:
+        if scope == "app" and (refresh_app_status := self.refresh.app_status_higher_priority):
             app_status = self._convert_ops_status_to_advanced_status(refresh_app_status)
             status_list.append(app_status)
+            return status_list
+
+        if self.refresh.in_progress and not self.refresh.next_unit_allowed_to_refresh:
+            status_list.append(ClusterStatuses.HEALTH_CHECK_FAILED.value)
 
         if refresh_unit_status := self.refresh.unit_status_higher_priority:
             unit_status = self._convert_ops_status_to_advanced_status(refresh_unit_status)

--- a/src/managers/upgrades.py
+++ b/src/managers/upgrades.py
@@ -14,7 +14,7 @@ from data_platform_helpers.advanced_statuses.types import Scope
 
 from core.cluster import ClusterState
 from core.workload import WorkloadBase
-from statuses import CharmStatuses
+from statuses import CharmStatuses, ClusterStatuses
 
 logger = logging.getLogger(__name__)
 
@@ -40,17 +40,18 @@ class UpgradesManager(ManagerStatusProtocol):
 
         While `refresh.[app|unit]_status_higher_priority` must be of higher priority than any other
         status, `refresh.unit_status_lower_priority()` should only be set it if there is no other
-        status at all. We achieve this by having `upgrades_manager` last in the component priority
-        order, but setting the field `approved_critical_component` to True if the refresh_status is
-        of higher priority than any other status.
+        status at all. We achieve this by setting the field `approved_critical_component` to True
+        if the refresh_status is of higher priority than any other status.
 
-        This logic ignores all statuses set directly by the refresh lib, as of refresh v3.1.0.
         For more information: see https://canonical-charm-refresh.readthedocs-hosted.com/latest/add-to-charm/status/
         """
         status_list: list[StatusObject] = []
 
         if not self.refresh:
             return [CharmStatuses.ACTIVE_IDLE.value]
+
+        if self.refresh.in_progress and not self.refresh.next_unit_allowed_to_refresh:
+            status_list.append(ClusterStatuses.HEALTH_CHECK_FAILED.value)
 
         if refresh_app_status := self.refresh.app_status_higher_priority:
             app_status = self._convert_ops_status_to_advanced_status(refresh_app_status)

--- a/src/statuses.py
+++ b/src/statuses.py
@@ -76,9 +76,7 @@ class ClusterStatuses(Enum):
     AUTHENTICATION_NOT_ENABLED = StatusObject(
         status="blocked", message="failed to enable authentication in etcd"
     )
-    HEALTH_CHECK_FAILED = StatusObject(
-        status="maintenance", message="health check failed", running="async"
-    )
+    HEALTH_CHECK_FAILED = StatusObject(status="maintenance", message="health check failed")
     REMOVED = StatusObject(status="blocked", message="unit removed from cluster", running="async")
     PASSWORD_UPDATE_FAILED = StatusObject(
         status="blocked", message="failed to update password", running="async"

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -167,3 +167,21 @@ async def reboot_unit(ops_test: OpsTest, unit_name: str) -> None:
     reboot_cmd = f"exec --unit {unit_name} -- sudo reboot"
     await ops_test.juju(*reboot_cmd.split(), check=True)
     logger.info(f"Rebooted unit {unit_name}.")
+
+
+async def disable_etcd_service(ops_test: OpsTest, unit_name: str) -> None:
+    """Stop and disable the etcd service on a unit."""
+    stop_cmd = f"exec --unit {unit_name} -- sudo systemctl stop snap.charmed-etcd.etcd"
+    disable_cmd = f"exec --unit {unit_name} -- sudo systemctl disable snap.charmed-etcd.etcd"
+    await ops_test.juju(*stop_cmd.split(), check=True)
+    await ops_test.juju(*disable_cmd.split(), check=True)
+    logger.info(f"Stopped and disabled etcd service on unit {unit_name}.")
+
+
+async def enable_etcd_service(ops_test: OpsTest, unit_name: str) -> None:
+    """Enable and start the etcd service on a unit."""
+    enable_cmd = f"exec --unit {unit_name} -- sudo systemctl enable snap.charmed-etcd.etcd"
+    start_cmd = f"exec --unit {unit_name} -- sudo systemctl start snap.charmed-etcd.etcd"
+    await ops_test.juju(*enable_cmd.split(), check=True)
+    await ops_test.juju(*start_cmd.split(), check=True)
+    logger.info(f"Enabled and started etcd service on unit {unit_name}.")

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -28,8 +28,8 @@ from .helpers import (
 logger = logging.getLogger(__name__)
 
 NUM_UNITS = 3
-PREVIOUS_REVISIONS = {"x86_64": 15, "aarch64": 16}
-WORKLOAD_VERSIONS = {"previous": "3.6.1", "target": "3.6.2"}
+CHARM_REVISIONS_TO_DEPLOY = {"x86_64": 89, "aarch64": 88}
+WORKLOAD_VERSION_TARGET = "3.6.2"
 
 
 async def test_deploy_previous_etcd_version(ops_test: OpsTest) -> None:
@@ -38,7 +38,7 @@ async def test_deploy_previous_etcd_version(ops_test: OpsTest) -> None:
         APP_NAME,
         num_units=NUM_UNITS,
         channel="3.6/edge",
-        revision=PREVIOUS_REVISIONS[machine()],
+        revision=CHARM_REVISIONS_TO_DEPLOY[machine()],
     )
 
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000, wait_for_exact_units=NUM_UNITS)
@@ -113,7 +113,7 @@ async def test_upgrade_to_local(charm: str, ops_test: OpsTest) -> None:
         unit_endpoint = get_unit_endpoint(ops_test, unit_name=unit.name, app_name=APP_NAME)
         assert (
             get_etcd_version(unit_endpoint, user=INTERNAL_USER, password=password)
-            == WORKLOAD_VERSIONS["target"]
+            == WORKLOAD_VERSION_TARGET
         ), f"unit {unit.name} was not upgraded"
 
         assert any(unit.name.replace("/", "") == member["name"] for member in cluster_members), (

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -61,18 +61,6 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
     # start writing data to the cluster
     start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
-    # initiate the upgrade
-    logger.info(f"Refresh etcd to v{WORKLOAD_VERSION['target']}")
-    await etcd_application.refresh(path=charm)
-
-    # versions will always be marked "incompatible" if refresh to a local version
-    # see: https://github.com/canonical/charm-refresh/blob/main/charm_refresh/_main.py#L182-L185
-    logger.info("Wait for refresh to block as incompatible")
-    await wait_until(ops_test, apps=[APP_NAME], apps_statuses=["blocked"])
-    assert "incompatible" in etcd_application.status_message, (
-        "Refresh should be marked incompatible when using locally built charm"
-    )
-
     # Refresh always happens from highest to lowest unit number
     refresh_order = sorted(
         etcd_application.units,
@@ -80,18 +68,27 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
         reverse=True,
     )
 
-    logger.info(f"Continue refresh on unit {refresh_order[0].name}")
-    logger.info("Running `force-refresh-start` action with check-compatibility=false")
-    # we need to ignore pre-refresh-checks here because cluster health will be degraded immediately
-    await refresh_order[0].run_action(
-        "force-refresh-start", **{"check-compatibility": False, "run-pre-refresh-checks": False}
-    )
+    # initiate the upgrade
+    logger.info(f"Refresh etcd to v{WORKLOAD_VERSION['target']}")
+    await etcd_application.refresh(path=charm)
 
     logger.info(f"Pause etcd service on unit {refresh_order[-1].name} to force upgrade to fail")
     await disable_etcd_service(ops_test, unit_name=refresh_order[-1].name)
 
-    # no chance to know exactly which status messages to look for here, so we use `wait_for_idle`
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+    # versions will always be marked "incompatible" if refresh to a local version
+    # see: https://github.com/canonical/charm-refresh/blob/main/charm_refresh/_main.py#L182-L185
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+    if "incompatible" in etcd_application.status_message:
+        logger.info("Upgrade is blocked due to incompatibility")
+
+        logger.info(f"Continue refresh on unit {refresh_order[0].name}")
+        logger.info("Running `force-refresh-start` action with check-compatibility=false")
+        force_refresh_action = await refresh_order[0].run_action(
+            "force-refresh-start", **{"check-compatibility": False, "run-pre-refresh-checks": False}
+        )
+
+    # wait for the first unit to settle
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
     assert "health check failed" in refresh_order[0].workload_status_message, (
         "Health check after upgrade should have failed"
@@ -178,7 +175,7 @@ async def test_upgrade_to_local(charm: str, ops_test: OpsTest) -> None:
     # versions will always be marked "incompatible" if refresh to a local version
     # this will not be the case when the PR is released
     # see: https://github.com/canonical/charm-refresh/blob/main/charm_refresh/_main.py#L182-L185
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], idle_period=30)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=2)
     if "incompatible" in etcd_application.status_message:
         logger.info("Upgrade is blocked due to incompatibility")
 

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -101,7 +101,8 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
     logger.info(f"Continue etcd service on unit {refresh_order[-1].name}")
     await enable_etcd_service(ops_test, unit_name=refresh_order[-1].name)
 
-    await etcd_application.refresh(APP_NAME, switch=APP_NAME)
+    refresh_cmd = f"refresh {APP_NAME} --model={ops_test.model.info.name} --switch {APP_NAME} --channel {CHARM_CHANNEL}"
+    return_code, _, std_err = await ops_test.juju(*refresh_cmd.split())
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
     logger.info("Check etcd versions and cluster membership")

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -103,14 +103,21 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
     await enable_etcd_service(ops_test, unit_name=refresh_order[-1].name)
 
     # ops_test.application.refresh can't refresh from local to published charm, use command line
+    # in `juju refresh`, --switch and --revision are mutually exclusive
+    # we can only roll back to the latest released revision from a local charm
     refresh_cmd = f"refresh {APP_NAME} --model={ops_test.model.info.name} --switch {APP_NAME} --channel {CHARM_CHANNEL}"
     return_code, _, std_err = await ops_test.juju(*refresh_cmd.split())
 
-    # versions will always be marked "incompatible" if refresh with a local version
-    await wait_until(ops_test, apps=[APP_NAME], apps_statuses=["blocked"])
-    await refresh_order[0].run_action("force-refresh-start", **{"check-compatibility": False})
+    # will be marked "incompatible" if rollback is not to the same revision as initially deployed
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], idle_period=30)
+    if "incompatible" in etcd_application.status_message:
+        logger.info("Rollback is blocked due to incompatibility")
+
+        logger.info("Running `force-refresh-start` action with check-compatibility=false")
+        await refresh_order[0].run_action("force-refresh-start", **{"check-compatibility": False})
 
     # wait for rollback to complete
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
     logger.info("Check etcd versions and cluster membership")
@@ -157,18 +164,6 @@ async def test_upgrade_to_local(charm: str, ops_test: OpsTest) -> None:
     pre_refresh_response = await pre_refresh_action.wait()
     assert pre_refresh_response.results.get("return-code") == 0, "action failed"
 
-    # initiate the upgrade
-    logger.info(f"Refresh etcd to v{WORKLOAD_VERSION['target']}")
-    await etcd_application.refresh(path=charm)
-
-    # versions will always be marked "incompatible" if refresh to a local version
-    # see: https://github.com/canonical/charm-refresh/blob/main/charm_refresh/_main.py#L182-L185
-    logger.info("Wait for refresh to block as incompatible")
-    await wait_until(ops_test, apps=[APP_NAME], apps_statuses=["blocked"])
-    assert "incompatible" in etcd_application.status_message, (
-        "Refresh should be marked incompatible when using locally built charm"
-    )
-
     # Refresh always happens from highest to lowest unit number
     refresh_order = sorted(
         etcd_application.units,
@@ -176,13 +171,24 @@ async def test_upgrade_to_local(charm: str, ops_test: OpsTest) -> None:
         reverse=True,
     )
 
-    logger.info(f"Continue refresh on unit {refresh_order[0].name}")
-    logger.info("Running `force-refresh-start` action with check-compatibility=false")
-    force_refresh_action = await refresh_order[0].run_action(
-        "force-refresh-start", **{"check-compatibility": False}
-    )
-    force_refresh_response = await force_refresh_action.wait()
-    assert force_refresh_response.results.get("return-code") == 0, "action failed"
+    # initiate the upgrade
+    logger.info(f"Refresh etcd to v{WORKLOAD_VERSION['target']}")
+    await etcd_application.refresh(path=charm)
+
+    # versions will always be marked "incompatible" if refresh to a local version
+    # this will not be the case when the PR is released
+    # see: https://github.com/canonical/charm-refresh/blob/main/charm_refresh/_main.py#L182-L185
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], idle_period=30)
+    if "incompatible" in etcd_application.status_message:
+        logger.info("Upgrade is blocked due to incompatibility")
+
+        logger.info(f"Continue refresh on unit {refresh_order[0].name}")
+        logger.info("Running `force-refresh-start` action with check-compatibility=false")
+        force_refresh_action = await refresh_order[0].run_action(
+            "force-refresh-start", **{"check-compatibility": False}
+        )
+        force_refresh_response = await force_refresh_action.wait()
+        assert force_refresh_response.results.get("return-code") == 0, "action failed"
 
     assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
 

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -101,7 +101,7 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
     logger.info(f"Continue etcd service on unit {refresh_order[-1].name}")
     await enable_etcd_service(ops_test, unit_name=refresh_order[-1].name)
 
-    await etcd_application.refresh(switch=APP_NAME, channel=CHARM_CHANNEL)
+    await etcd_application.refresh(APP_NAME, switch=APP_NAME, channel=CHARM_CHANNEL)
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
     logger.info("Check etcd versions and cluster membership")

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from platform import machine
+
+from pytest_operator.plugin import OpsTest
+
+from literals import INTERNAL_USER, PEER_RELATION
+
+from ..helpers import (
+    APP_NAME,
+    get_cluster_endpoints,
+    get_cluster_members,
+    get_etcd_version,
+    get_secret_by_label,
+    get_unit_endpoint,
+)
+from ..helpers_deployment import wait_until
+from .helpers import (
+    assert_continuous_writes_consistent,
+    assert_continuous_writes_increasing,
+    start_continuous_writes,
+    stop_continuous_writes,
+)
+
+logger = logging.getLogger(__name__)
+
+NUM_UNITS = 3
+PREVIOUS_REVISIONS = {"x86_64": 15, "aarch64": 16}
+WORKLOAD_VERSIONS = {"previous": "3.6.1", "target": "3.6.2"}
+
+
+async def test_deploy_previous_etcd_version(ops_test: OpsTest) -> None:
+    """Deploy the previous version of etcd from Charmhub."""
+    await ops_test.model.deploy(
+        APP_NAME,
+        num_units=NUM_UNITS,
+        channel="3.6/edge",
+        revision=PREVIOUS_REVISIONS[machine()],
+    )
+
+    await wait_until(ops_test, apps=[APP_NAME], timeout=1000, wait_for_exact_units=NUM_UNITS)
+
+
+async def test_upgrade_to_local(charm: str, ops_test: OpsTest) -> None:
+    """Refresh the charm and upgrade etcd, ensuring high availability while upgrading."""
+    etcd_application = ops_test.model.applications[APP_NAME]
+
+    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
+    password = secret.get(f"{INTERNAL_USER}-password")
+
+    # start writing data to the cluster
+    start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+    # pre-refresh-check
+    for unit in etcd_application.units:
+        if await unit.is_leader_from_status():
+            leader_unit = unit
+    logger.info("Running `pre-refresh-check` action")
+    pre_refresh_action = await leader_unit.run_action("pre-refresh-check")
+    pre_refresh_response = await pre_refresh_action.wait()
+    assert pre_refresh_response.results.get("return-code") == 0, "action failed"
+
+    # initiate the upgrade
+    logger.info("Refresh the charm")
+    await etcd_application.refresh(path=charm)
+
+    # versions will always be marked "incompatible" if refresh to a local version
+    # see: https://github.com/canonical/charm-refresh/blob/main/charm_refresh/_main.py#L182-L185
+    logger.info("Wait for refresh to block as incompatible")
+    await wait_until(ops_test, apps=[APP_NAME], apps_statuses=["blocked"])
+    assert "incompatible" in etcd_application.status_message, (
+        "Refresh should be marked incompatible when using locally built charm"
+    )
+
+    # Refresh always happens from highest to lowest unit number
+    refresh_order = sorted(
+        etcd_application.units,
+        key=lambda unit: int(unit.name.split("/")[1]),
+        reverse=True,
+    )
+
+    logger.info(f"Continue refresh on unit {refresh_order[0].name}")
+    logger.info("Running `force-refresh-start` action with check-compatibility=false")
+    force_refresh_action = await refresh_order[0].run_action(
+        "force-refresh-start", **{"check-compatibility": False}
+    )
+    force_refresh_response = await force_refresh_action.wait()
+    assert force_refresh_response.results.get("return-code") == 0, "action failed"
+
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+    await wait_until(ops_test, apps=[APP_NAME], apps_statuses=["blocked"])
+    assert "resume-refresh" in etcd_application.status_message, (
+        "Refresh should wait for user to continue with `resume-refresh` action"
+    )
+
+    logger.info("Continue refresh on all other units with `resume-refresh` action")
+    resume_refresh_action = await refresh_order[1].run_action("resume-refresh")
+    resume_refresh_response = await resume_refresh_action.wait()
+    assert resume_refresh_response.results.get("return-code") == 0, "action failed"
+
+    # wait for upgrade to complete
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+    logger.info("Check etcd versions and cluster membership")
+    cluster_members = get_cluster_members(endpoints, user=INTERNAL_USER, password=password)
+    for unit in etcd_application.units:
+        unit_endpoint = get_unit_endpoint(ops_test, unit_name=unit.name, app_name=APP_NAME)
+        assert (
+            get_etcd_version(unit_endpoint, user=INTERNAL_USER, password=password)
+            == WORKLOAD_VERSIONS["target"]
+        ), f"unit {unit.name} was not upgraded"
+
+        assert any(unit.name.replace("/", "") == member["name"] for member in cluster_members), (
+            f"{unit.name} is not in {cluster_members}"
+        )
+
+    stop_continuous_writes()
+    assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+
+def test_fail_upgrade_and_rollback():
+    pass

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -8,6 +8,7 @@ from platform import machine
 from pytest_operator.plugin import OpsTest
 
 from literals import INTERNAL_USER, PEER_RELATION
+from statuses import ClusterStatuses
 
 from ..helpers import (
     APP_NAME,
@@ -21,6 +22,7 @@ from ..helpers_deployment import wait_until
 from .helpers import (
     assert_continuous_writes_consistent,
     assert_continuous_writes_increasing,
+    send_process_control_signal,
     start_continuous_writes,
     stop_continuous_writes,
 )
@@ -28,25 +30,96 @@ from .helpers import (
 logger = logging.getLogger(__name__)
 
 NUM_UNITS = 3
+CHARM_CHANNEL = "3.6/edge"
 CHARM_REVISIONS_TO_DEPLOY = {"x86_64": 89, "aarch64": 88}
-WORKLOAD_VERSION_TARGET = "3.6.2"
+WORKLOAD_VERSION = {"previous": "3.6.1", "target": "3.6.2"}
 
 
-async def test_deploy_previous_etcd_version(ops_test: OpsTest) -> None:
-    """Deploy the previous version of etcd from Charmhub."""
+async def test_deploy(ops_test: OpsTest) -> None:
+    """Deploy the charm with the previously released workload version of etcd."""
     await ops_test.model.deploy(
         APP_NAME,
         num_units=NUM_UNITS,
-        channel="3.6/edge",
+        channel=CHARM_CHANNEL,
         revision=CHARM_REVISIONS_TO_DEPLOY[machine()],
     )
 
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000, wait_for_exact_units=NUM_UNITS)
 
 
+async def test_fail_upgrade_and_rollback(charm: str, etcd_process: str, ops_test: OpsTest) -> None:
+    """Run a refresh, fail and roll back."""
+    etcd_application = ops_test.model.applications[APP_NAME]
+
+    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
+    password = secret.get(f"{INTERNAL_USER}-password")
+
+    # start writing data to the cluster
+    start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+    # initiate the upgrade
+    logger.info(f"Refresh etcd to v{WORKLOAD_VERSION['target']}")
+    await etcd_application.refresh(path=charm)
+
+    # versions will always be marked "incompatible" if refresh to a local version
+    # see: https://github.com/canonical/charm-refresh/blob/main/charm_refresh/_main.py#L182-L185
+    logger.info("Wait for refresh to block as incompatible")
+    await wait_until(ops_test, apps=[APP_NAME], apps_statuses=["blocked"])
+    assert "incompatible" in etcd_application.status_message, (
+        "Refresh should be marked incompatible when using locally built charm"
+    )
+
+    # Refresh always happens from highest to lowest unit number
+    refresh_order = sorted(
+        etcd_application.units,
+        key=lambda unit: int(unit.name.split("/")[1]),
+        reverse=True,
+    )
+
+    logger.info(f"Continue refresh on unit {refresh_order[0].name}")
+    logger.info("Running `force-refresh-start` action with check-compatibility=false")
+    await refresh_order[0].run_action("force-refresh-start", **{"check-compatibility": False})
+
+    logger.info(f"Pause etcd service on unit {refresh_order[-1]} to force upgrade to fail")
+    send_process_control_signal(
+        unit_name=refresh_order[-1].name,
+        model_full_name=ops_test.model_full_name,
+        signal="SIGSTOP",
+        etcd_process=etcd_process,
+    )
+
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        units_full_statuses={
+            APP_NAME: [ClusterStatuses.HEALTH_CHECK_FAILED.value],
+        },
+        wait_for_exact_units=1,
+    )
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+    logger.info(f"Upgrade failed - roll back to previous version v{WORKLOAD_VERSION['previous']}")
+    logger.info(f"Continue etcd service on unit {refresh_order[-1]}")
+    send_process_control_signal(
+        unit_name=refresh_order[-1].name,
+        model_full_name=ops_test.model_full_name,
+        signal="SIGCONT",
+        etcd_process=etcd_process,
+    )
+
+    await etcd_application.refresh(switch=APP_NAME, channel=CHARM_CHANNEL)
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    stop_continuous_writes()
+    assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+
 async def test_upgrade_to_local(charm: str, ops_test: OpsTest) -> None:
     """Refresh the charm and upgrade etcd, ensuring high availability while upgrading."""
     etcd_application = ops_test.model.applications[APP_NAME]
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
     endpoints = get_cluster_endpoints(ops_test, APP_NAME)
     secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
@@ -65,7 +138,7 @@ async def test_upgrade_to_local(charm: str, ops_test: OpsTest) -> None:
     assert pre_refresh_response.results.get("return-code") == 0, "action failed"
 
     # initiate the upgrade
-    logger.info("Refresh the charm")
+    logger.info(f"Refresh etcd to v{WORKLOAD_VERSION['target']}")
     await etcd_application.refresh(path=charm)
 
     # versions will always be marked "incompatible" if refresh to a local version
@@ -113,7 +186,7 @@ async def test_upgrade_to_local(charm: str, ops_test: OpsTest) -> None:
         unit_endpoint = get_unit_endpoint(ops_test, unit_name=unit.name, app_name=APP_NAME)
         assert (
             get_etcd_version(unit_endpoint, user=INTERNAL_USER, password=password)
-            == WORKLOAD_VERSION_TARGET
+            == WORKLOAD_VERSION["target"]
         ), f"unit {unit.name} was not upgraded"
 
         assert any(unit.name.replace("/", "") == member["name"] for member in cluster_members), (
@@ -122,7 +195,3 @@ async def test_upgrade_to_local(charm: str, ops_test: OpsTest) -> None:
 
     stop_continuous_writes()
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
-
-
-def test_fail_upgrade_and_rollback():
-    pass

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -82,6 +82,7 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
 
     logger.info(f"Continue refresh on unit {refresh_order[0].name}")
     logger.info("Running `force-refresh-start` action with check-compatibility=false")
+    # we need to ignore pre-refresh-checks here because cluster health will be degraded immediately
     await refresh_order[0].run_action(
         "force-refresh-start", **{"check-compatibility": False, "run-pre-refresh-checks": False}
     )
@@ -101,12 +102,15 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
     logger.info(f"Continue etcd service on unit {refresh_order[-1].name}")
     await enable_etcd_service(ops_test, unit_name=refresh_order[-1].name)
 
+    # ops_test.application.refresh can't refresh from local to published charm, use command line
     refresh_cmd = f"refresh {APP_NAME} --model={ops_test.model.info.name} --switch {APP_NAME} --channel {CHARM_CHANNEL}"
     return_code, _, std_err = await ops_test.juju(*refresh_cmd.split())
 
+    # versions will always be marked "incompatible" if refresh with a local version
     await wait_until(ops_test, apps=[APP_NAME], apps_statuses=["blocked"])
     await refresh_order[0].run_action("force-refresh-start", **{"check-compatibility": False})
 
+    # wait for rollback to complete
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
     logger.info("Check etcd versions and cluster membership")
@@ -121,7 +125,7 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
         assert any(unit.name.replace("/", "") == member["name"] for member in cluster_members), (
             f"{unit.name} is not in {cluster_members}"
         )
-    logger.info("Successfully rolled back after failed upgrade")
+    logger.info(f"Successful rollback to v{WORKLOAD_VERSION['previous']} after failed upgrade")
 
     assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
     stop_continuous_writes()

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -5,6 +5,7 @@
 import logging
 from platform import machine
 
+import pytest
 from pytest_operator.plugin import OpsTest
 
 from literals import INTERNAL_USER, PEER_RELATION
@@ -35,6 +36,7 @@ CHARM_REVISIONS_TO_DEPLOY = {"x86_64": 89, "aarch64": 88}
 WORKLOAD_VERSION = {"previous": "3.6.1", "target": "3.6.2"}
 
 
+@pytest.mark.abort_on_fail
 async def test_deploy(ops_test: OpsTest) -> None:
     """Deploy the charm with the previously released workload version of etcd."""
     await ops_test.model.deploy(
@@ -47,6 +49,7 @@ async def test_deploy(ops_test: OpsTest) -> None:
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000, wait_for_exact_units=NUM_UNITS)
 
 
+@pytest.mark.abort_on_fail
 async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
     """Run a refresh, fail and roll back."""
     etcd_application = ops_test.model.applications[APP_NAME]
@@ -79,7 +82,9 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
 
     logger.info(f"Continue refresh on unit {refresh_order[0].name}")
     logger.info("Running `force-refresh-start` action with check-compatibility=false")
-    await refresh_order[0].run_action("force-refresh-start", **{"check-compatibility": False})
+    await refresh_order[0].run_action(
+        "force-refresh-start", **{"check-compatibility": False, "run-pre-refresh-checks": False}
+    )
 
     logger.info(f"Pause etcd service on unit {refresh_order[-1].name} to force upgrade to fail")
     await disable_etcd_service(ops_test, unit_name=refresh_order[-1].name)
@@ -99,11 +104,26 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
     await etcd_application.refresh(switch=APP_NAME, channel=CHARM_CHANNEL)
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
+    logger.info("Check etcd versions and cluster membership")
+    cluster_members = get_cluster_members(endpoints, user=INTERNAL_USER, password=password)
+    for unit in etcd_application.units:
+        unit_endpoint = get_unit_endpoint(ops_test, unit_name=unit.name, app_name=APP_NAME)
+        assert (
+            get_etcd_version(unit_endpoint, user=INTERNAL_USER, password=password)
+            == WORKLOAD_VERSION["previous"]
+        ), f"unit {unit.name} was not rolled back"
+
+        assert any(unit.name.replace("/", "") == member["name"] for member in cluster_members), (
+            f"{unit.name} is not in {cluster_members}"
+        )
+    logger.info("Successfully rolled back after failed upgrade")
+
     assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
     stop_continuous_writes()
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
+@pytest.mark.abort_on_fail
 async def test_upgrade_to_local(charm: str, ops_test: OpsTest) -> None:
     """Refresh the charm and upgrade etcd, ensuring high availability while upgrading."""
     etcd_application = ops_test.model.applications[APP_NAME]

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -8,7 +8,6 @@ from platform import machine
 from pytest_operator.plugin import OpsTest
 
 from literals import INTERNAL_USER, PEER_RELATION
-from statuses import ClusterStatuses
 
 from ..helpers import (
     APP_NAME,
@@ -22,7 +21,8 @@ from ..helpers_deployment import wait_until
 from .helpers import (
     assert_continuous_writes_consistent,
     assert_continuous_writes_increasing,
-    send_process_control_signal,
+    disable_etcd_service,
+    enable_etcd_service,
     start_continuous_writes,
     stop_continuous_writes,
 )
@@ -47,7 +47,7 @@ async def test_deploy(ops_test: OpsTest) -> None:
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000, wait_for_exact_units=NUM_UNITS)
 
 
-async def test_fail_upgrade_and_rollback(charm: str, etcd_process: str, ops_test: OpsTest) -> None:
+async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
     """Run a refresh, fail and roll back."""
     etcd_application = ops_test.model.applications[APP_NAME]
 
@@ -81,32 +81,20 @@ async def test_fail_upgrade_and_rollback(charm: str, etcd_process: str, ops_test
     logger.info("Running `force-refresh-start` action with check-compatibility=false")
     await refresh_order[0].run_action("force-refresh-start", **{"check-compatibility": False})
 
-    logger.info(f"Pause etcd service on unit {refresh_order[-1]} to force upgrade to fail")
-    send_process_control_signal(
-        unit_name=refresh_order[-1].name,
-        model_full_name=ops_test.model_full_name,
-        signal="SIGSTOP",
-        etcd_process=etcd_process,
-    )
+    logger.info(f"Pause etcd service on unit {refresh_order[-1].name} to force upgrade to fail")
+    await disable_etcd_service(ops_test, unit_name=refresh_order[-1].name)
 
-    await wait_until(
-        ops_test,
-        apps=[APP_NAME],
-        units_full_statuses={
-            APP_NAME: [ClusterStatuses.HEALTH_CHECK_FAILED.value],
-        },
-        wait_for_exact_units=1,
+    # no chance to know exactly which status messages to look for here, so we use `wait_for_idle`
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+
+    assert "health check failed" in refresh_order[0].workload_status_message, (
+        "Health check after upgrade should have failed"
     )
     assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
     logger.info(f"Upgrade failed - roll back to previous version v{WORKLOAD_VERSION['previous']}")
-    logger.info(f"Continue etcd service on unit {refresh_order[-1]}")
-    send_process_control_signal(
-        unit_name=refresh_order[-1].name,
-        model_full_name=ops_test.model_full_name,
-        signal="SIGCONT",
-        etcd_process=etcd_process,
-    )
+    logger.info(f"Continue etcd service on unit {refresh_order[-1].name}")
+    await enable_etcd_service(ops_test, unit_name=refresh_order[-1].name)
 
     await etcd_application.refresh(switch=APP_NAME, channel=CHARM_CHANNEL)
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -101,7 +101,7 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
     logger.info(f"Continue etcd service on unit {refresh_order[-1].name}")
     await enable_etcd_service(ops_test, unit_name=refresh_order[-1].name)
 
-    await etcd_application.refresh(APP_NAME, switch=APP_NAME, channel=CHARM_CHANNEL)
+    await etcd_application.refresh(APP_NAME, switch=APP_NAME)
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
     logger.info("Check etcd versions and cluster membership")

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -83,8 +83,9 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
 
         logger.info(f"Continue refresh on unit {refresh_order[0].name}")
         logger.info("Running `force-refresh-start` action with check-compatibility=false")
-        force_refresh_action = await refresh_order[0].run_action(
-            "force-refresh-start", **{"check-compatibility": False, "run-pre-refresh-checks": False}
+        await refresh_order[0].run_action(
+            "force-refresh-start",
+            **{"check-compatibility": False, "run-pre-refresh-checks": False},
         )
 
     # wait for the first unit to settle

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -103,6 +103,10 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
 
     refresh_cmd = f"refresh {APP_NAME} --model={ops_test.model.info.name} --switch {APP_NAME} --channel {CHARM_CHANNEL}"
     return_code, _, std_err = await ops_test.juju(*refresh_cmd.split())
+
+    await wait_until(ops_test, apps=[APP_NAME], apps_statuses=["blocked"])
+    await refresh_order[0].run_action("force-refresh-start", **{"check-compatibility": False})
+
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
     logger.info("Check etcd versions and cluster membership")

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -125,7 +125,10 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
 
     assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
     stop_continuous_writes()
-    assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
+    # while the upgrade failure was forced, the cluster was shortly not available
+    assert_continuous_writes_consistent(
+        endpoints=endpoints, user=INTERNAL_USER, password=password, ignore_revision=True
+    )
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/ha/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/test_upgrade_and_rollback.py
@@ -77,7 +77,7 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
 
     # versions will always be marked "incompatible" if refresh to a local version
     # see: https://github.com/canonical/charm-refresh/blob/main/charm_refresh/_main.py#L182-L185
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
     if "incompatible" in etcd_application.status_message:
         logger.info("Upgrade is blocked due to incompatibility")
 
@@ -88,9 +88,8 @@ async def test_fail_upgrade_and_rollback(charm: str, ops_test: OpsTest) -> None:
             **{"check-compatibility": False, "run-pre-refresh-checks": False},
         )
 
-    # wait for the first unit to settle
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
-
+    # wait for the first refreshed unit to settle
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
     assert "health check failed" in refresh_order[0].workload_status_message, (
         "Health check after upgrade should have failed"
     )
@@ -176,7 +175,7 @@ async def test_upgrade_to_local(charm: str, ops_test: OpsTest) -> None:
     # versions will always be marked "incompatible" if refresh to a local version
     # this will not be the case when the PR is released
     # see: https://github.com/canonical/charm-refresh/blob/main/charm_refresh/_main.py#L182-L185
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=2)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], idle_period=30)
     if "incompatible" in etcd_application.status_message:
         logger.info("Upgrade is blocked due to incompatibility")
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -467,3 +467,29 @@ def get_role(
         ]
     except json.JSONDecodeError:
         return None
+
+
+def get_etcd_version(
+    endpoint: str,
+    user: str | None = None,
+    password: str | None = None,
+    tls_enabled: bool = False,
+) -> str:
+    """Check workload version of etcd endpoint."""
+    etcd_command = f"etcdctl endpoint status --endpoints={endpoint} -w=json"
+    if user:
+        etcd_command = f"{etcd_command} --user={user}"
+    if password:
+        etcd_command = f"{etcd_command} --password={password}"
+    if tls_enabled:
+        etcd_command = f"{etcd_command} \
+            --cacert client_ca.pem \
+            --cert client.pem \
+            --key client.key"
+
+    try:
+        result = subprocess.getoutput(etcd_command).split("\n")[0]
+        status = json.loads(result)[0]
+        return status["Status"]["version"]
+    except KeyError:
+        raise

--- a/tests/spread/test_upgrade_and_rollback.py/task.yaml
+++ b/tests/spread/test_upgrade_and_rollback.py/task.yaml
@@ -1,0 +1,10 @@
+summary: test_upgrade_and_rollback.py
+environment:
+  TEST_MODULE: ha/test_upgrade_and_rollback.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-arm64-noble-medium
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_upgrades.py
+++ b/tests/unit/test_upgrades.py
@@ -194,7 +194,7 @@ def test_statuses() -> None:
     ctx = testing.Context(EtcdOperatorCharm)
     peer_relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
 
-    state_in = testing.State(relations={peer_relation})
+    state_in = testing.State(relations={peer_relation}, leader=True)
 
     # higher app status
     refresh_mock = MagicMock()
@@ -204,7 +204,8 @@ def test_statuses() -> None:
     with patch("charm_refresh.Machines", MagicMock(return_value=refresh_mock)):
         state_out = ctx.run(ctx.on.update_status(), state_in)
 
-        assert state_out.unit_status == BlockedStatus("123")
+        assert state_out.app_status == BlockedStatus("123")
+        assert state_out.unit_status != BlockedStatus("123")
 
     # higher unit status
     refresh_mock = MagicMock()


### PR DESCRIPTION
This PR provides basic integration test coverage for upgrading charmed etcd.

**Functional changes**
- update etcd to version 3.6.2 (to test the workload upgrade)
- fix handling of upgrades relevant statuses:
  - finding from testing: upgrades have to be first in status priority order to avoid low-priority statuses being overridden, such as `etcd 3.6.1 running; Snap revision 15 (outdated); Charm version 3.6/1.0.0`
  - `health check failed` should not be set as running status, it should only be shown after the upgrades hook has completed (if failed)

**Test coverage**
- deploy from charmhub with the previous workload version of etcd (`3.6.1`, revisions and versions configurable)
- run an upgrade to `3.6.2`, make it fail after the first unit upgraded (because of cluster health) and roll back to `3.6.1`
- run the full upgrade to `3.6.2` for all units
- during upgrades, ensure cluster availability with continuous writes
- note: for now, upgrades will always be marked as incompatible if upgrading to a locally built charm (because of the charm version compatibility check) -> it is required to run the `force-refresh-start` action with `check-compatibility=false` to make the upgrade happen

