### PR TITLE
[DPE-8606] - Add profile config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -62,3 +62,10 @@ options:
       Wait for manual confirmation to resume refresh after these units refresh
 
       Allowed values: "all", "first", "none"
+  
+  profile:
+    type: string
+    default: production
+    description: |
+      Profile representing the scope of deployment, and used to tune etcd's configuration options. 
+      Allowed values are: "production" or "testing".

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -139,6 +139,11 @@ class EtcdEvents(Object):
             event.defer()
             return
 
+        if not self.charm.config_manager.are_tuning_parameters_valid():
+            logger.error("Deferring start because of invalid tuning parameters.")
+            event.defer()
+            return
+
         self.charm.config_manager.set_config_properties()
 
         if not self.charm.state.cluster.cluster_state and self.charm.unit.is_leader():
@@ -302,6 +307,7 @@ class EtcdEvents(Object):
         if (
             self.charm.config_manager.are_tuning_parameters_valid()
             and self.charm.config_manager.requires_restart()
+            and self.charm.state.unit_server.is_started
         ):
             # apply config and initiate restart
             self.charm.rolling_restart()

--- a/src/literals.py
+++ b/src/literals.py
@@ -52,6 +52,8 @@ TLS_CLIENT_PRIVATE_KEY_CONFIG = "tls-client-private-key"
 
 S3_RELATION_NAME = "s3-credentials"
 AZURE_RELATION_NAME = "azure-credentials"
+QUOTA_BACKEND_BYTES = "quota-backend-bytes"
+PRODUCTION_QUOTA_BACKEND_BYTES = 8589934592  # 8GiB
 
 
 @dataclass
@@ -113,3 +115,10 @@ class TuningOptions(StrEnum):
 
     ELECTION_TIMEOUT_CONFIG = "election-timeout"
     HEARTBEAT_INTERVAL_CONFIG = "heartbeat-interval"
