### PR TITLE
[DPE-8487] Improve error handling

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -14,7 +14,6 @@ from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
 from data_platform_helpers.advanced_statuses.handler import StatusHandler
 
-from common.exceptions import HealthCheckFailedError
 from core.cluster import ClusterState
 from events.backup import BackupEvents
 from events.etcd import EtcdEvents
@@ -35,6 +34,7 @@ from managers.config import ConfigManager
 from managers.external_clients import ExternalClientsManager
 from managers.tls import TLSManager
 from managers.upgrades import UpgradesManager
+from statuses import ClusterStatuses
 from workload import EtcdWorkload
 
 logger = logging.getLogger(__name__)
@@ -144,11 +144,22 @@ class EtcdOperatorCharm(ops.CharmBase):
     def _restart(self, _) -> None:
         """Restart callback for the rolling ips lib."""
         logger.debug("executing normal rolling restart")
-        logger.debug(f"relation data for unit: {self.state.unit_server.relation_data}")
 
         self.config_manager.set_config_properties()
         if not self.cluster_manager.restart_member():
-            raise HealthCheckFailedError("Failed to check health of the member after restart")
+            self.status.set_running_status(
+                ClusterStatuses.RESTART_FAILED.value,
+                scope="unit",
+                component_name=self.cluster_manager.name,
+                statuses_state=self.state.statuses,
+            )
+            return
+
+        self.state.statuses.delete(
+            ClusterStatuses.RESTART_FAILED.value,
+            scope="unit",
+            component=self.cluster_manager.name,
+        )
 
     def rolling_restart(self, callback_override: str = "_restart") -> None:
         """Initiate a rolling restart."""
@@ -179,9 +190,21 @@ class EtcdOperatorCharm(ops.CharmBase):
         if not self.cluster_manager.restart_member():
             try:
                 self.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
-                raise HealthCheckFailedError("Failed to check health of the member after restart")
+                self.status.set_running_status(
+                    ClusterStatuses.RESTART_FAILED.value,
+                    scope="unit",
+                    component_name=self.cluster_manager.name,
+                    statuses_state=self.state.statuses,
+                )
+                return
             except CalledProcessError:
                 logger.warning("Health check failed, TLS client certificates expired")
+
+        self.state.statuses.delete(
+            ClusterStatuses.RESTART_FAILED.value,
+            scope="unit",
+            component=self.cluster_manager.name,
+        )
 
     def _restart_enable_peer_tls(self, _) -> None:
         """Enable peer TLS."""
@@ -208,9 +231,21 @@ class EtcdOperatorCharm(ops.CharmBase):
         if not self.cluster_manager.restart_member(move_leader=False):
             try:
                 self.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
-                raise HealthCheckFailedError("Failed to check health of the member after restart")
+                self.status.set_running_status(
+                    ClusterStatuses.RESTART_FAILED.value,
+                    scope="unit",
+                    component_name=self.cluster_manager.name,
+                    statuses_state=self.state.statuses,
+                )
+                return
             except CalledProcessError:
                 logger.warning("Health check failed, TLS client certificates expired")
+
+        self.state.statuses.delete(
+            ClusterStatuses.RESTART_FAILED.value,
+            scope="unit",
+            component=self.cluster_manager.name,
+        )
 
     def _restart_disable_client_tls(self, _) -> None:
         """Disable client TLS."""
@@ -237,9 +272,21 @@ class EtcdOperatorCharm(ops.CharmBase):
         if not self.cluster_manager.restart_member(move_leader=False):
             try:
                 self.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
-                raise HealthCheckFailedError("Failed to check health of the member after restart")
+                self.status.set_running_status(
+                    ClusterStatuses.RESTART_FAILED.value,
+                    scope="unit",
+                    component_name=self.cluster_manager.name,
+                    statuses_state=self.state.statuses,
+                )
+                return
             except CalledProcessError:
                 logger.warning("Health check failed, TLS client certificates expired")
+
+        self.state.statuses.delete(
+            ClusterStatuses.RESTART_FAILED.value,
+            scope="unit",
+            component=self.cluster_manager.name,
+        )
 
     def _restart_disable_peer_tls(self, _) -> None:
         """Disable peer TLS."""
@@ -270,9 +317,21 @@ class EtcdOperatorCharm(ops.CharmBase):
         if not self.cluster_manager.restart_member(move_leader=False):
             try:
                 self.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
-                raise HealthCheckFailedError("Failed to check health of the member after restart")
+                self.status.set_running_status(
+                    ClusterStatuses.RESTART_FAILED.value,
+                    scope="unit",
+                    component_name=self.cluster_manager.name,
+                    statuses_state=self.state.statuses,
+                )
+                return
             except CalledProcessError:
                 logger.warning("Health check failed, TLS client certificates expired")
