### PR TITLE
[DPE-8407] update etcd to version 3.6.5

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -1,13 +1,13 @@
 # https://canonical-charm-refresh.readthedocs-hosted.com/latest/refresh-versions-toml/
 
 charm_major = 1
-workload = "3.6.4"
+workload = "3.6.5"
 
 [snap]
 name = "charmed-etcd"
 
 [snap.revisions]
 # amd64
-x86_64 = "21"
+x86_64 = "23"
 # arm64
-aarch64 = "22"
+aarch64 = "24"

--- a/tests/integration/ha/upgrades/literals.py
+++ b/tests/integration/ha/upgrades/literals.py
@@ -6,6 +6,6 @@
 
 NUM_UNITS = 3
 CHARM_CHANNEL = "3.6/edge"
-CHARM_REVISIONS_TO_DEPLOY = {"x86_64": 94, "aarch64": 95}
-WORKLOAD_VERSION = {"previous": "3.6.2", "target": "3.6.4"}
+CHARM_REVISIONS_TO_DEPLOY = {"x86_64": 102, "aarch64": 103}
+WORKLOAD_VERSION = {"previous": "3.6.4", "target": "3.6.5"}
 CERTIFICATE_EXPIRY_TIME = 250


### PR DESCRIPTION
## Description of issue or feature:
This PR updates etcd to version 3.6.5. Release notes for the upstream release can be found [here](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.6.md#v365-2025-09-19).

https://warthogs.atlassian.net/browse/DPE-8407

## Solution:
- update the snap revisions to deploy in `refresh_versions.toml`
- update the integration test config for upgrades

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [X] Integration tests
