### PR TITLE
[DPE-7836]: Add backend quota backend bytes config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -63,13 +63,15 @@ options:
       Allowed values: "all", "first", "none"
 
   quota-backend-bytes:
-    type: int
+    type: string
+    default: auto
     description: |
       Sets the backend database size limit in bytes for each etcd member. When this limit is exceeded, 
       the cluster raises a NOSPACE alarm and enters a read-only mode, rejecting all write requests. 
       This value should be sized according to the cluster's workload and available RAM. 
+      The value needs to be `auto` or an integer representing the size in bytes.
+      If value is set to 'auto' the formula used is min(100GiB, 0.9*memory, 0.9*data_storage_size) 
       The community-recommended maximum is 8 GiB. 
       A minimum of 100MiB is enforced. 
-      If no value is set the formula used is min(100GiB, 0.9*memory, 0.9*data_storage_size) 
       WARNING: The LXD 'dir' storage driver exposes the host's total disk space to containers, which 
       can cause inaccurate quota calculations. 

--- a/config.yaml
+++ b/config.yaml
@@ -60,15 +60,16 @@ options:
     default: first
     description: |
       Wait for manual confirmation to resume refresh after these units refresh
-
       Allowed values: "all", "first", "none"
 
   quota-backend-bytes:
     type: int
-    default: 8589934592
-    description: Sets the backend database size limit in bytes for each etcd member. When this limit is exceeded, 
+    description: |
+      Sets the backend database size limit in bytes for each etcd member. When this limit is exceeded, 
       the cluster raises a NOSPACE alarm and enters a read-only mode, rejecting all write requests. 
       This value should be sized according to the cluster's workload and available RAM. 
       The community-recommended maximum is 8 GiB. 
-      A minimum of 100MB is enforced.
-      The formula used is min(config_value, 0.9*memory, 0.9*data_storage_size)
+      A minimum of 100MiB is enforced. 
+      If no value is set the formula used is min(100GiB, 0.9*memory, 0.9*data_storage_size) 
+      WARNING: The LXD 'dir' storage driver exposes the host's total disk space to containers, which 
+      can cause inaccurate quota calculations. 

--- a/config.yaml
+++ b/config.yaml
@@ -62,3 +62,13 @@ options:
       Wait for manual confirmation to resume refresh after these units refresh
 
       Allowed values: "all", "first", "none"
+
+  quota-backend-bytes:
+    type: int
+    default: 8589934592
+    description: Sets the backend database size limit in bytes for each etcd member. When this limit is exceeded, 
+      the cluster raises a NOSPACE alarm and enters a read-only mode, rejecting all write requests. 
+      This value should be sized according to the cluster's workload and available RAM. 
+      The community-recommended maximum is 8 GiB. 
+      A minimum of 100MB is enforced.
+      The formula used is min(config_value, 0.9*memory, 0.9*data_storage_size)

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -288,3 +288,12 @@ class WorkloadBase(ABC):
             float: The size of the etcd database file in Bytes.
         """
         pass
+
+    @abstractmethod
+    def is_lxd_cloud(self) -> bool:
+        """Check if the workload is running in an LXD cloud environment.
+
+        Returns:
+            bool: True if running in LXD cloud, False otherwise.
+        """
+        pass

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -263,29 +263,29 @@ class WorkloadBase(ABC):
         return {"hostname": hostname, "private_ip": private_ip, "public_ip": public_ip}
 
     @abstractmethod
-    def memory_size(self) -> float:
+    def memory_size(self) -> int:
         """Get the total memory size of the system in Bytes.
 
         Returns:
-            float: The total memory size in Bytes.
+            int: The total memory size in Bytes.
         """
         pass
 
     @abstractmethod
-    def data_storage_size(self) -> float:
+    def data_storage_size(self) -> int:
         """Get the size of the data storage in Bytes.
 
         Returns:
-            float: The size of the data storage in Bytes.
+            int: The size of the data storage in Bytes.
         """
         pass
 
     @abstractmethod
-    def get_db_file_size(self) -> float:
+    def get_db_file_size(self) -> int:
         """Get the size of the etcd database file in Bytes.
 
         Returns:
-            float: The size of the etcd database file in Bytes.
+            int: The size of the etcd database file in Bytes.
         """
         pass
 

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -261,3 +261,12 @@ class WorkloadBase(ABC):
             raise ValueError("Could not get private IP address of the unit.")
 
         return {"hostname": hostname, "private_ip": private_ip, "public_ip": public_ip}
+
+    @abstractmethod
+    def memory_size(self) -> float:
+        """Get the total memory size of the system in Bytes.
+
+        Returns:
+            float: The total memory size in Bytes.
+        """
+        pass

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -279,3 +279,12 @@ class WorkloadBase(ABC):
             float: The size of the data storage in Bytes.
         """
         pass
+
+    @abstractmethod
+    def get_db_file_size(self) -> float:
+        """Get the size of the etcd database file in Bytes.
+
+        Returns:
+            float: The size of the etcd database file in Bytes.
+        """
+        pass

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -297,3 +297,12 @@ class WorkloadBase(ABC):
             bool: True if running in LXD cloud, False otherwise.
         """
         pass
+
+    @abstractmethod
+    def data_storage_attached(self) -> bool:
+        """Check if the data storage is attached.
+
+        Returns:
+            bool: True if data storage is attached, False otherwise.
+        """
+        pass

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -270,3 +270,12 @@ class WorkloadBase(ABC):
             float: The total memory size in Bytes.
         """
         pass
+
+    @abstractmethod
+    def data_storage_size(self) -> float:
+        """Get the size of the data storage in Bytes.
+
+        Returns:
+            float: The size of the data storage in Bytes.
+        """
+        pass

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -302,6 +302,7 @@ class EtcdEvents(Object):
         if (
             self.charm.config_manager.are_tuning_parameters_valid()
             and self.charm.config_manager.requires_restart()
+            and self.charm.state.unit_server.is_started
         ):
             # apply config and initiate restart
             self.charm.rolling_restart()

--- a/src/literals.py
+++ b/src/literals.py
@@ -53,6 +53,8 @@ TLS_CLIENT_PRIVATE_KEY_CONFIG = "tls-client-private-key"
 S3_RELATION_NAME = "s3-credentials"
 AZURE_RELATION_NAME = "azure-credentials"
 
+MIN_QUOTA_BACKEND_BYTES = 100 * 1024**2  # 100MB in bytes
+
 
 @dataclass
 class StatusLevel:
@@ -113,3 +115,4 @@ class TuningOptions(StrEnum):
 
     ELECTION_TIMEOUT_CONFIG = "election-timeout"
     HEARTBEAT_INTERVAL_CONFIG = "heartbeat-interval"
+    QUOTA_BACKEND_BYTES_CONFIG = "quota-backend-bytes"

--- a/src/literals.py
+++ b/src/literals.py
@@ -53,7 +53,8 @@ TLS_CLIENT_PRIVATE_KEY_CONFIG = "tls-client-private-key"
 S3_RELATION_NAME = "s3-credentials"
 AZURE_RELATION_NAME = "azure-credentials"
 
-MIN_QUOTA_BACKEND_BYTES = 100 * 1024**2  # 100MB in bytes
+MIN_QUOTA_BACKEND_BYTES = 100 * 1024**2  # 100MiB in bytes
+MAX_QUOTA_BACKEND_BYTES = 100 * 1024**3  # 100GiB in bytes
 
 
 @dataclass

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -18,6 +18,7 @@ from core.workload import WorkloadBase
 from literals import (
     CONFIG_FILE,
     DATABASE_DIR,
+    MAX_QUOTA_BACKEND_BYTES,
     METRICS_PORT,
     MIN_QUOTA_BACKEND_BYTES,
     RestoreStep,
@@ -191,12 +192,10 @@ class ConfigManager(ManagerStatusProtocol):
                 )
                 return False
 
-        if quota_backend_bytes := self.config.get(TuningOptions.QUOTA_BACKEND_BYTES_CONFIG.value):
-            # if less than 100MB
-            if (
-                type(quota_backend_bytes) is not int
-                or quota_backend_bytes < MIN_QUOTA_BACKEND_BYTES
-            ):
+        if quota_backend_bytes := self._get_tuning_config_value(
+            TuningOptions.QUOTA_BACKEND_BYTES_CONFIG
+        ):
+            if quota_backend_bytes < MIN_QUOTA_BACKEND_BYTES:
                 logger.error(
                     f"Quota backend bytes too low: {quota_backend_bytes}. Minimum is {MIN_QUOTA_BACKEND_BYTES}."
                 )