+
+        self.state.statuses.delete(
+            ClusterStatuses.RESTART_FAILED.value,
+            scope="unit",
+            component=self.cluster_manager.name,
+        )
 
     def _restart_ca_rotation(self, _) -> None:
         """Restart callback for CA rotation."""
@@ -285,9 +344,21 @@ class EtcdOperatorCharm(ops.CharmBase):
         if not self.cluster_manager.restart_member():
             try:
                 self.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
-                raise HealthCheckFailedError("Failed to check health of the member after restart")
+                self.status.set_running_status(
+                    ClusterStatuses.RESTART_FAILED.value,
+                    scope="unit",
+                    component_name=self.cluster_manager.name,
+                    statuses_state=self.state.statuses,
+                )
+                return
             except CalledProcessError:
                 logger.warning("Health check failed, TLS client certificates expired")
+
+        self.state.statuses.delete(
+            ClusterStatuses.RESTART_FAILED.value,
+            scope="unit",
+            component=self.cluster_manager.name,
+        )
 
         if self.state.unit_server.tls_peer_ca_rotation_state == TLSCARotationState.NEW_CA_DETECTED:
             self.tls_manager.set_ca_rotation_state(TLSType.PEER, TLSCARotationState.NEW_CA_ADDED)
@@ -319,9 +390,21 @@ class EtcdOperatorCharm(ops.CharmBase):
         if not self.cluster_manager.restart_member():
             try:
                 self.tls_manager.check_certificate_validity(tls_type=TLSType.CLIENT)
-                raise HealthCheckFailedError("Failed to check health of the member after restart")
+                self.status.set_running_status(
+                    ClusterStatuses.RESTART_FAILED.value,
+                    scope="unit",
+                    component_name=self.cluster_manager.name,
+                    statuses_state=self.state.statuses,
+                )
+                return
             except CalledProcessError:
                 logger.warning("Health check failed, TLS client certificates expired")
