### PR TITLE
pin juju agent-version to ' 3.6.9' because of issue #20714

### DIFF
--- a/concierge.yaml
+++ b/concierge.yaml
@@ -4,7 +4,7 @@ juju:
 providers:
   lxd:
     enable: true
-    bootstrap: true
+    bootstrap: false
 host:
   snaps:
     jhack:

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,7 +1,7 @@
 juju:
   model-defaults:
     logging-config: <root>=INFO; unit=DEBUG
-    agent-version: 3.6.9
+  agent-version: 3.6.9
 providers:
   lxd:
     enable: true

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,7 +1,7 @@
 juju:
   model-defaults:
     logging-config: <root>=INFO; unit=DEBUG
-  agent-version: 3.6.9
+    agent-version: 3.6.9
 providers:
   lxd:
     enable: true

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,8 +1,7 @@
 juju:
   model-defaults:
     logging-config: <root>=INFO; unit=DEBUG
-  bootstrap-constraints:
-    agent-version: 3.6.9
+  agent-version: 3.6.9
 providers:
   lxd:
     enable: true

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,6 +1,8 @@
 juju:
   model-defaults:
     logging-config: <root>=INFO; unit=DEBUG
+  bootstrap-constraints:
+    agent-version: 3.6.9
 providers:
   lxd:
     enable: true

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,11 +1,10 @@
 juju:
   model-defaults:
     logging-config: <root>=INFO; unit=DEBUG
-  agent-version: 3.6.9
 providers:
   lxd:
     enable: true
-    bootstrap: true
+    bootstrap: false
 host:
   snaps:
     jhack:

--- a/spread.yaml
+++ b/spread.yaml
@@ -128,7 +128,7 @@ prepare: |
 
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace
-  /snap/bin/juju bootstrap localhost concierge-lxd --verbose --model-default 'logging-config=<root>=INFO; unit=DEBUG' --agent-version: 3.6.9
+  /snap/bin/juju bootstrap localhost concierge-lxd --verbose --model-default 'logging-config=<root>=INFO; unit=DEBUG' --agent-version=3.6.9
   /snap/bin/juju add-model -c concierge-lxd testing
 
   pipx install tox poetry

--- a/spread.yaml
+++ b/spread.yaml
@@ -128,6 +128,8 @@ prepare: |
 
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace
+  /snap/bin/juju bootstrap localhost concierge-lxd --verbose --model-default 'logging-config=<root>=INFO; unit=DEBUG' --agent-version=3.6.9
+  /snap/bin/juju add-model -c concierge-lxd testing
 
   pipx install tox poetry
 prepare-each: |

--- a/spread.yaml
+++ b/spread.yaml
@@ -127,13 +127,13 @@ prepare: |
   go install github.com/canonical/concierge@latest
 
   # Install charmcraft & pipx (on lxd-vm backend)
-  concierge prepare --trace
+  go/bin/concierge prepare --trace
 
   pipx install tox poetry
 prepare-each: |
   cd "$SPREAD_PATH"
   # `concierge prepare` needs to be run for each spread job in case Juju version changed
-  concierge prepare --trace
+  go/bin/concierge prepare --trace
 
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050

--- a/spread.yaml
+++ b/spread.yaml
@@ -124,7 +124,7 @@ prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
   cd "$SPREAD_PATH"
-  snap install --classic concierge
+  go install github.com/canonical/concierge@latest
 
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace

--- a/spread.yaml
+++ b/spread.yaml
@@ -124,16 +124,18 @@ prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
   cd "$SPREAD_PATH"
-  GOBIN=$SPREAD_PATH/bin/ go install github.com/canonical/concierge@latest
+  snap install --classic concierge
 
   # Install charmcraft & pipx (on lxd-vm backend)
-  $SPREAD_PATH/bin/concierge prepare --trace
+  concierge prepare --trace
+  /snap/bin/juju bootstrap localhost concierge-lxd --verbose --model-default 'logging-config=<root>=INFO; unit=DEBUG' --agent-version: 3.6.9
+  /snap/bin/juju add-model -c concierge-lxd testing
 
   pipx install tox poetry
 prepare-each: |
   cd "$SPREAD_PATH"
   # `concierge prepare` needs to be run for each spread job in case Juju version changed
-  $SPREAD_PATH/bin/concierge prepare --trace
+  concierge prepare --trace
 
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050

--- a/spread.yaml
+++ b/spread.yaml
@@ -127,13 +127,13 @@ prepare: |
   go install github.com/canonical/concierge@latest
 
   # Install charmcraft & pipx (on lxd-vm backend)
-  go/bin/concierge prepare --trace
+  $GOROOT/bin/concierge prepare --trace
 
   pipx install tox poetry
 prepare-each: |
   cd "$SPREAD_PATH"
   # `concierge prepare` needs to be run for each spread job in case Juju version changed
-  go/bin/concierge prepare --trace
+  $GOROOT/bin/concierge prepare --trace
 
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050

--- a/spread.yaml
+++ b/spread.yaml
@@ -124,16 +124,16 @@ prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
   cd "$SPREAD_PATH"
-  go install github.com/canonical/concierge@latest
+  GOBIN=$SPREAD_PATH/bin/ go install github.com/canonical/concierge@latest
 
   # Install charmcraft & pipx (on lxd-vm backend)
-  $GOROOT/bin/concierge prepare --trace
+  $SPREAD_PATH/bin/concierge prepare --trace
 
   pipx install tox poetry
 prepare-each: |
   cd "$SPREAD_PATH"
   # `concierge prepare` needs to be run for each spread job in case Juju version changed
-  $GOROOT/bin/concierge prepare --trace
+  $SPREAD_PATH/bin/concierge prepare --trace
 
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050


### PR DESCRIPTION
## Description of issue or feature:
Juju release `3.6.10` introduced a regression: New IP addresses are not picked up after an IP address change, see [#20714](https://github.com/juju/juju/issues/20714).

## Solution:
Fix the Juju agent-version used in integration tests to the previous version `3.6.9`, to allow for proper testing and unblock releases.

Therefore we temporarily disable bootstrapping a Juju lxd controller with concierge and instead do that ourselves in the spread script.

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [X] Integration tests