@@ -257,11 +256,13 @@ class ConfigManager(ManagerStatusProtocol):
         Returns:
             int: The value of the tuning option.
         """
-        if option == TuningOptions.QUOTA_BACKEND_BYTES_CONFIG:
+        if option == TuningOptions.QUOTA_BACKEND_BYTES_CONFIG and not self.config.get(
+            TuningOptions.QUOTA_BACKEND_BYTES_CONFIG.value
+        ):
             memory_max = int(self.workload.memory_size() * 0.9)
             storage_max = int(self.workload.data_storage_size() * 0.9)
             value = min(
-                self.config.get(option.value),
+                MAX_QUOTA_BACKEND_BYTES,
                 memory_max,
                 storage_max,
             )

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -19,6 +19,7 @@ from literals import (
     CONFIG_FILE,
     DATABASE_DIR,
     METRICS_PORT,
+    MIN_QUOTA_BACKEND_BYTES,
     RestoreStep,
     TLSState,
     TuningOptions,
@@ -93,7 +94,8 @@ class ConfigManager(ManagerStatusProtocol):
         if self.are_tuning_parameters_valid():
             for option in TuningOptions:
                 # take over the config value set by users
-                config_properties[option.value] = self.config.get(option.value)
+                value = self._get_tuning_config_value(option)
+                config_properties[option.value] = value
 
         if self.state.unit_server.tls_client_state in [TLSState.TO_TLS, TLSState.TLS]:
             # replace http with https in listen-client-urls and advertise-client-urls
@@ -168,10 +170,30 @@ class ConfigManager(ManagerStatusProtocol):
         """
         if heartbeat_interval := self.config.get(TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value):
             if heartbeat_interval < 10 or heartbeat_interval > 5000:
+                logger.error(
+                    f"Heartbeat interval {heartbeat_interval} is invalid. "
+                    "It must be between 10ms and 5000ms."
+                )
                 return False
 
         if election_timeout := self.config.get(TuningOptions.ELECTION_TIMEOUT_CONFIG.value):
             if election_timeout < heartbeat_interval * 10 or election_timeout > 50000:
+                logger.error(
+                    f"Election timeout {election_timeout} is invalid. "
+                    f"It must be at least 10x the heartbeat interval ({heartbeat_interval}) "
+                    "and no more than 50000ms."
+                )
+                return False
+
+        if quota_backend_bytes := self.config.get(TuningOptions.QUOTA_BACKEND_BYTES_CONFIG.value):
+            # if less than 100MB
+            if (
+                type(quota_backend_bytes) is not int
+                or quota_backend_bytes < MIN_QUOTA_BACKEND_BYTES
+            ):
+                logger.error(
+                    f"Quota backend bytes too low: {quota_backend_bytes}. Minimum is {MIN_QUOTA_BACKEND_BYTES}."
+                )
                 return False
 
         return True
@@ -185,7 +207,7 @@ class ConfigManager(ManagerStatusProtocol):
             return False
 
         for option in TuningOptions:
-            if self.config.get(option.value) != current_config_values[option.value]:
+            if self._get_tuning_config_value(option) != current_config_values[option.value]:
                 logger.info(f"Config change to {option.value} requires restart")
                 return True
 
@@ -212,3 +234,22 @@ class ConfigManager(ManagerStatusProtocol):
         )
 
         return cluster_endpoints
+
+    def _get_tuning_config_value(self, option: TuningOptions) -> int:
+        """Get the value of a tuning configuration option.
+
+        Args:
+            option (TuningOptions): The tuning option to get the value for.
+
+        Returns:
+            int: The value of the tuning option.
+        """
+        if option == TuningOptions.QUOTA_BACKEND_BYTES_CONFIG and (
+            value := min(
+                self.config.get(option.value),
+                int(self.workload.memory_size() * 0.9),
+            )
+        ) != self.config.get(option.value):
+            logger.warning(f"Quota backend bytes reduced to {value} to fit available memory.")
+            return value
+        return self.config.get(option.value)

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -192,30 +192,35 @@ class ConfigManager(ManagerStatusProtocol):
                 )
                 return False
 