+
+        self.state.statuses.delete(
+            ClusterStatuses.RESTART_FAILED.value,
+            scope="unit",
+            component=self.cluster_manager.name,
+        )
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/common/certificates.py
+++ b/src/common/certificates.py
@@ -34,8 +34,13 @@ def is_leaf_certificate_valid(mtls_cert: str) -> bool:
     Returns:
         (bool): True if the certificate is not a CA.
     """
-    leaf_cert = leaf_certificate(mtls_cert)
-    certificate = x509.load_pem_x509_certificate(data=leaf_cert.encode())
+    try:
+        leaf_cert = leaf_certificate(mtls_cert)
+        certificate = x509.load_pem_x509_certificate(data=leaf_cert.encode())
+    except ValueError as e:
+        logger.error(e)
+        return False
+
     # check if the certificate is a CA
     try:
         basic_constraints = certificate.extensions.get_extension_for_class(
@@ -43,6 +48,7 @@ def is_leaf_certificate_valid(mtls_cert: str) -> bool:
         ).value
     except x509.ExtensionNotFound:
         return False
+
     # check if the certificate can sign other certificates
     try:
         key_usage = certificate.extensions.get_extension_for_class(x509.KeyUsage).value

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -220,9 +220,14 @@ class BackupEvents(Object):
             event.fail(error)
             return
 
-        backup_list = self.charm.backup_manager.list_backups()
-        logger.debug(f"backup list: {backup_list}")
+        try:
+            backup_list = self.charm.backup_manager.list_backups()
+        except EtcdBackupError as e:
+            event.set_results({"error": e})
+            event.fail("Listing backups failed. Check the error logs for more details.")
+            return
 
+        logger.debug(f"backup list: {backup_list}")
         event.set_results({"backups": self.charm.backup_manager.format_backup_list(backup_list)})
 
     def _on_restore_action(self, event: ActionEvent) -> None:
@@ -236,8 +241,13 @@ class BackupEvents(Object):
             event.fail("Must provide backup-id to restore.")
             return
 
-        if backup_id_to_restore not in self.charm.backup_manager.list_backups():
-            event.fail("Backup ID not found.")
+        try:
+            if backup_id_to_restore not in self.charm.backup_manager.list_backups():
+                event.fail("Backup ID not found.")
+                return
+        except EtcdBackupError as e:
+            event.set_results({"error": e})
+            event.fail("Restoring a backup failed. Check the error logs for more details.")
             return
 
         event.log(f"Initiating restore process for backup-id {backup_id_to_restore}")

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -289,6 +289,12 @@ class EtcdEvents(Object):
                     component_name=self.charm.cluster_manager.name,
                     statuses_state=self.charm.state.statuses,
                 )
+            else:
+                self.charm.state.statuses.delete(
+                    ClusterStatuses.RESTART_FAILED.value,
+                    scope="unit",
+                    component=self.charm.cluster_manager.name,
+                )
 
             # update cluster configuration
             self.charm.cluster_manager.broadcast_peer_url(self.charm.state.unit_server.peer_url)

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -5,7 +5,7 @@
 """Etcd related and core event handlers."""
 
 import logging
-from subprocess import CalledProcessError
+from subprocess import CalledProcessError, TimeoutExpired
 from typing import TYPE_CHECKING
 
 import ops
@@ -99,7 +99,7 @@ class EtcdEvents(Object):
                 # fix the permissions of the directory if re-attaching existing storage
                 self.charm.workload.exec(["chmod", "-R", "750", path])
                 self.charm.workload.exec(["chown", "-R", f"{SNAP_USER}:{SNAP_GROUP}", path])
-            except CalledProcessError:
+            except (CalledProcessError, TimeoutExpired):
                 # gracefully continue if the path is not there yet
                 logger.warning("Could not adjust directory permissions")
 
@@ -108,15 +108,7 @@ class EtcdEvents(Object):
         try:
             self.charm.workload.install()
         except EtcdServiceError:
-            self.charm.status.set_running_status(
-                EtcdServiceStatuses.SERVICE_NOT_INSTALLED.value,
-                scope="unit",
-                component_name=self.charm.cluster_manager.name,
-                statuses_state=self.charm.state.statuses,
-            )
-            raise EtcdServiceError(
-                "Failed to install the etcd snap. Check the logs for more details."
-            )
+            raise EtcdServiceError("Failed to install the etcd snap")
 
     def _on_start(self, event: ops.StartEvent) -> None:  # noqa: C901
         """Handle start event."""

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -282,35 +282,18 @@ class EtcdEvents(Object):
             # we need to update the client-urls by restarting etcd
             self.charm.config_manager.set_config_properties()
             # after ip change, this member is unavailable, no need to acquire restart lock
-            self.charm.cluster_manager.restart_member(move_leader=False)
-
-        try:
-            # this check will raise a `ValueError` if the member is not healthy
-            if (
-                self.charm.state.unit_server.peer_url
-                not in self.charm.cluster_manager.member.peer_urls
-            ):
-                logger.info("Cluster configuration requires update for peer url")
-                self.charm.cluster_manager.broadcast_peer_url(
-                    self.charm.state.unit_server.peer_url
-                )
-                if self.charm.unit.is_leader():
-                    self.charm.cluster_manager.update_cluster_member_state()
-
-                self.charm.state.statuses.delete(
+            if not self.charm.cluster_manager.restart_member(move_leader=False):
+                self.charm.status.set_running_status(
                     ClusterStatuses.RESTART_FAILED.value,
                     scope="unit",
-                    component=self.charm.cluster_manager.name,
+                    component_name=self.charm.cluster_manager.name,
+                    statuses_state=self.charm.state.statuses,
                 )
-        except ValueError:
-            self.charm.status.set_running_status(
-                ClusterStatuses.RESTART_FAILED.value,
-                scope="unit",
-                component_name=self.charm.cluster_manager.name,
-                statuses_state=self.charm.state.statuses,
-            )
-            event.defer()
-            return
+
+            # update cluster configuration
+            self.charm.cluster_manager.broadcast_peer_url(self.charm.state.unit_server.peer_url)
+            if self.charm.unit.is_leader():
+                self.charm.cluster_manager.update_cluster_member_state()
 
         # we can only handle this now as we must update ip addresses during long-running upgrades
         if self.charm.refresh_in_progress:
@@ -463,7 +446,7 @@ class EtcdEvents(Object):
         if not self.charm.workload.alive() and not self.charm.refresh_in_progress:
             if not self.charm.cluster_manager.restart_member():
                 self.charm.status.set_running_status(
-                    EtcdServiceStatuses.SERVICE_NOT_RUNNING.value,
+                    ClusterStatuses.RESTART_FAILED.value,
                     scope="unit",
                     component_name=self.charm.cluster_manager.name,
                     statuses_state=self.charm.state.statuses,
@@ -471,7 +454,7 @@ class EtcdEvents(Object):
                 return
 
             self.charm.state.statuses.delete(
-                EtcdServiceStatuses.SERVICE_NOT_RUNNING.value,
+                ClusterStatuses.RESTART_FAILED.value,
                 scope="unit",
                 component=self.charm.cluster_manager.name,
             )

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -26,7 +26,6 @@ from common.exceptions import (
     EtcdClusterManagementError,
     EtcdServiceError,
     EtcdUserManagementError,
-    HealthCheckFailedError,
     RaftLeaderNotFoundError,
 )
 from literals import (
@@ -283,13 +282,35 @@ class EtcdEvents(Object):
             # we need to update the client-urls by restarting etcd
             self.charm.config_manager.set_config_properties()
             # after ip change, this member is unavailable, no need to acquire restart lock
-            if not self.charm.cluster_manager.restart_member(move_leader=False):
-                raise HealthCheckFailedError("Failed to check health of the member after restart")
+            self.charm.cluster_manager.restart_member(move_leader=False)
 
-            # update cluster configuration
-            self.charm.cluster_manager.broadcast_peer_url(self.charm.state.unit_server.peer_url)
-            if self.charm.unit.is_leader():
-                self.charm.cluster_manager.update_cluster_member_state()
+        try:
+            # this check will raise a `ValueError` if the member is not healthy
+            if (
+                self.charm.state.unit_server.peer_url
+                not in self.charm.cluster_manager.member.peer_urls
+            ):
+                logger.info("Cluster configuration requires update for peer url")
+                self.charm.cluster_manager.broadcast_peer_url(
+                    self.charm.state.unit_server.peer_url
+                )
+                if self.charm.unit.is_leader():
+                    self.charm.cluster_manager.update_cluster_member_state()
+
+                self.charm.state.statuses.delete(
+                    ClusterStatuses.RESTART_FAILED.value,
+                    scope="unit",
+                    component=self.charm.cluster_manager.name,
+                )
+        except ValueError:
+            self.charm.status.set_running_status(
+                ClusterStatuses.RESTART_FAILED.value,
+                scope="unit",
+                component_name=self.charm.cluster_manager.name,
+                statuses_state=self.charm.state.statuses,
+            )
+            event.defer()
+            return
 
         # we can only handle this now as we must update ip addresses during long-running upgrades
         if self.charm.refresh_in_progress:
@@ -398,7 +419,7 @@ class EtcdEvents(Object):
                 return
 
     def _on_leader_elected(self, event: LeaderElectedEvent) -> None:
-        """Handle all events in the 'cluster' peer relation."""
+        """Handle Juju leadership changes in the peer relation."""
         if not self.charm.state.peer_relation:
             event.defer()
             return
@@ -448,6 +469,12 @@ class EtcdEvents(Object):
                     statuses_state=self.charm.state.statuses,
                 )
                 return
+
+            self.charm.state.statuses.delete(
+                EtcdServiceStatuses.SERVICE_NOT_RUNNING.value,
+                scope="unit",
+                component=self.charm.cluster_manager.name,
+            )
 
         try:
             if self.charm.cluster_manager.is_cluster_failed:

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -404,6 +404,7 @@ class EtcdEvents(Object):
         if not self.charm.state.peer_relation:
             event.defer()
             return
+
         if self.charm.unit.is_leader() and not self.charm.state.cluster.internal_user_credentials:
             if admin_secret_id := self.charm.config.get(INTERNAL_USER_PASSWORD_CONFIG):
                 try:

--- a/src/events/external_clients.py
+++ b/src/events/external_clients.py
@@ -112,16 +112,12 @@ class ExternalClientsEvents(Object):
         )
 
         # validate leaf certificate
-        try:
-            if not is_leaf_certificate_valid(event.mtls_cert):
-                logger.error("Invalid end-entity certificate")
-                # clean the old user if exists
-                if old_common_name:
-                    self._on_relation_broken(event)  # type: ignore
-                    return
+        if not is_leaf_certificate_valid(event.mtls_cert):
+            logger.error("Invalid end-entity certificate")
+            # clean the old user if exists
+            if old_common_name:
+                self._on_relation_broken(event)  # type: ignore
                 return
-        except ValueError as e:
-            logger.error(e)
             return
 
         # if leader then create/update user

--- a/src/events/external_clients.py
+++ b/src/events/external_clients.py
@@ -27,6 +27,7 @@ from literals import (
     TLSState,
     TLSType,
 )
+from statuses import ExternalClientsStatuses
 
 if TYPE_CHECKING:
     from charm import EtcdOperatorCharm
@@ -111,12 +112,16 @@ class ExternalClientsEvents(Object):
         )
 
         # validate leaf certificate
-        if not is_leaf_certificate_valid(event.mtls_cert):
-            logger.error("Invalid end-entity certificate")
-            # clean the old user if exists
-            if old_common_name:
-                self._on_relation_broken(event)  # type: ignore
+        try:
+            if not is_leaf_certificate_valid(event.mtls_cert):
+                logger.error("Invalid end-entity certificate")
+                # clean the old user if exists
+                if old_common_name:
+                    self._on_relation_broken(event)  # type: ignore
+                    return
                 return
+        except ValueError as e:
+            logger.error(e)
             return
 
         # if leader then create/update user
@@ -147,7 +152,18 @@ class ExternalClientsEvents(Object):
 
                 if relation_managed_user is None:
                     logger.info(f"Creating new user: {common_name}")
-                    self.charm.cluster_manager.add_managed_user(common_name, event.prefix)
+                    try:
+                        self.charm.cluster_manager.add_managed_user(common_name, event.prefix)
+                    except EtcdUserManagementError as e:
+                        self.charm.status.set_running_status(
+                            ExternalClientsStatuses.EC_USER_MANAGEMENT_ERROR.value,
+                            scope="app",
+                            component_name=self.charm.external_clients_manager.name,
+                            statuses_state=self.charm.state.statuses,
+                        )
+                        logger.error(e)
+                        return
+
                     self.charm.external_clients_manager.add_managed_user(
                         event.relation.id, common_name
                     )
@@ -165,6 +181,11 @@ class ExternalClientsEvents(Object):
             event.defer()
             return
         self._update_client_truststore()
+        self.charm.state.statuses.delete(
+            ExternalClientsStatuses.EC_USER_MANAGEMENT_ERROR.value,
+            scope="app",
+            component=self.charm.external_clients_manager.name,
+        )
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Handle the relation broken event."""

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -162,7 +162,10 @@ class ClusterManager(ManagerStatusProtocol):
             password=self.admin_password,
             client_url=self.state.unit_server.client_url,
         )
