### PR TITLE
[DPE-8007] Add config option for certificate domain

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,14 +48,6 @@ options:
       for client certificates. Example: "mydomain.com". This must match the allowed domains from the TLS provider.
       In the case of Vault, this should be set to one of the domains configured in "pki_allowed_domains". 
 
-  client-certificate-include-ip-sans:
-    type: boolean
-    default: true
-    description: |
-      Config option to enable or disable IP addresses in the subject alternative names (SAN) used for 
-      certificate signing requests for client certificates. This should be set to false if the related 
-      TLS provider does not support IP addresses in certificates.
-
   peer-certificate-domain:
     type: string
     description: |

--- a/config.yaml
+++ b/config.yaml
@@ -63,14 +63,6 @@ options:
       for peer server certificates. Example: "mydomain.com". This must match the allowed domains from the TLS 
       provider. In the case of Vault, this should be set to one of the domains configured in "pki_allowed_domains". 
 
-  peer-certificate-include-ip-sans:
-    type: boolean
-    default: true
-    description: |
-      Config option to enable or disable IP addresses in the subject alternative names (SAN) used for 
-      certificate signing requests for peer server certificates. This should be set to false if the related 
-      TLS provider does not support IP addresses in certificates.
-
   pause-after-unit-refresh:
     type: string
     default: first

--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,36 @@ options:
       Use "{unit}" as a placeholder to be filled with the unit number, e.g. "worker-{unit}" will be translated as 
       "worker-0" for unit 0 and "worker-1" for unit 1 when requesting the certificate.
 
+  client-certificate-domain:
+    type: string
+    description: |
+      Config option to specify a domain to be added to the common names in certificate signing requests
+      for client certificates. Example: "mydomain.com". This must match the allowed domains from the TLS provider.
+      In the case of Vault, this should be set to one of the domains configured in "pki_allowed_domains". 
+
+  client-certificate-include-ip-sans:
+    type: boolean
+    default: true
+    description: |
+      Config option to enable or disable IP addresses in the subject alternative names (SAN) used for 
+      certificate signing requests for client certificates. This should be set to false if the related 
+      TLS provider does not support IP addresses in certificates.
+
+  peer-certificate-domain:
+    type: string
+    description: |
+      Config option to specify a domain to be added to the common names in certificate signing requests 
+      for peer server certificates. Example: "mydomain.com". This must match the allowed domains from the TLS 
+      provider. In the case of Vault, this should be set to one of the domains configured in "pki_allowed_domains". 
+
+  peer-certificate-include-ip-sans:
+    type: boolean
+    default: true
+    description: |
+      Config option to enable or disable IP addresses in the subject alternative names (SAN) used for 
+      certificate signing requests for peer server certificates. This should be set to false if the related 
+      TLS provider does not support IP addresses in certificates.
+
   pause-after-unit-refresh:
     type: string
     default: first