-        if quota_backend_bytes := self._get_tuning_config_value(
-            TuningOptions.QUOTA_BACKEND_BYTES_CONFIG
-        ):
-            if quota_backend_bytes < MIN_QUOTA_BACKEND_BYTES:
-                logger.error(
-                    "Quota backend bytes too low: %s. Minimum is %s.",
-                    quota_backend_bytes,
-                    MIN_QUOTA_BACKEND_BYTES,
-                )
-                return False
+        # avoid recalculating quota_backend_bytes multiple times
+        quota_backend_bytes = self.quota_backend_bytes
+        if quota_backend_bytes is None:
+            logger.error(
+                "Quota backend bytes value '%s' is invalid. It must be an integer or 'auto'.",
+                self.config.get(TuningOptions.QUOTA_BACKEND_BYTES_CONFIG.value),
+            )
+            return False
+        if quota_backend_bytes < MIN_QUOTA_BACKEND_BYTES:
+            logger.error(
+                "Quota backend bytes too low: %s. Minimum is %s.",
+                quota_backend_bytes,
+                MIN_QUOTA_BACKEND_BYTES,
+            )
+            return False
 
-            if quota_backend_bytes < (db_file_size := self.workload.get_db_file_size()):
-                logger.error(
-                    "Quota backend bytes %s is less than current DB file size %s",
-                    quota_backend_bytes,
-                    db_file_size,
-                )
-                return False
+        if quota_backend_bytes < (db_file_size := self.workload.get_db_file_size()):
+            logger.error(
+                "Quota backend bytes %s is less than current DB file size %s",
+                quota_backend_bytes,
+                db_file_size,
+            )
+            return False
 
-            if self.workload.is_lxd_cloud():
-                logger.warning(
-                    "The deployment's quota-backend-bytes value is %s - consider applying constraints and/or setting the right lxd storage driver",
-                    quota_backend_bytes,
-                )
+        if self.workload.is_lxd_cloud():
+            logger.warning(
+                "The deployment's quota-backend-bytes value is %s - consider applying constraints and/or setting the right lxd storage driver",
+                quota_backend_bytes,
+            )
 
         return True
 