-        client.broadcast_peer_url(self.member.id, peer_urls)
+        try:
+            client.broadcast_peer_url(self.member.id, peer_urls)
+        except ValueError as e:
+            logger.error(e)
 
     def is_healthy(self, cluster: bool = True) -> bool:
         """Run the `endpoint health` command and return True if healthy.

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -374,11 +374,6 @@ class ClusterManager(ManagerStatusProtocol):
             scope=scope, component=self.name, running_status_only=True, running_status_type="async"
         ).root
 
-        if self.state.unit_server.unit.status == BlockedStatus(
-            EtcdServiceStatuses.SERVICE_NOT_INSTALLED.value.message
-        ):
-            return [EtcdServiceStatuses.SERVICE_NOT_INSTALLED.value]
-
         if not self.state.peer_relation:
             status_list.append(EtcdServiceStatuses.SERVICE_INSTALLING.value)
             return status_list

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -11,7 +11,6 @@ from typing import List
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
 from data_platform_helpers.advanced_statuses.types import Scope
-from ops import BlockedStatus
 from requests import RequestException
 from tenacity import Retrying, retry, stop_after_attempt, wait_fixed, wait_random_exponential
 

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -48,7 +48,7 @@ class ConfigManager(ManagerStatusProtocol):
         self.config_file = workload.paths.config_file
 
     @property
-    def config_properties(self) -> str:
+    def config_properties(self) -> str:  # noqa: C901
         """Assemble the config properties.
 
         Returns:
@@ -115,10 +115,14 @@ class ConfigManager(ManagerStatusProtocol):
             config_properties["listen-peer-urls"] = self.state.unit_server.peer_url.replace(
                 "http://", "https://"
             )
-            config_properties["initial-cluster"] = config_properties["initial-cluster"].replace(
-                self.state.unit_server.peer_url,
-                self.state.unit_server.peer_url.replace("http://", "https://"),
-            )
+            # in the `rebuild_cluster` workflow `initial-cluster` is not set
+            if config_properties.get("initial-cluster"):
+                config_properties["initial-cluster"] = config_properties[
+                    "initial-cluster"
+                ].replace(
+                    self.state.unit_server.peer_url,
+                    self.state.unit_server.peer_url.replace("http://", "https://"),
+                )
             config_properties["initial-advertise-peer-urls"] = config_properties[
                 "initial-advertise-peer-urls"
             ].replace("http://", "https://")
@@ -143,9 +147,11 @@ class ConfigManager(ManagerStatusProtocol):
             config_properties["listen-peer-urls"] = self.state.unit_server.peer_url.replace(
                 "https://", "http://"
             )
-            config_properties["initial-cluster"] = config_properties["initial-cluster"].replace(
-                "https://", "http://"
-            )
+            # in the `rebuild_cluster` workflow `initial-cluster` is not set
+            if config_properties.get("initial-cluster"):
+                config_properties["initial-cluster"] = config_properties[
+                    "initial-cluster"
+                ].replace("https://", "http://")
             config_properties["initial-advertise-peer-urls"] = config_properties[
                 "initial-advertise-peer-urls"
             ].replace("https://", "http://")