--- a/docs/how-to/tls/enable-tls.md
+++ b/docs/how-to/tls/enable-tls.md
@@ -30,6 +30,8 @@ This guide will use the [Self-signed Certificates](https://charmhub.io/self-sign
 Check [this guide](https://charmhub.io/topics/security-with-x-509-certificates) for an overview of all the TLS certificates charms available. 
 
 If [Vault](https://charmhub.io/vault-k8s?channel=1.18/edge) is used as TLS provider, it is required in version 1.18 at least. 
+See [](../tune-settings.md/#certificate-sans-configuration) for information on how to configure the certificate domain 
+in accordance to Vault's configuration.
 ```
 
 Deploy the `self-signed-certificates` charm. etcd uses `v4` of the [{spellexception}`tls-certificates` library](https://charmhub.io/tls-certificates-interface/libraries/tls_certificates), which is currently only supported in the `edge` channel.

--- a/docs/how-to/tls/enable-tls.md
+++ b/docs/how-to/tls/enable-tls.md
@@ -14,6 +14,10 @@ etcd also supports mutual TLS authentication, which provides an additional layer
 
 ## Deploy a TLS provider
 
+```{attention}
+Etcd's communication is strictly IP-based, both for peer-to-peer as well as client-to-server communication. Make sure to choose a TLS provider that supports IP SANs.
+```
+
 Charmed etcd provides the option of using different CA certificates for client-server and peer-to-peer communication. This allows you to have different levels of trust for the two types of communication. You can also use the same CA certificate for both types of communication.
 
 You can enable peer-to-peer encryption alone, client-to-server encryption alone, or both at the same time.
@@ -25,8 +29,7 @@ This guide will use the [Self-signed Certificates](https://charmhub.io/self-sign
 
 Check [this guide](https://charmhub.io/topics/security-with-x-509-certificates) for an overview of all the TLS certificates charms available. 
 
-If [Vault](https://charmhub.io/vault-k8s?channel=1.18/edge) is used as TLS provider, it is required in version 1.18 at least. Currently Vault 
-is only supported with the configuration option `pki_allow_any_name=true`, allowing for any domain name in requested certificates. 
+If [Vault](https://charmhub.io/vault-k8s?channel=1.18/edge) is used as TLS provider, it is required in version 1.18 at least. 
 ```
 
 Deploy the `self-signed-certificates` charm. etcd uses `v4` of the [{spellexception}`tls-certificates` library](https://charmhub.io/tls-certificates-interface/libraries/tls_certificates), which is currently only supported in the `edge` channel.

--- a/docs/how-to/tune-settings.md
+++ b/docs/how-to/tune-settings.md
@@ -81,12 +81,19 @@ to decide the correct adjustments to the parameters for your specific requiremen
 
 ## Certificate SANs configuration
 
+```{attention}
+Etcd's communication is strictly IP-based, both for peer-to-peer as well as client-to-server communication. 
+Make sure to choose a TLS provider that supports IP SANs.
+```
+
 In X.509 TLS certificates, a `Subject Alternative Name` (SAN) allows a certificate subject to be associated with the 
 service name and domain name components of a DNS record. If charmed etcd is deployed in an environment where the DNS 
 resolution on the client side does not correspond to the DNS resolution on the server side, it might be required to add 
 custom SANs to the TLS certificates used for client- and/or peer-communication.
 
 See more about TLS in charmed etcd: [TLS encryption](tls/index.md)
+
+### Add extra-sans
 
 To add different IP addresses or hostnames to the SANs of charmed etcd's TLS certificates, configure the `certificate-extra-sans`
 option. It is possible to add a comma-separated list of multiple values, as long as each of them is a valid IP address 
@@ -106,3 +113,18 @@ Wildcards (`*`) are not allowed as part of the `certificate-extra-sans` configur
 If it is required to include the unit number of each unit, this can be done by using the `{unit}` placeholder. For example,
 a configuration of `certificate-extra-sans="etcd{unit}.my-external-domain.com"` would result in `etcd0.my-external-domain.com`
 as an additional SAN in the TLS certificates for unit `charmed-etcd/0`.
+
+### Add a domain
+
+If a specific domain name is required for the TLS certificates used in etcd, configure the `client-certificate-domain`
+and/or `peer-certificate-domain` option. The configuration value should match the allowed value from the TLS provider.
+
+For example, if you want to expose your charmed etcd cluster externally and want to use client certificates for the 
+domain `mycompany.com`, configure it like this:
+
+```text
+juju config charmed-etcd client-certificate-domain="mycompany.com"
+```
+
+This option can be configured for client and peer certificates separately. If the configured domain name is valid 
+and not yet included in charmed etcd's certificates, it will automatically refresh those.

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -107,12 +107,16 @@ class EtcdServer(RelationState):
     def peer_url(self) -> str:
         """The peer connection endpoint for the etcd server."""
         scheme = "https" if self.tls_peer_state in [TLSState.TLS, TLSState.TO_NO_TLS] else "http"
+        # `peer_url` MUST be IP address, etcd does not support using DNS names for the listeners
+        # see https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md#breaking-changes
         return f"{scheme}://{self.ip}:{PEER_PORT}"
 
     @property
     def client_url(self) -> str:
         """The client connection endpoint for the etcd server."""
         scheme = "https" if self.tls_client_state in [TLSState.TLS, TLSState.TO_NO_TLS] else "http"
+        # `client_url` MUST be IP address, etcd does not support using DNS names for the listeners
+        # see https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md#breaking-changes
         return f"{scheme}://{self.ip}:{CLIENT_PORT}"
 
     @property

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -364,15 +364,22 @@ class TLSEvents(Object):
         if tls_client_private_key_id := self.charm.config.get(TLS_CLIENT_PRIVATE_KEY_CONFIG):
             self.update_private_key(tls_client_private_key_id)
 
-        if self.charm.tls_manager.extra_sans_config_is_valid():
-            if (
-                self.charm.state.unit_server.tls_client_state == TLSState.TLS
-                and self.charm.tls_manager.certificate_sans_require_update(TLSType.CLIENT)
-                or self.charm.state.unit_server.tls_peer_state == TLSState.TLS
-                and self.charm.tls_manager.certificate_sans_require_update(TLSType.PEER)
-            ):
-                logger.debug("Config change for certificate options, refresh TLS certificates")
-                self.refresh_tls_certificates_event.emit()
+        if not (
+            self.charm.tls_manager.extra_sans_config_is_valid()
+            and self.charm.tls_manager.certificate_domain_config_is_valid(TLSType.CLIENT)
+            and self.charm.tls_manager.certificate_domain_config_is_valid(TLSType.PEER)
+        ):
+            logger.warning("TLS certificates not updated because of invalid configuration")
+            return
+
+        if (
+            self.charm.state.unit_server.tls_client_state == TLSState.TLS
+            and self.charm.tls_manager.certificate_sans_require_update(TLSType.CLIENT)
+            or self.charm.state.unit_server.tls_peer_state == TLSState.TLS
+            and self.charm.tls_manager.certificate_sans_require_update(TLSType.PEER)
+        ):
+            logger.debug("Config change for certificate options, refresh TLS certificates")
+            self.refresh_tls_certificates_event.emit()
 
     def _on_secret_changed(self, event: SecretChangedEvent) -> None:
         """Handle TLS related secret changes."""

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -117,9 +117,11 @@ class TLSEvents(Object):
             PEER_TLS_RELATION_NAME,
             certificate_requests=[
                 CertificateRequestAttributes(
-                    common_name=common_name,
+                    common_name=self.charm.tls_manager.build_common_name(
+                        common_name, TLSType.PEER
+                    ),
                     sans_ip=self.charm.tls_manager.build_sans_ip(TLSType.PEER),
-                    sans_dns=self.charm.tls_manager.build_sans_dns(),
+                    sans_dns=self.charm.tls_manager.build_sans_dns(TLSType.PEER),
                 ),
             ],
             private_key=peer_private_key,
@@ -130,9 +132,11 @@ class TLSEvents(Object):
             CLIENT_TLS_RELATION_NAME,
             certificate_requests=[
                 CertificateRequestAttributes(
-                    common_name=common_name,
+                    common_name=self.charm.tls_manager.build_common_name(
+                        common_name, TLSType.CLIENT
+                    ),
                     sans_ip=self.charm.tls_manager.build_sans_ip(TLSType.CLIENT),
-                    sans_dns=self.charm.tls_manager.build_sans_dns(),
+                    sans_dns=self.charm.tls_manager.build_sans_dns(TLSType.CLIENT),
                 ),
             ],
             private_key=client_private_key,
@@ -367,7 +371,7 @@ class TLSEvents(Object):
                 or self.charm.state.unit_server.tls_peer_state == TLSState.TLS
                 and self.charm.tls_manager.certificate_sans_require_update(TLSType.PEER)
             ):
-                logger.debug("Config change for certificate-extra-sans, refresh TLS certificates")
+                logger.debug("Config change for certificate options, refresh TLS certificates")
                 self.refresh_tls_certificates_event.emit()
 
     def _on_secret_changed(self, event: SecretChangedEvent) -> None:

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -288,12 +288,6 @@ class TLSManager(ManagerStatusProtocol):
         """
         sans_ip = set()
 
-        if tls_type == TLSType.CLIENT and not self.state.config.get(
-            "client-certificate-include-ip-sans"
-        ):
-            # return early without any IP's because IP SANs are disabled
-            return frozenset(sans_ip)
-
         if self.extra_sans_config_is_valid() and (
             extra_sans_config := self.state.config.get("certificate-extra-sans")
         ):

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -294,6 +294,7 @@ class TLSManager(ManagerStatusProtocol):
             or tls_type == TLSType.PEER
             and not self.state.config.get("peer-certificate-include-ip-sans")
         ):
+            # return early without any IP's because IP SANs are disabled
             return frozenset(sans_ip)
 
         if self.extra_sans_config_is_valid() and (
@@ -335,6 +336,7 @@ class TLSManager(ManagerStatusProtocol):
         sans_dns.add(self.state.unit_server.unit_name.replace("/", ""))
         sans_dns.add(self.workload.get_host_mapping()["hostname"])
 
+        # add desired domain to every DNS name if configured
         if self.certificate_domain_config_is_valid(tls_type) and (
             certificate_domain_config := self.state.config.get(f"{tls_type}-certificate-domain")
         ):

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -548,4 +548,10 @@ class TLSManager(ManagerStatusProtocol):
         if not self.extra_sans_config_is_valid():
             status_list.append(TLSStatuses.SANS_CONFIG_INVALID.value)
 
+        if not self.certificate_domain_config_is_valid(TLSType.CLIENT):
+            status_list.append(TLSStatuses.CLIENT_DOMAIN_CONFIG_INVALID.value)
+
+        if not self.certificate_domain_config_is_valid(TLSType.PEER):
+            status_list.append(TLSStatuses.PEER_DOMAIN_CONFIG_INVALID.value)
+
         return status_list if status_list else [CharmStatuses.ACTIVE_IDLE.value]

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -288,11 +288,8 @@ class TLSManager(ManagerStatusProtocol):
         """
         sans_ip = set()
 
-        if (
-            tls_type == TLSType.CLIENT
-            and not self.state.config.get("client-certificate-include-ip-sans")
-            or tls_type == TLSType.PEER
-            and not self.state.config.get("peer-certificate-include-ip-sans")
+        if tls_type == TLSType.CLIENT and not self.state.config.get(
+            "client-certificate-include-ip-sans"
         ):
             # return early without any IP's because IP SANs are disabled
             return frozenset(sans_ip)

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -343,7 +343,7 @@ class TLSManager(ManagerStatusProtocol):
         if self.certificate_domain_config_is_valid(tls_type) and (
             certificate_domain_config := self.state.config.get(f"{tls_type}-certificate-domain")
         ):
-            return common_name + "." + certificate_domain_config
+            return f"{common_name}.{certificate_domain_config}"
 
         return common_name
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -287,6 +287,15 @@ class TLSManager(ManagerStatusProtocol):
             frozenset[str]: The SANs IP.
         """
         sans_ip = set()
+
+        if (
+            tls_type == TLSType.CLIENT
+            and not self.state.config.get("client-certificate-include-ip-sans")
+            or tls_type == TLSType.PEER
+            and not self.state.config.get("peer-certificate-include-ip-sans")
+        ):
+            return frozenset(sans_ip)
+
         if self.extra_sans_config_is_valid() and (
             extra_sans_config := self.state.config.get("certificate-extra-sans")
         ):
@@ -306,7 +315,7 @@ class TLSManager(ManagerStatusProtocol):
 
         return frozenset(sans_ip)
 
-    def build_sans_dns(self) -> frozenset[str]:
+    def build_sans_dns(self, tls_type: TLSType) -> frozenset[str]:
         """Build the SANs DNS for the TLS certificate.
 
         Returns:
@@ -325,7 +334,28 @@ class TLSManager(ManagerStatusProtocol):
 
         sans_dns.add(self.state.unit_server.unit_name.replace("/", ""))
         sans_dns.add(self.workload.get_host_mapping()["hostname"])
+
+        if self.certificate_domain_config_is_valid(tls_type) and (
+            certificate_domain_config := self.state.config.get(f"{tls_type}-certificate-domain")
+        ):
+            updated_sans_dns = set()
+            for san in sans_dns:
+                updated_sans_dns.add(san + "." + certificate_domain_config)
+            return frozenset(updated_sans_dns)
+
         return frozenset(sans_dns)
+
+    def build_common_name(self, common_name: str, tls_type: TLSType) -> str:
+        """Build the Common Name for the TLS certificate."""
+        if not (
+            certificate_domain_config := self.state.config.get(f"{tls_type}-certificate-domain")
+        ):
+            return common_name
+
+        if self.certificate_domain_config_is_valid(tls_type):
+            return common_name + "." + certificate_domain_config
+
+        return common_name
 
     def extra_sans_config_is_valid(self) -> bool:
         """Validate configuration value for certificate-extra-sans option.
@@ -345,6 +375,19 @@ class TLSManager(ManagerStatusProtocol):
                 ):
                     logger.error(f"certificate-extra-sans configuration is invalid for {san}")
                     return False
+
+        return True
+
+    def certificate_domain_config_is_valid(self, tls_type: TLSType) -> bool:
+        """Validate configuration value for {peer|client}-certificate-domain option."""
+        if not (
+            certificate_domain_config := self.state.config.get(f"{tls_type}-certificate-domain")
+        ):
+            return True
+
+        if not self._is_hostname(certificate_domain_config):
+            logger.error(f"{tls_type}-certificate-domain configuration is invalid")
+            return False
 
         return True
 
@@ -391,7 +434,7 @@ class TLSManager(ManagerStatusProtocol):
         """
         current_sans = self.get_current_sans(tls_type)
         new_sans_ip = self.build_sans_ip(tls_type)
-        new_sans_dns = self.build_sans_dns()
+        new_sans_dns = self.build_sans_dns(tls_type)
 
         if new_sans_ip ^ current_sans["sans_ip"] or new_sans_dns ^ current_sans["sans_dns"]:
             return True

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -340,12 +340,9 @@ class TLSManager(ManagerStatusProtocol):
 
     def build_common_name(self, common_name: str, tls_type: TLSType) -> str:
         """Build the Common Name for the TLS certificate."""
-        if not (
+        if self.certificate_domain_config_is_valid(tls_type) and (
             certificate_domain_config := self.state.config.get(f"{tls_type}-certificate-domain")
         ):
-            return common_name
-
-        if self.certificate_domain_config_is_valid(tls_type):
             return common_name + "." + certificate_domain_config
 
         return common_name
@@ -373,12 +370,9 @@ class TLSManager(ManagerStatusProtocol):
 
     def certificate_domain_config_is_valid(self, tls_type: TLSType) -> bool:
         """Validate configuration value for {peer|client}-certificate-domain option."""
-        if not (
+        if (
             certificate_domain_config := self.state.config.get(f"{tls_type}-certificate-domain")
-        ):
-            return True
-
-        if not self._is_hostname(certificate_domain_config):
+        ) and not self._is_hostname(certificate_domain_config):
             logger.error(f"{tls_type}-certificate-domain configuration is invalid")
             return False
 

--- a/src/statuses.py
+++ b/src/statuses.py
@@ -120,16 +120,16 @@ class TLSStatuses(Enum):
     )
     SANS_CONFIG_INVALID = StatusObject(
         status="blocked",
-        message="Invalid value set for the config option 'certificate-extra-sans'",
+        message="Invalid value for config option 'certificate-extra-sans'",
         short_message="Invalid value `certificate-extra-sans`",
     )
     CLIENT_DOMAIN_CONFIG_INVALID = StatusObject(
         status="blocked",
-        message="Invalid config value for 'client-certificate-domain'",
+        message="Invalid value for config option 'client-certificate-domain'",
     )
     PEER_DOMAIN_CONFIG_INVALID = StatusObject(
         status="blocked",
-        message="Invalid config value for 'peer-certificate-domain'",
+        message="Invalid value for config option 'peer-certificate-domain'",
     )
 
 

--- a/src/statuses.py
+++ b/src/statuses.py
@@ -120,8 +120,16 @@ class TLSStatuses(Enum):
     )
     SANS_CONFIG_INVALID = StatusObject(
         status="blocked",
-        message="Invalid value set for the config options 'certificate-extra-sans'",
+        message="Invalid value set for the config option 'certificate-extra-sans'",
         short_message="Invalid value `certificate-extra-sans`",
+    )
+    CLIENT_DOMAIN_CONFIG_INVALID = StatusObject(
+        status="blocked",
+        message="Invalid config value for 'client-certificate-domain'",
+    )
+    PEER_DOMAIN_CONFIG_INVALID = StatusObject(
+        status="blocked",
+        message="Invalid config value for 'peer-certificate-domain'",
     )
 
 

--- a/tests/integration/tls/test_vault_intermediate_ca.py
+++ b/tests/integration/tls/test_vault_intermediate_ca.py
@@ -220,3 +220,33 @@ async def test_tls_enabled(ops_test: OpsTest) -> None:
         )
         == TEST_VALUE
     ), "Failed to read key"
+
+
+@pytest.mark.abort_on_fail
+async def test_restrict_certificate_domain(ops_test: OpsTest) -> None:
+    """Restrict the allowed domains and request new certificates."""
+    logger.info("Restrict allowed certificate domains in Vault")
+    vault_domain_config_value = "domain1, domain2, domain3"
+    etcd_domain_config_value = "domain3"
+    await ops_test.model.applications[VAULT_NAME].set_config(
+        {"pki_allowed_domains": vault_domain_config_value}
+    )
+    await wait_until(ops_test, apps=[VAULT_NAME])
+
+    logger.info("Configure certificate domains in etcd")
+    await ops_test.model.applications[APP_NAME].set_config(
+        {
+            "client-certificate-domain": etcd_domain_config_value,
+            "peer-certificate-domain": etcd_domain_config_value,
+        }
+    )
+
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+
+    await download_client_certificate_from_unit(ops_test, APP_NAME)
+    client_cert_subject = subprocess.getoutput(
+        "openssl x509 -noout -subject -in client.pem "
+    )
+    assert etcd_domain_config_value in client_cert_subject, (
+        f"expected domain name {etcd_domain_config_value} not found in certificate subject {client_cert_subject}"
+    )

--- a/tests/integration/tls/test_vault_intermediate_ca.py
+++ b/tests/integration/tls/test_vault_intermediate_ca.py
@@ -13,6 +13,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from literals import INTERNAL_USER, PEER_RELATION
+from statuses import TLSStatuses
 
 from ..helpers import (
     APP_NAME,
@@ -227,13 +228,13 @@ async def test_restrict_certificate_domain(ops_test: OpsTest) -> None:
     """Restrict the allowed domains and request new certificates."""
     logger.info("Restrict allowed certificate domains in Vault")
     vault_domain_config_value = "domain1, domain2, domain3"
-    etcd_domain_config_value = "domain3"
     await ops_test.model.applications[VAULT_NAME].set_config(
         {"pki_allowed_domains": vault_domain_config_value}
     )
     await wait_until(ops_test, apps=[VAULT_NAME])
 
-    logger.info("Configure certificate domains in etcd")
+    logger.info("Configure certificate domain in etcd")
+    etcd_domain_config_value = "domain3"
     await ops_test.model.applications[APP_NAME].set_config(
         {
             "client-certificate-domain": etcd_domain_config_value,
@@ -244,9 +245,31 @@ async def test_restrict_certificate_domain(ops_test: OpsTest) -> None:
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
 
     await download_client_certificate_from_unit(ops_test, APP_NAME)
-    client_cert_subject = subprocess.getoutput(
-        "openssl x509 -noout -subject -in client.pem "
-    )
+    client_cert_subject = subprocess.getoutput("openssl x509 -noout -subject -in client.pem ")
     assert etcd_domain_config_value in client_cert_subject, (
         f"expected domain name {etcd_domain_config_value} not found in certificate subject {client_cert_subject}"
     )
+    logger.info("Certificates in etcd updated with new domain")
+
+    logger.info("Set config in etcd to invalid value")
+    etcd_invalid_domain_config_value = "192.168.2.200"
+
+    await ops_test.model.applications[APP_NAME].set_config(
+        {"client-certificate-domain": etcd_invalid_domain_config_value}
+    )
+
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        apps_full_statuses={
+            APP_NAME: [TLSStatuses.CLIENT_DOMAIN_CONFIG_INVALID.value],
+        },
+        wait_for_exact_units=NUM_UNITS,
+    )
+
+    await download_client_certificate_from_unit(ops_test, APP_NAME)
+    client_cert_subject = subprocess.getoutput("openssl x509 -noout -subject -in client.pem ")
+    assert etcd_invalid_domain_config_value not in client_cert_subject, (
+        f"domain name {etcd_invalid_domain_config_value} found in certificate subject {client_cert_subject}"
+    )
+    logger.info("Certificates not updated after configuring invalid domain name")

--- a/tests/integration/tls/test_vault_intermediate_ca.py
+++ b/tests/integration/tls/test_vault_intermediate_ca.py
@@ -251,6 +251,10 @@ async def test_restrict_certificate_domain(ops_test: OpsTest) -> None:
     )
     logger.info("Certificates in etcd updated with new domain")
 
+
+@pytest.mark.abort_on_fail
+async def test_invalid_certificate_domain(ops_test: OpsTest) -> None:
+    """Ensure no new certificates are requested if invalid domain is configured."""
     logger.info("Set config in etcd to invalid value")
     etcd_invalid_domain_config_value = "192.168.2.200"
 

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1657,7 +1657,7 @@ def test_set_extra_sans_config_option():
         assert status_is(state_out, CharmStatuses.ACTIVE_IDLE.value)
 
 
-def test_disable_ip_sans_config_option():
+def test_disable_ip_sans():
     relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
@@ -1689,3 +1689,95 @@ def test_disable_ip_sans_config_option():
         state_out = ctx.run(ctx.on.config_changed(), state_in)
         assert isinstance(ctx.emitted_events[1], RefreshTLSCertificatesEvent)
         assert status_is(state_out, CharmStatuses.ACTIVE_IDLE.value)
+
+
+def test_set_domain_config_option():
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={
+            "authentication": "enabled",
+            "cluster_state": "existing",
+            "cluster_members": "charmed-etcd0=https://my_ip:2380",
+        },
+        local_unit_data={
+            "private_ip": "my_ip",
+            "tls_peer_state": TLSState.TLS.value,
+            "tls_client_state": TLSState.TLS.value,
+        },
+    )
+    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+
+    # happy path
+    ctx = testing.Context(EtcdOperatorCharm)
+    state_in = testing.State(
+        config={
+            "client-certificate-domain": "mydomain.com",
+        },
+        relations={relation},
+    )
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        assert isinstance(ctx.emitted_events[1], RefreshTLSCertificatesEvent)
+        assert status_is(state_out, CharmStatuses.ACTIVE_IDLE.value)
+
+    # invalid client domain name
+    ctx = testing.Context(EtcdOperatorCharm)
+    state_in = testing.State(
+        config={
+            "client-certificate-domain": ".domain",
+        },
+        relations={relation},
+    )
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        assert status_is(state_out, TLSStatuses.CLIENT_DOMAIN_CONFIG_INVALID.value)
+
+    # invalid peer domain name
+    ctx = testing.Context(EtcdOperatorCharm)
+    state_in = testing.State(
+        config={
+            "peer-certificate-domain": "mydomain.com, anotherdomain.com",
+        },
+        relations={relation},
+    )
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        assert status_is(state_out, TLSStatuses.PEER_DOMAIN_CONFIG_INVALID.value)
+
+    # both are invalid
+    ctx = testing.Context(EtcdOperatorCharm)
+    state_in = testing.State(
+        config={
+            "peer-certificate-domain": "10.1.1.0",
+            "client-certificate-domain": "-",
+        },
+        relations={relation},
+    )
+
+    current_sans_value = "X509v3 Subject Alternative Name: \n    DNS:myhostname, DNS:charmed-etcd0, IP Address:127.0.1.1"
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("workload.EtcdWorkload.exec", return_value=current_sans_value),
+        patch("workload.EtcdWorkload.get_host_mapping", return_value={"hostname": "myhostname"}),
+        patch("workload.EtcdWorkload.get_private_ip", return_value="127.0.1.1"),
+        patch("subprocess.run"),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        # client config status is set before peer config status
+        assert status_is(state_out, TLSStatuses.CLIENT_DOMAIN_CONFIG_INVALID.value)
+        # no RefreshTLSCertificatesEvent must be emitted
+        assert len(ctx.emitted_events) == 1

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1740,6 +1740,8 @@ def test_set_domain_config_option():
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
         assert status_is(state_out, TLSStatuses.CLIENT_DOMAIN_CONFIG_INVALID.value)
+        # no RefreshTLSCertificatesEvent must be emitted
+        assert len(ctx.emitted_events) == 1
 
     # invalid peer domain name
     ctx = testing.Context(EtcdOperatorCharm)
@@ -1756,8 +1758,10 @@ def test_set_domain_config_option():
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
         assert status_is(state_out, TLSStatuses.PEER_DOMAIN_CONFIG_INVALID.value)
+        # no RefreshTLSCertificatesEvent must be emitted
+        assert len(ctx.emitted_events) == 1
 
-    # both are invalid
+    # both client and peer domain names are invalid
     ctx = testing.Context(EtcdOperatorCharm)
     state_in = testing.State(
         config={

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1655,3 +1655,37 @@ def test_set_extra_sans_config_option():
         # no RefreshTLSCertificatesEvent must be emitted
         assert len(ctx.emitted_events) == 1
         assert status_is(state_out, CharmStatuses.ACTIVE_IDLE.value)
+
+
+def test_disable_ip_sans_config_option():
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={
+            "authentication": "enabled",
+            "cluster_state": "existing",
+            "cluster_members": "charmed-etcd0=https://my_ip:2380",
+        },
+        local_unit_data={
+            "private_ip": "my_ip",
+            "tls_peer_state": TLSState.TLS.value,
+            "tls_client_state": TLSState.TLS.value,
+        },
+    )
+    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+
+    ctx = testing.Context(EtcdOperatorCharm)
+    state_in = testing.State(
+        config={
+            "client-certificate-include-ip-sans": False,
+        },
+        relations={relation},
+    )
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("subprocess.run"),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        assert isinstance(ctx.emitted_events[1], RefreshTLSCertificatesEvent)
+        assert status_is(state_out, CharmStatuses.ACTIVE_IDLE.value)

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1657,40 +1657,6 @@ def test_set_extra_sans_config_option():
         assert status_is(state_out, CharmStatuses.ACTIVE_IDLE.value)
 
 
-def test_disable_ip_sans():
-    relation = testing.PeerRelation(
-        id=1,
-        endpoint=PEER_RELATION,
-        local_app_data={
-            "authentication": "enabled",
-            "cluster_state": "existing",
-            "cluster_members": "charmed-etcd0=https://my_ip:2380",
-        },
-        local_unit_data={
-            "private_ip": "my_ip",
-            "tls_peer_state": TLSState.TLS.value,
-            "tls_client_state": TLSState.TLS.value,
-        },
-    )
-    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
-
-    ctx = testing.Context(EtcdOperatorCharm)
-    state_in = testing.State(
-        config={
-            "client-certificate-include-ip-sans": False,
-        },
-        relations={relation},
-    )
-
-    with (
-        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("subprocess.run"),
-    ):
-        state_out = ctx.run(ctx.on.config_changed(), state_in)
-        assert isinstance(ctx.emitted_events[1], RefreshTLSCertificatesEvent)
-        assert status_is(state_out, CharmStatuses.ACTIVE_IDLE.value)
-
-
 def test_set_domain_config_option():
     relation = testing.PeerRelation(
         id=1,


### PR DESCRIPTION
## Description of issue or feature:
When using Vault as TLS provider for etcd, we currently only support it with the configuration `pki_allow_any_name=true`. In order to allow using Vault (or another TLS provider) with a more restrictive configuration, we need to provide a specific domain as part of the common name and DNS SANs in the certificate requests.

[DPE-8007](https://warthogs.atlassian.net/browse/DPE-8007)

## Solution:
The PR adds configuration options for `client-certificate-domain` and `peer-certificate-domain`. The values set to these configurations will be appended to the common name and all DNS SANs of the respective certificate requests, if valid. If invalid, a blocked status will be displayed to the user.

The existing code structure can mostly be used for this, the foundation has already been laid when implementing the `certificate-extra-sans` configuration. Now, only two new methods `certificate_domain_config_is_valid()` and `build_common_name()` have been added to the TLS manager.

**Important note:**
Etcd's communication is strictly IP-based, both for peer-to-peer as well as client-to-server communication. It is not possible to disable IP SANs in the certificate requests. For more information see: [breaking change in v3.2](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md#breaking-changes) and [etcd issue 6336](https://github.com/etcd-io/etcd/issues/6336)

The PR also adds user documentation for the new configuration options and a note regarding IP SANs to the existing TLS docs.

## How was this change tested?
- [X] Manually
- [X] Unit tests
- [X] Integration tests

Manual testing was performed with both self-signed-certificates for regression testing as well as Vault for ensuring that we are now able to use Vault as TLS provider with restricted domain names (also covered with integration test).

[DPE-8007]: https://warthogs.atlassian.net/browse/DPE-8007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