@@ -265,9 +270,19 @@ class ConfigManager(ManagerStatusProtocol):
         Returns:
             int: The value of the tuning option.
         """
-        if option == TuningOptions.QUOTA_BACKEND_BYTES_CONFIG and not self.config.get(
-            TuningOptions.QUOTA_BACKEND_BYTES_CONFIG.value
-        ):
+        if option == TuningOptions.QUOTA_BACKEND_BYTES_CONFIG:
+            return self.quota_backend_bytes
+        return self.config.get(option.value)
+
+    @property
+    def quota_backend_bytes(self) -> int | None:
+        """Get the quota-backend-bytes configuration value.
+
+        Returns:
+            int: The quota-backend-bytes value.
+        """
+        config_value = self.config.get(TuningOptions.QUOTA_BACKEND_BYTES_CONFIG.value)
+        if config_value == "auto":
             memory_max = int(self.workload.memory_size() * 0.9)
             storage_max = int(self.workload.data_storage_size() * 0.9)
             value = min(
@@ -280,4 +295,8 @@ class ConfigManager(ManagerStatusProtocol):
             if value == storage_max:
                 logger.warning(f"Quota backend bytes reduced to {value} to fit available storage.")
             return value
-        return self.config.get(option.value)
+
+        try:
+            return int(str(config_value))
+        except (TypeError, ValueError):
+            return None

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -178,17 +178,17 @@ class ConfigManager(ManagerStatusProtocol):
         if heartbeat_interval := self.config.get(TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value):
             if heartbeat_interval < 10 or heartbeat_interval > 5000:
                 logger.error(
-                    f"Heartbeat interval {heartbeat_interval} is invalid. "
-                    "It must be between 10ms and 5000ms."
+                    "Heartbeat interval %s is invalid. It must be between 10ms and 5000ms.",
+                    heartbeat_interval,
                 )
                 return False
 
         if election_timeout := self.config.get(TuningOptions.ELECTION_TIMEOUT_CONFIG.value):
             if election_timeout < heartbeat_interval * 10 or election_timeout > 50000:
                 logger.error(
-                    f"Election timeout {election_timeout} is invalid. "
-                    f"It must be at least 10x the heartbeat interval ({heartbeat_interval}) "
-                    "and no more than 50000ms."
+                    "Election timeout %s is invalid. It must be at least 10x the heartbeat interval (%s) and no more than 50000ms.",
+                    election_timeout,
+                    heartbeat_interval,
                 )
                 return False
 
@@ -197,16 +197,25 @@ class ConfigManager(ManagerStatusProtocol):
         ):
             if quota_backend_bytes < MIN_QUOTA_BACKEND_BYTES:
                 logger.error(
-                    f"Quota backend bytes too low: {quota_backend_bytes}. Minimum is {MIN_QUOTA_BACKEND_BYTES}."
+                    "Quota backend bytes too low: %s. Minimum is %s.",
+                    quota_backend_bytes,
+                    MIN_QUOTA_BACKEND_BYTES,
                 )
                 return False
 
             if quota_backend_bytes < (db_file_size := self.workload.get_db_file_size()):
                 logger.error(
-                    f"Quota backend bytes {quota_backend_bytes} is less than current DB file size "
-                    f"{db_file_size}."
+                    "Quota backend bytes %s is less than current DB file size %s",
+                    quota_backend_bytes,
+                    db_file_size,
                 )
                 return False
+
+            if self.workload.is_lxd_cloud():
+                logger.warning(
+                    "The deployment's quota-backend-bytes value is %s - consider applying constraints and/or setting the right lxd storage driver",
+                    quota_backend_bytes,
+                )
 
         return True
 

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -284,7 +284,10 @@ class ConfigManager(ManagerStatusProtocol):
         config_value = self.config.get(TuningOptions.QUOTA_BACKEND_BYTES_CONFIG.value)
         if config_value == "auto":
             memory_max = int(self.workload.memory_size() * 0.9)
-            storage_max = int(self.workload.data_storage_size() * 0.9)
+            if self.workload.data_storage_attached():
+                storage_max = int(self.workload.data_storage_size() * 0.9)
+            else:
+                storage_max = MAX_QUOTA_BACKEND_BYTES
             value = min(
                 MAX_QUOTA_BACKEND_BYTES,
                 memory_max,

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -244,12 +244,17 @@ class ConfigManager(ManagerStatusProtocol):
         Returns:
             int: The value of the tuning option.
         """
-        if option == TuningOptions.QUOTA_BACKEND_BYTES_CONFIG and (
-            value := min(
+        if option == TuningOptions.QUOTA_BACKEND_BYTES_CONFIG:
+            memory_max = int(self.workload.memory_size() * 0.9)
+            storage_max = int(self.workload.data_storage_size() * 0.9)
+            value = min(
                 self.config.get(option.value),
-                int(self.workload.memory_size() * 0.9),
+                memory_max,
+                storage_max,
             )
-        ) != self.config.get(option.value):
-            logger.warning(f"Quota backend bytes reduced to {value} to fit available memory.")
+            if value == memory_max:
+                logger.warning(f"Quota backend bytes reduced to {value} to fit available memory.")
+            if value == storage_max:
+                logger.warning(f"Quota backend bytes reduced to {value} to fit available storage.")
             return value
         return self.config.get(option.value)

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -196,6 +196,13 @@ class ConfigManager(ManagerStatusProtocol):
                 )
                 return False
 
+            if quota_backend_bytes < (db_file_size := self.workload.get_db_file_size()):
+                logger.error(
+                    f"Quota backend bytes {quota_backend_bytes} is less than current DB file size "
+                    f"{db_file_size}."
+                )
+                return False
+
         return True
 
     def requires_restart(self) -> bool:

--- a/src/statuses.py
+++ b/src/statuses.py
@@ -90,7 +90,7 @@ class ConfigStatuses(Enum):
 
     TUNING_CONFIG_INVALID = StatusObject(
         status="blocked",
-        message="Invalid values set for the config options: 'election-timeout', 'heartbeat-interval'",
+        message="Invalid values set for the config options: 'election-timeout', 'heartbeat-interval', or 'quota-backend-bytes'",
     )
 
 