--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -8,7 +8,7 @@ import json
 import logging
 from pathlib import Path
 
-from charms.tls_certificates_interface.v4.tls_certificates import Certificate
+from charms.tls_certificates_interface.v4.tls_certificates import Certificate, TLSCertificatesError
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
 from data_platform_helpers.advanced_statuses.types import Scope
@@ -94,7 +94,11 @@ class ExternalClientsManager(ManagerStatusProtocol):
         raw_cas = mtls_cert.split("-----END CERTIFICATE-----")
         # add the marker back to the certificate
         cert = raw_cas[0].strip() + "\n-----END CERTIFICATE-----"
-        return Certificate.from_string(cert).common_name
+        try:
+            return Certificate.from_string(cert).common_name
+        except TLSCertificatesError as e:
+            logger.error(e)
+            return ""
 
     def update_client_relations_data(self, etcd_version: str) -> None:
         """Update the ECR data."""

--- a/src/managers/external_clients.py
+++ b/src/managers/external_clients.py
@@ -146,7 +146,9 @@ class ExternalClientsManager(ManagerStatusProtocol):
 
     def get_statuses(self, scope: Scope, recompute: bool = False) -> list[StatusObject]:
         """Compute the component status."""
-        status_list: list[StatusObject] = []
+        status_list: list[StatusObject] = self.state.statuses.get(
+            scope=scope, component=self.name, running_status_only=True, running_status_type="async"
+        ).root
 
         for relation in self.state.etcd_provides.relations:
             mtls_cert = self.state.etcd_provides.fetch_relation_field(relation.id, "mtls-cert")

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -5,6 +5,7 @@
 """Manager for handling TLS related events."""
 
 import base64
+import binascii
 import logging
 import re
 from ipaddress import ip_address
@@ -483,11 +484,16 @@ class TLSManager(ManagerStatusProtocol):
             logger.error(f"Secret {private_key_secret_id} does not contain a private key.")
             return None
 
-        private_key = (
-            secret_content
-            if re.match(r"(-+(BEGIN|END) [A-Z ]+-+)", secret_content)
-            else base64.b64decode(secret_content).decode("utf-8").strip()
-        )
+        try:
+            private_key = (
+                secret_content
+                if re.match(r"(-+(BEGIN|END) [A-Z ]+-+)", secret_content)
+                else base64.b64decode(secret_content).decode("utf-8").strip()
+            )
+        except (UnicodeDecodeError, binascii.Error) as e:
+            logger.error(e)
+            return None
+
         private_key = PrivateKey(raw=private_key)
         if not private_key.is_valid():
             logger.error("Invalid private key format.")

--- a/src/statuses.py
+++ b/src/statuses.py
@@ -160,6 +160,11 @@ class ExternalClientsStatuses(Enum):
     EC_TLS_IS_DISABLED = StatusObject(
         status="blocked", message="Client relation: TLS is disabled. Please enable TLS"
     )
+    EC_USER_MANAGEMENT_ERROR = StatusObject(
+        status="blocked",
+        message="Client relation: User management error. Please check logs",
+        running="async",
+    )
 
 
 class EtcdServiceStatuses(Enum):

--- a/src/statuses.py
+++ b/src/statuses.py
@@ -148,7 +148,7 @@ class ExternalClientsStatuses(Enum):
 
     EC_INVALID_CERTIFICATE = StatusObject(
         status="blocked",
-        message="Client relation: The certificate provided is a CA certificate. Please provide an end-entity certificate",
+        message="Client relation: The provided certificate is invalid. Please provide a valid certificate",
     )
     EC_MISSING_CREDENTIALS = StatusObject(
         status="blocked", message="Client relation: Missing certificate or prefix"

--- a/src/statuses.py
+++ b/src/statuses.py
@@ -172,11 +172,6 @@ class EtcdServiceStatuses(Enum):
     SERVICE_STARTING = StatusObject(
         status="maintenance", message="Waiting for etcd to start...", running="async"
     )
-    SERVICE_NOT_INSTALLED = StatusObject(
-        status="blocked",
-        message="unable to install etcd snap",
-        running="async",
-    )
     SERVICE_NOT_RUNNING = StatusObject(
         status="blocked", message="etcd service not running", running="async"
     )

--- a/src/statuses.py
+++ b/src/statuses.py
@@ -80,6 +80,9 @@ class ClusterStatuses(Enum):
     )
     HEALTH_CHECK_FAILED = StatusObject(status="maintenance", message="health check failed")
     REMOVED = StatusObject(status="blocked", message="unit removed from cluster", running="async")
