### PR TITLE
[DPE-8049] - Move Tiobe to noble

### DIFF
--- a/.github/workflows/tics_run_sh_ghaction_test.yaml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yaml
@@ -20,7 +20,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y python3-venv
 
       - name: Install pipx
-        run: python3 -m pip install --user pipx && python3 -m pipx ensurepath
+        run: sudo apt install pipx && pipx ensurepath
 
       - name: Add pipx to PATH
         run: echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"

--- a/.github/workflows/tics_run_sh_ghaction_test.yaml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tiobe-scan:
-    runs-on: [self-hosted, jammy, tiobe]
+    runs-on: [self-hosted, noble, tiobe]
 
     steps:
       - name: Checkout the project

--- a/.github/workflows/tics_run_sh_ghaction_test.yaml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yaml
@@ -20,7 +20,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y python3-venv
 
       - name: Install pipx
-        run: sudo apt install pipx && pipx ensurepath
+        run: sudo apt install -y pipx && pipx ensurepath
 
       - name: Add pipx to PATH
         run: echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"


### PR DESCRIPTION
## Description of issue or feature:
Python 3.12 not found on jammy

## Solution:
This pull request updates the GitHub Actions workflow configuration for the TIOBE scan job. The main changes involve updating the runner environment to Noble to support python 3.12.
* Changed the runner environment from `jammy` to `noble` in the `runs-on` specification for the `tiobe-scan` job, ensuring compatibility with newer Ubuntu versions.

Dependency installation improvement:

* Updated the installation of `pipx` to use the system package manager (`apt install`) instead of `pip`.

## How was this change tested?
Ran the tics workflow