--- a/src/workload.py
+++ b/src/workload.py
@@ -241,4 +241,14 @@ class EtcdWorkload(WorkloadBase):
             bool: True if running in LXD cloud, False otherwise.
         """
         # LXD sets up a Unix socket at /dev/lxd/sock inside the container
+        # https://documentation.ubuntu.com/lxd/latest/dev-lxd/#implementation-details
         return Path("/dev/lxd/sock").exists()
+
+    @override
+    def data_storage_attached(self) -> bool:
+        """Check if the data storage is attached.
+
+        Returns:
+            bool: True if data storage is attached, False otherwise.
+        """
+        return Path(SNAP_DATA_PATH).exists()

--- a/src/workload.py
+++ b/src/workload.py
@@ -232,3 +232,13 @@ class EtcdWorkload(WorkloadBase):
         if db_file_path.exists() and db_file_path.is_file():
             return db_file_path.stat().st_size
         return 0
+
+    @override
+    def is_lxd_cloud(self) -> bool:
+        """Check if the workload is running in an LXD cloud environment.
+
+        Returns:
+            bool: True if running in LXD cloud, False otherwise.
+        """
+        # LXD sets up a Unix socket at /dev/lxd/sock inside the container
+        return Path("/dev/lxd/sock").exists()

--- a/src/workload.py
+++ b/src/workload.py
@@ -203,7 +203,7 @@ class EtcdWorkload(WorkloadBase):
                 2a130b7e1fcdd83633c4aa70998c314d7c38b476/fs/proc/meminfo.c#L31
 
         Returns:
-            float: The total memory size in Bytes.
+            int: The total memory size in Bytes.
         """
         with open("/proc/meminfo") as f:
             meminfo = f.read().split("\n")
@@ -213,11 +213,11 @@ class EtcdWorkload(WorkloadBase):
         return int(memory_sizes["MemTotal"] * 1024)  # convert from kB to Bytes
 
     @override
-    def data_storage_size(self) -> float:
+    def data_storage_size(self) -> int:
         """Get the size of the data storage in Bytes.
 
         Returns:
-            float: The size of the data storage in Bytes.
+            int: The size of the data storage in Bytes.
         """
         return shutil.disk_usage(SNAP_DATA_PATH).total
 

--- a/src/workload.py
+++ b/src/workload.py
@@ -23,7 +23,7 @@ from typing_extensions import override
 
 from common.exceptions import EtcdServiceError
 from core.workload import WorkloadBase
-from literals import SNAP_DATA_PATH, SNAP_NAME, SNAP_SERVICE, VERSIONS_FILE
+from literals import DATABASE_DIR, SNAP_DATA_PATH, SNAP_NAME, SNAP_SERVICE, VERSIONS_FILE
 
 logger = logging.getLogger(__name__)
 