+    RESTART_FAILED = StatusObject(
+        status="maintenance", message="unhealthy after restarting", running="async"
+    )
     PASSWORD_UPDATE_FAILED = StatusObject(
         status="blocked", message="failed to update password", running="async"
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -326,7 +326,7 @@ def test_update_status():
         patch("managers.cluster.ClusterManager.clean_users"),
     ):
         state_out = ctx.run(ctx.on.update_status(), state_in)
-        assert status_is(state_out, EtcdServiceStatuses.SERVICE_NOT_RUNNING.value)
+        assert status_is(state_out, ClusterStatuses.RESTART_FAILED.value)
 
     # test data storage
     # Set up storage with some content:
@@ -649,8 +649,6 @@ def test_set_config_options():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
     ):
         ctx.run(ctx.on.config_changed(), state_in)
@@ -670,8 +668,6 @@ def test_set_config_options():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
     ):
         ctx.run(ctx.on.config_changed(), state_in)
@@ -691,8 +687,6 @@ def test_set_config_options():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
     ):
         ctx.run(ctx.on.config_changed(), state_in)
@@ -712,8 +706,6 @@ def test_set_config_options():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -737,8 +729,6 @@ def test_set_config_options():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -649,6 +649,8 @@ def test_set_config_options():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
     ):
         ctx.run(ctx.on.config_changed(), state_in)
@@ -668,6 +670,8 @@ def test_set_config_options():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
     ):
         ctx.run(ctx.on.config_changed(), state_in)
@@ -687,6 +691,8 @@ def test_set_config_options():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
     ):
         ctx.run(ctx.on.config_changed(), state_in)
@@ -706,6 +712,8 @@ def test_set_config_options():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -729,6 +737,8 @@ def test_set_config_options():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)

--- a/tests/unit/test_external_client_relations.py
+++ b/tests/unit/test_external_client_relations.py
@@ -26,6 +26,7 @@ from common.exceptions import EtcdUserManagementError
 from literals import (
     CERTIFICATE_TRANSFER_RELATION,
     EXTERNAL_CLIENTS_RELATION,
+    STATUS_PEERS_RELATION,
     TLSCARotationState,
     TLSState,
     TLSType,
@@ -202,6 +203,53 @@ def test_add_ecr_new_user_leader(cluster_tls_context, mtls_cert):
             == CLIENT_COMMON_NAME
         )
         restart_member.assert_called_once()