+
+
+class Profile(StrEnum):
+    """Profiles for deployment scope."""
+
+    PRODUCTION = "production"
+    TESTING = "testing"

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -19,6 +19,9 @@ from literals import (
     CONFIG_FILE,
     DATABASE_DIR,
     METRICS_PORT,
+    PRODUCTION_QUOTA_BACKEND_BYTES,
+    QUOTA_BACKEND_BYTES,
+    Profile,
     RestoreStep,
     TLSState,
     TuningOptions,
@@ -95,6 +98,14 @@ class ConfigManager(ManagerStatusProtocol):
                 # take over the config value set by users
                 config_properties[option.value] = self.config.get(option.value)
 
+            config_profile = Profile(self.config.get("profile"))
+            if config_profile == Profile.PRODUCTION:
+                config_properties[QUOTA_BACKEND_BYTES] = PRODUCTION_QUOTA_BACKEND_BYTES
+            else:
+                # remove quota-backend-bytes from config for testing profile
+                if QUOTA_BACKEND_BYTES in config_properties:
+                    del config_properties[QUOTA_BACKEND_BYTES]
+
         if self.state.unit_server.tls_client_state in [TLSState.TO_TLS, TLSState.TLS]:
             # replace http with https in listen-client-urls and advertise-client-urls
             config_properties["listen-client-urls"] = self.state.unit_server.client_url.replace(
@@ -161,17 +172,24 @@ class ConfigManager(ManagerStatusProtocol):
         )
 
     def are_tuning_parameters_valid(self) -> bool:
-        """Validate configuration values for tuning parameters.
+        """Validate configuration values for tuning parameters and profile.
 
         Returns:
             bool: True if tuning config values are valid, False if invalid.
         """
         if heartbeat_interval := self.config.get(TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value):
             if heartbeat_interval < 10 or heartbeat_interval > 5000:
+                logger.error(f"Invalid heartbeat_interval value: {heartbeat_interval}")
                 return False
 
         if election_timeout := self.config.get(TuningOptions.ELECTION_TIMEOUT_CONFIG.value):
             if election_timeout < heartbeat_interval * 10 or election_timeout > 50000:
+                logger.error(f"Invalid election_timeout value: {election_timeout}")
+                return False
+
+        if profile := self.config.get("profile"):
+            if profile not in [option.value for option in Profile]:
+                logger.error(f"Invalid profile value: {profile}")
                 return False
 
         return True
@@ -189,11 +207,22 @@ class ConfigManager(ManagerStatusProtocol):
                 logger.info(f"Config change to {option.value} requires restart")
                 return True
 
+        config_profile = Profile(self.config.get("profile"))
+        if (
+            config_profile == Profile.PRODUCTION
+            and current_config_values.get(QUOTA_BACKEND_BYTES) != PRODUCTION_QUOTA_BACKEND_BYTES
+        ) or (config_profile == Profile.TESTING and QUOTA_BACKEND_BYTES in current_config_values):
+            logger.info("Config change to profile requires restart")
+            return True
+
         return False
 
     def get_statuses(self, scope: Scope, recompute: bool = False) -> list[StatusObject]:
         """Compute the Cluster manager's statuses."""
         status_list: list[StatusObject] = []
+
+        if self.config.get("profile") not in [option.value for option in Profile]:
+            status_list.append(ConfigStatuses.PROFILE_INVALID.value)
 
         if not self.are_tuning_parameters_valid():
             status_list.append(ConfigStatuses.TUNING_CONFIG_INVALID.value)

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -102,9 +102,7 @@ class ConfigManager(ManagerStatusProtocol):
             if config_profile == Profile.PRODUCTION:
                 config_properties[QUOTA_BACKEND_BYTES] = PRODUCTION_QUOTA_BACKEND_BYTES
             else:
-                # remove quota-backend-bytes from config for testing profile
-                if QUOTA_BACKEND_BYTES in config_properties:
-                    del config_properties[QUOTA_BACKEND_BYTES]
+                config_properties.pop(QUOTA_BACKEND_BYTES, None)
 
         if self.state.unit_server.tls_client_state in [TLSState.TO_TLS, TLSState.TLS]:
             # replace http with https in listen-client-urls and advertise-client-urls

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -51,7 +51,7 @@ class ConfigManager(ManagerStatusProtocol):
         self.config_file = workload.paths.config_file
 
     @property
-    def config_properties(self) -> str:
+    def config_properties(self) -> str:  # noqa: C901
         """Assemble the config properties.
 
         Returns:

--- a/src/statuses.py
+++ b/src/statuses.py
@@ -92,6 +92,10 @@ class ConfigStatuses(Enum):
         status="blocked",
         message="Invalid values set for the config options: 'election-timeout', 'heartbeat-interval'",
     )
+    PROFILE_INVALID = StatusObject(
+        status="blocked",
+        message="Invalid profile configuration option. Only “production” and “testing” values are allowed",
+    )
 
 
 class TLSStatuses(Enum):

--- a/src/statuses.py
+++ b/src/statuses.py
@@ -94,7 +94,7 @@ class ConfigStatuses(Enum):
     )
     PROFILE_INVALID = StatusObject(
         status="blocked",
-        message="Invalid profile configuration option. Only “production” and “testing” values are allowed",
+        message="Invalid profile configuration option. Only 'production' and 'testing' values are allowed",
     )
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -612,7 +612,11 @@ def test_config_changed():
         leader=True,
     )
 
-    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
@@ -631,7 +635,8 @@ def test_set_config_options():
     relation = testing.PeerRelation(
         id=1,
         endpoint=PEER_RELATION,
-        local_unit_data={"private_ip": "my_ip"},
+        local_unit_data={"private_ip": "my_ip", "state": "started"},
+        local_app_data={"cluster_state": "existing", "authentication": "enabled"},
     )
     ctx = testing.Context(EtcdOperatorCharm)
 
@@ -645,7 +650,11 @@ def test_set_config_options():
         leader=True,
     )
 
-    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
@@ -664,7 +673,11 @@ def test_set_config_options():
         leader=True,
     )
 
-    current_config_file = {"election-timeout": 1000, "heartbeat-interval": 100}
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
@@ -683,7 +696,11 @@ def test_set_config_options():
         leader=True,
     )
 
-    current_config_file = {"election-timeout": 5000, "heartbeat-interval": 500}
+    current_config_file = {
+        "election-timeout": 5000,
+        "heartbeat-interval": 500,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
@@ -702,7 +719,11 @@ def test_set_config_options():
         leader=True,
     )
 
-    current_config_file = {"election-timeout": 5000, "heartbeat-interval": 500}
+    current_config_file = {
+        "election-timeout": 5000,
+        "heartbeat-interval": 500,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
@@ -725,7 +746,11 @@ def test_set_config_options():
         leader=True,
     )
 
-    current_config_file = {"election-timeout": 5000, "heartbeat-interval": 500}
+    current_config_file = {
+        "election-timeout": 5000,
+        "heartbeat-interval": 500,
+        "quota-backend-bytes": 8589934592,
+    }
 
     with (
         patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
@@ -736,6 +761,87 @@ def test_set_config_options():
         assert status_is(
             state_out,
             ConfigStatuses.TUNING_CONFIG_INVALID.value,
+        )
+
+
+def test_update_profile():
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_unit_data={"private_ip": "my_ip", "state": "started"},
+        local_app_data={"cluster_state": "existing", "authentication": "enabled"},
+    )
+    ctx = testing.Context(EtcdOperatorCharm)
+
+    # testing to production
+    state_in = testing.State(
+        config={
+            TuningOptions.ELECTION_TIMEOUT_CONFIG.value: 5000,
+            TuningOptions.HEARTBEAT_INTERVAL_CONFIG.value: 500,
+            "profile": "production",
+        },
+        relations={relation},
+        leader=True,
+    )
+
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+    }
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
+    ):
+        ctx.run(ctx.on.config_changed(), state_in)
+        rolling_restart.assert_called_once()
+
+    # production to testing
+    state_in = testing.State(
+        config={
+            "profile": "testing",
+        },
+        relations={relation},
+        leader=True,
+    )
+
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+        "quota-backend-bytes": 8589934592,
+    }
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
+    ):
+        ctx.run(ctx.on.config_changed(), state_in)
+        rolling_restart.assert_called_once()
+
+    # invalid profile
+    state_in = testing.State(
+        config={
+            "profile": "invalid-profile",
+        },
+        relations={relation},
+        leader=True,
+    )
+
+    current_config_file = {
+        "election-timeout": 1000,
+        "heartbeat-interval": 100,
+        "quota-backend-bytes": 8589934592,
+    }
+
+    with (
+        patch("workload.EtcdWorkload.load_yaml_file", return_value=current_config_file),
+        patch("charm.EtcdOperatorCharm.rolling_restart") as rolling_restart,
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+        rolling_restart.assert_not_called()
+        assert status_is(
+            state_out,
+            ConfigStatuses.PROFILE_INVALID.value,
         )
 
 


### PR DESCRIPTION
## Description of issue or feature:

This pull request introduces a new `profile` configuration option to tune etcd deployment for either `production` or `testing` environments. It enforces profile validity, adjusts configuration parameters based on the selected profile, and ensures that changes to the profile trigger appropriate configuration updates and restarts. The tests have been updated to cover these new behaviors.

## Solution:

**Profile configuration and validation:**
* Added a `profile` option to `config.yaml`, allowing users to select either "production" or "testing" deployment profiles.
* Introduced `Profile` enum and validation logic to ensure only valid profile values are accepted; invalid values block the unit and surface a clear status message. [[1]](diffhunk://#diff-959ba637043ab4ac88c6f9f9109022f78a7df1b9a2ab3a0407bff4f124c2db64R118-R124) [[2]](diffhunk://#diff-a24e7472936c291b5c95f9c56ccc25cccef3adf4c4cbd1de135e2dde31ae592cL164-R192) [[3]](diffhunk://#diff-074beea58df119261178a25e474cd0c240fa20f1c6fb6990867d357676e96cefR95-R98)

**Configuration tuning based on profile:**
* In production profile, automatically sets `quota-backend-bytes` to 8GiB; in testing profile, removes this parameter from the config. [[1]](diffhunk://#diff-959ba637043ab4ac88c6f9f9109022f78a7df1b9a2ab3a0407bff4f124c2db64R55-R56) [[2]](diffhunk://#diff-a24e7472936c291b5c95f9c56ccc25cccef3adf4c4cbd1de135e2dde31ae592cR101-R108)
* Ensures that changes to the profile or related config parameters trigger a rolling restart when necessary. [[1]](diffhunk://#diff-a24e7472936c291b5c95f9c56ccc25cccef3adf4c4cbd1de135e2dde31ae592cR210-R226) [[2]](diffhunk://#diff-4d4b45129d72bf79a08e70009a59f4ebe0a016b4727117155249c864ae4a1b49R310)

**Event handling and startup logic:**
* Defers start events if tuning parameters or profile are invalid, logging errors for easier troubleshooting.

**Testing improvements:**
* Added and updated unit tests to verify correct behavior for profile changes, including transitions between profiles and handling of invalid profiles. [[1]](diffhunk://#diff-0580ab9aef31b44580478eb270ec3422c5e6fef35df585fecb3a68317e246809L615-R619) [[2]](diffhunk://#diff-0580ab9aef31b44580478eb270ec3422c5e6fef35df585fecb3a68317e246809L634-R639) [[3]](diffhunk://#diff-0580ab9aef31b44580478eb270ec3422c5e6fef35df585fecb3a68317e246809L648-R657) [[4]](diffhunk://#diff-0580ab9aef31b44580478eb270ec3422c5e6fef35df585fecb3a68317e246809L667-R680) [[5]](diffhunk://#diff-0580ab9aef31b44580478eb270ec3422c5e6fef35df585fecb3a68317e246809L686-R703) [[6]](diffhunk://#diff-0580ab9aef31b44580478eb270ec3422c5e6fef35df585fecb3a68317e246809L705-R726) [[7]](diffhunk://#diff-0580ab9aef31b44580478eb270ec3422c5e6fef35df585fecb3a68317e246809L728-R753) [[8]](diffhunk://#diff-0580ab9aef31b44580478eb270ec3422c5e6fef35df585fecb3a68317e246809R767-R847)

## How was this change tested?
- [x] Manually
- [x] Unit tests
- [ ] Integration tests