@@ -220,3 +220,15 @@ class EtcdWorkload(WorkloadBase):
             float: The size of the data storage in Bytes.
         """
         return shutil.disk_usage(SNAP_DATA_PATH).total
+
+    @override
+    def get_db_file_size(self) -> int:
+        """Get the size of the etcd database file in bytes.
+
+        Returns:
+            int: Size of the etcd database file in bytes.
+        """
+        db_file_path = Path(DATABASE_DIR) / "snap" / "db"
+        if db_file_path.exists() and db_file_path.is_file():
+            return db_file_path.stat().st_size
+        return 0

--- a/src/workload.py
+++ b/src/workload.py
@@ -191,3 +191,22 @@ class EtcdWorkload(WorkloadBase):
     def snap_revision(self) -> str:
         """Get the snap revision that is currently installed."""
         return self.etcd.revision
+
+    @override
+    def memory_size(self) -> int:
+        """Get the total memory size of the system in Bytes.
+
+        Read the /proc/meminfo file and return the values.
+        According to the kernel source code, the values are always in kB:
+            https://github.com/torvalds/linux/blob/
+                2a130b7e1fcdd83633c4aa70998c314d7c38b476/fs/proc/meminfo.c#L31
+
+        Returns:
+            float: The total memory size in Bytes.
+        """
+        with open("/proc/meminfo") as f:
+            meminfo = f.read().split("\n")
+            meminfo = [line.split() for line in meminfo if line.strip()]
+
+        memory_sizes = {line[0][:-1]: float(line[1]) for line in meminfo}
+        return int(memory_sizes["MemTotal"] * 1024)  # convert from kB to Bytes

--- a/src/workload.py
+++ b/src/workload.py
@@ -5,6 +5,7 @@
 """Implementation of WorkloadBase for running on VMs."""
 
 import logging
+import shutil
 import subprocess
 from os.path import exists
 from pathlib import Path
@@ -22,7 +23,7 @@ from typing_extensions import override
 
 from common.exceptions import EtcdServiceError
 from core.workload import WorkloadBase
-from literals import SNAP_NAME, SNAP_SERVICE, VERSIONS_FILE
+from literals import SNAP_DATA_PATH, SNAP_NAME, SNAP_SERVICE, VERSIONS_FILE
 
 logger = logging.getLogger(__name__)
 
@@ -210,3 +211,12 @@ class EtcdWorkload(WorkloadBase):
 
         memory_sizes = {line[0][:-1]: float(line[1]) for line in meminfo}
         return int(memory_sizes["MemTotal"] * 1024)  # convert from kB to Bytes
+
+    @override
+    def data_storage_size(self) -> float:
+        """Get the size of the data storage in Bytes.
+
+        Returns:
+            float: The size of the data storage in Bytes.
+        """
+        return shutil.disk_usage(SNAP_DATA_PATH).total

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -125,6 +125,14 @@ def mock_get_host_mapping(mocker):
 
 
 @pytest.fixture(autouse=True)  # autouse=True makes this fixture run for all tests in the module
+def mock_data_storage_size(mocker):
+    mocker.patch(
+        "workload.EtcdWorkload.data_storage_size",
+        return_value=10 * 1024**3,  # 10 GB in Bytes
+    )
+
+
+@pytest.fixture(autouse=True)
 def mock_is_cluster_failed(mocker):
     mocker.patch(
         "managers.cluster.EtcdClient.get_metric",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -612,7 +612,11 @@ def test_config_changed():
         leader=True,
     )
 
-    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
@@ -631,7 +635,8 @@ def test_set_config_options():
     relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
-        local_unit_data={"private_ip": "my_ip"},
+        local_unit_data={"private_ip": "my_ip", "state": "started"},
+        local_app_data={"cluster_state": "existing", "authentication": "enabled"},
     )
     ctx = testing.Context(EtcdOperatorCharm)
 
@@ -645,7 +650,11 @@ def test_set_config_options():
         leader=True,
     )
 
-    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
@@ -664,7 +673,11 @@ def test_set_config_options():
         leader=True,
     )
 
-    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
@@ -683,7 +696,11 @@ def test_set_config_options():
         leader=True,
     )
 
-    current_config_file = {"election-timeout": 5000, "heartbeat-interval": 500}
+    current_config_file = {
+        "election-timeout": 5000,
+        "heartbeat-interval": 500,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
@@ -702,7 +719,11 @@ def test_set_config_options():
         leader=True,
     )
 
-    current_config_file = {"election-timeout": 5000, "heartbeat-interval": 500}
+    current_config_file = {
+        "election-timeout": 5000,
+        "heartbeat-interval": 500,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
@@ -725,7 +746,11 @@ def test_set_config_options():
         leader=True,
     )
 
-    current_config_file = {"election-timeout": 5000, "heartbeat-interval": 500}
+    current_config_file = {
+        "election-timeout": 5000,
+        "heartbeat-interval": 500,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -691,6 +691,7 @@ def test_set_config_options():
         config={
             TuningOptions.ELECTION_TIMEOUT_CONFIG.value: 5000,
             TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value: 500,
+            TuningOptions.QUOTA_BACKEND_BYTES_CONFIG.value: "8589934592",
         },
         relations={relation},
         leader=True,

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -807,7 +807,11 @@ def test_set_tls_private_key():
         {"private-key": private_key},
         label=TLS_PEER_PRIVATE_KEY_CONFIG,
     )
-    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch(
@@ -976,7 +980,11 @@ def test_set_tls_private_key():
         {"private-key": private_key},
         label=TLS_CLIENT_PRIVATE_KEY_CONFIG,
     )
-    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch(
@@ -1068,7 +1076,11 @@ def test_set_tls_private_key():
         config={TLS_CLIENT_PRIVATE_KEY_CONFIG: secret.id},
         secrets={secret},
     )
-    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch(
@@ -1508,7 +1520,11 @@ def test_set_extra_sans_config_option():
             "tls_client_state": TLSState.TLS.value,
         },
     )
-    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+        "quota-backend-bytes": 8589934592,
+    }
 
     # happy path
     ctx = testing.Context(EtcdOperatorCharm)
@@ -1672,7 +1688,11 @@ def test_set_domain_config_option():
             "tls_client_state": TLSState.TLS.value,
         },
     )
-    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+        "quota-backend-bytes": 8589934592,
+    }
 
     # happy path
     ctx = testing.Context(EtcdOperatorCharm)


### PR DESCRIPTION
## Description of issue or feature:
[Spec](https://docs.google.com/document/d/1oTPbR65NSQxWvG5Fjkwo18bGCkArYNvmSS1mZBBsZ1A/edit?tab=t.0)

This pull request introduces a new configuration option for etcd, `quota-backend-bytes`, which sets a limit on the backend database size for each etcd member. The implementation ensures this value is validated, respects system memory constraints, and is enforced with a minimum threshold. 
## Solution:

**Etcd storage quota configuration and validation:**

* Added a new `quota-backend-bytes` option to `config.yaml` for specifying the backend database size limit, with documentation and default value set to 8 GiB.
* Introduced `MIN_QUOTA_BACKEND_BYTES` constant (100MB) and added `QUOTA_BACKEND_BYTES_CONFIG` to `TuningOptions` for consistent referencing. [[1]](diffhunk://#diff-959ba637043ab4ac88c6f9f9109022f78a7df1b9a2ab3a0407bff4f124c2db64R56-R57) [[2]](diffhunk://#diff-959ba637043ab4ac88c6f9f9109022f78a7df1b9a2ab3a0407bff4f124c2db64R118)
* Updated config validation in `ConfigManager` to check that `quota-backend-bytes` is an integer and not less than 100MB and that the database file size does not exceed this limit. [[1]](diffhunk://#diff-a24e7472936c291b5c95f9c56ccc25cccef3adf4c4cbd1de135e2dde31ae592cR188-R197) [[2]](diffhunk://#diff-a24e7472936c291b5c95f9c56ccc25cccef3adf4c4cbd1de135e2dde31ae592cR199-R204)
* Implemented `_get_tuning_config_value` to dynamically enforce that `quota-backend-bytes` does not exceed 90% of available memory and 90% of data storage size. [[1]](diffhunk://#diff-a24e7472936c291b5c95f9c56ccc25cccef3adf4c4cbd1de135e2dde31ae592cR245-R267)

**Workload introspection:**

* Added an abstract `memory_size()` method to `Workload` and implemented it in `EtcdWorkload` to read system memory from `/proc/meminfo`. [[1]](diffhunk://#diff-4d1ed63ca48f694e77680b1434284f1d8d896cffe1842fb6b8b8e616c192b696R264-R272) [[2]](diffhunk://#diff-38281d02638d07eddd511b40cb2aa3cc1877e72f7ce4caacfe2a2a0c34cfd75fR196-R213)
* Added an abstract `get_db_file_size()` method to `Workload` and implemented it in `EtcdWorkload` to retrieve the size of the etcd database file. [[1]](diffhunk://#diff-4d1ed63ca48f694e77680b1434284f1d8d896cffe1842fb6b8b8e616c192b696R283-R290) [[2]](diffhunk://#diff-38281d02638d07eddd511b40cb2aa3cc1877e72f7ce4caacfe2a2a0c34cfd75fR224-R234)

**Config management and status reporting:**

* Updated config property generation and restart logic to use the new value resolution method for tuning options. [[1]](diffhunk://#diff-a24e7472936c291b5c95f9c56ccc25cccef3adf4c4cbd1de135e2dde31ae592cL96-R98)
* Improved status messaging to include `quota-backend-bytes` in error reports for invalid tuning configs.

**Event handling:**

* Ensured configuration changes only trigger restarts if the unit server is started.
## How was this change tested?
- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