+
+
+def test_add_ecr_user_creation_failed(cluster_tls_context, mtls_cert):
+    """Test adding an external client relation to the charm."""
+    ctx, relations = cluster_tls_context
+    secret = Secret({"mtls-cert": mtls_cert}, owner="app")
+    ecr_relation = testing.Relation(
+        id=5,
+        endpoint=EXTERNAL_CLIENTS_RELATION,
+        remote_app_data={
+            "secret-mtls": secret.id,
+            "prefix": "/test/keys",
+            "requested-secrets": '["username", "password", "tls", "tls-ca", "uris", "read-only-uris", "entity-name", "entity-password"]',
+            "provided-secrets": '["mtls-cert"]',
+        },
+    )
+    status_peer_relation = testing.PeerRelation(
+        id=6,
+        endpoint=STATUS_PEERS_RELATION,
+    )
+
+    state_in = testing.State(
+        relations=relations + [ecr_relation, status_peer_relation],
+        leader=True,
+        secrets=[secret],
+    )
+
+    with (
+        ctx(ctx.on.relation_changed(ecr_relation), state_in) as manager,
+        patch("common.client.EtcdClient.get_user", return_value=None),
+        patch(
+            "common.client.EtcdClient.add_user",
+            side_effect=EtcdUserManagementError("failed to add managed user"),
+        ),
+        patch("common.client.EtcdClient._run_etcdctl", return_value="success"),
+        patch(
+            "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
+            return_value=([server_cert], MagicMock()),
+        ),
+    ):
+        charm: EtcdOperatorCharm = manager.charm
+        state_out = manager.run()
+        ecr_relation = state_out.get_relation(ecr_relation.id)
+        assert ecr_relation.id not in charm.state.cluster.managed_users
+        assert state_out.app_status == as_status(
+            ExternalClientsStatuses.EC_USER_MANAGEMENT_ERROR.value
+        )
 
 
 def test_add_ecr_new_user_not_leader(cluster_tls_context, mtls_cert):

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -989,8 +989,6 @@ def test_set_tls_private_key():
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4._find_available_certificates"
         ),
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         # Configure client private key
@@ -1077,8 +1075,6 @@ def test_set_tls_private_key():
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4._cleanup_certificate_requests"
         ) as cleanup,
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         # Configure peer private key configured
@@ -1525,8 +1521,6 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1544,8 +1538,6 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1563,8 +1555,6 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1583,8 +1573,6 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1603,8 +1591,6 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1623,8 +1609,6 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1643,8 +1627,6 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1665,8 +1647,6 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("workload.EtcdWorkload.exec", return_value=current_sans_value),
         patch("workload.EtcdWorkload.get_host_mapping", return_value={"hostname": "myhostname"}),
         patch("workload.EtcdWorkload.get_private_ip", return_value="127.0.1.1"),

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1685,8 +1685,6 @@ def test_set_domain_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1704,8 +1702,6 @@ def test_set_domain_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1724,8 +1720,6 @@ def test_set_domain_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1747,8 +1741,6 @@ def test_set_domain_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
-        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
-        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("workload.EtcdWorkload.exec", return_value=current_sans_value),
         patch("workload.EtcdWorkload.get_host_mapping", return_value={"hostname": "myhostname"}),
         patch("workload.EtcdWorkload.get_private_ip", return_value="127.0.1.1"),

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -989,6 +989,8 @@ def test_set_tls_private_key():
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4._find_available_certificates"
         ),
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         # Configure client private key
@@ -1075,6 +1077,8 @@ def test_set_tls_private_key():
             "charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4._cleanup_certificate_requests"
         ) as cleanup,
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         # Configure peer private key configured
@@ -1521,6 +1525,8 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1538,6 +1544,8 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1555,6 +1563,8 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1573,6 +1583,8 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1591,6 +1603,8 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1609,6 +1623,8 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1627,6 +1643,8 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1647,6 +1665,8 @@ def test_set_extra_sans_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("workload.EtcdWorkload.exec", return_value=current_sans_value),
         patch("workload.EtcdWorkload.get_host_mapping", return_value={"hostname": "myhostname"}),
         patch("workload.EtcdWorkload.get_private_ip", return_value="127.0.1.1"),
@@ -1685,6 +1705,8 @@ def test_set_domain_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1702,6 +1724,8 @@ def test_set_domain_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1720,6 +1744,8 @@ def test_set_domain_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("subprocess.run"),
     ):
         state_out = ctx.run(ctx.on.config_changed(), state_in)
@@ -1741,6 +1767,8 @@ def test_set_domain_config_option():
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("common.client.EtcdClient.member_list", return_value=MEMBER_LIST_DICT),
+        patch("managers.cluster.ClusterManager.broadcast_peer_url"),
         patch("workload.EtcdWorkload.exec", return_value=current_sans_value),
         patch("workload.EtcdWorkload.get_host_mapping", return_value={"hostname": "myhostname"}),
         patch("workload.EtcdWorkload.get_private_ip", return_value="127.0.1.1"),


### PR DESCRIPTION
## Description of issue or feature:
The following issues for stability and error handling have been addressed:
1) do not raise an uncaught error if the health check after restarting a unit fails
2) do not raise if getting the member information for updating the peer url fails
3) disaster recovery with `cluster-rebuild` action fails if peer TLS is enabled
4) charm can crash on invalid private key (#164)
5) do not raise if an object storage bucket/container is not accessible on backup/restore actions
6) do not raise if adding a managed user to the etcd cluster fails
7) do not raise uncaught errors if an external client provides an invalid mTLS certificate

## Solution:
These changes have been implemented:
1) Instead of raising, we set a `maintenance` status to display a message `unhealthy after restarting` to users. This applies to all restarts, for example TLS switchover, IP address update, CA rotation or config changes.
2) The error handling for `broadcast_peer_url` only catches the error, status display is handled by 1) mentioned above (which always follows).
3) Only replace `http` with `https` in config property `initial-cluster` if the config property actually exists (in cluster rebuild it does not).
4) Errors when decoding a provided private key for peer or client TLS are handled and no longer raise.
5) Handle the `EtcdBackupError` returned from the `BackupManager` class and fail the event
6) Handle the `EtcdUserManagementError` returned from the `ClusterManager` class and set a blocked status
7) Handle the `ValueError` returned from `is_leaf_certificate_valid` and the `TLSCertificatesError` in `get_common_name_from_chain` for invalid mTLS certificates

## How was this change tested?
- [X] Manually
- [X] Unit tests
- [X] Integration tests

All described issues above have been tested manually, as well as the proposed fixes.