### PR TITLE
[DPE-8068] Update to 3.6.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,7 +119,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: (GitHub hosted) Free up disk space
-        timeout-minutes: 1
+        timeout-minutes: 10
         run: |
           printf '\nDisk usage before cleanup\n'
           df --human-readable

--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -1,13 +1,13 @@
 # https://canonical-charm-refresh.readthedocs-hosted.com/latest/refresh-versions-toml/
 
 charm_major = 1
-workload = "3.6.2"
+workload = "3.6.4"
 
 [snap]
 name = "charmed-etcd"
 
 [snap.revisions]
 # amd64
-x86_64 = "17"
+x86_64 = "21"
 # arm64
-aarch64 = "18"
+aarch64 = "22"

--- a/tests/integration/ha/upgrades/literals.py
+++ b/tests/integration/ha/upgrades/literals.py
@@ -6,6 +6,6 @@
 
 NUM_UNITS = 3
 CHARM_CHANNEL = "3.6/edge"
-CHARM_REVISIONS_TO_DEPLOY = {"x86_64": 89, "aarch64": 88}
-WORKLOAD_VERSION = {"previous": "3.6.1", "target": "3.6.2"}
+CHARM_REVISIONS_TO_DEPLOY = {"x86_64": 94, "aarch64": 95}
+WORKLOAD_VERSION = {"previous": "3.6.2", "target": "3.6.4"}
 CERTIFICATE_EXPIRY_TIME = 250

--- a/tests/integration/ha/upgrades/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/upgrades/test_upgrade_and_rollback.py
@@ -17,6 +17,12 @@ from tests.integration.ha.helpers import (
     start_continuous_writes,
     stop_continuous_writes,
 )
+from tests.integration.ha.upgrades.literals import (
+    CHARM_CHANNEL,
+    CHARM_REVISIONS_TO_DEPLOY,
+    NUM_UNITS,
+    WORKLOAD_VERSION,
+)
 from tests.integration.helpers import (
     APP_NAME,
     get_cluster_endpoints,
@@ -28,11 +34,6 @@ from tests.integration.helpers import (
 from tests.integration.helpers_deployment import wait_until
 
 logger = logging.getLogger(__name__)
-
-NUM_UNITS = 3
-CHARM_CHANNEL = "3.6/edge"
-CHARM_REVISIONS_TO_DEPLOY = {"x86_64": 89, "aarch64": 88}
-WORKLOAD_VERSION = {"previous": "3.6.1", "target": "3.6.2"}
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
## Description of issue or feature:
After all integration tests for upgrading etcd have been merged, we can upgrade the etcd version used in our charm to the latest 3.6.4.

Jira ticket: https://warthogs.atlassian.net/browse/DPE-8068

## Solution:
Update the `refresh_versions.toml` file with the snap revisions to deploy and expected workload version.

changes along the way:
- increase timeout for the `Free up disk space` step in the terraform test Github workflow to ten minutes to account for frequent failures recently because of timeouts
- cleanup integration tests for upgrades (`test_upgrade_and_rollback.py`) to use the common literals for upgrades

## How was this change tested?
- [x] Manually
- [x] Unit tests
- [x] Integration tests

Upgrade path has been tested manually, edge cases are covered by integration tests.

There are no breaking or API changes in etcd 3.6.4 that would require adjustments to the operator code.