### PR TITLE
pin ubuntu 22.04 image used for lxd containers

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -119,8 +119,6 @@ jobs:
         run: |
           sudo lxc image copy ubuntu:568f69ff1166 local:
           sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
-          sudo lxc image copy ubuntu:60d56aa663ed local:
-          sudo lxc image alias create "juju/ubuntu@22.04/arm64" 60d56aa663ed
       - name: Run spread job
         timeout-minutes: 60
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -119,8 +119,8 @@ jobs:
         run: |
           sudo lxc image copy ubuntu:568f69ff1166 local:
           sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
-          sudo lxc image copy ubuntu:60d56aa663ed local:
-          sudo lxc image alias create "juju/ubuntu@22.04/arm64" 60d56aa663ed
+          sudo lxc image copy ubuntu:fb4b46c39440 local:
+          sudo lxc image alias create "juju/ubuntu@22.04/arm64" fb4b46c39440
       - name: Run spread job
         timeout-minutes: 60
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -119,8 +119,8 @@ jobs:
         run: |
           sudo lxc image copy ubuntu:568f69ff1166 local:
           sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
-          sudo lxc image copy ubuntu:fb4b46c39440 local:
-          sudo lxc image alias create "juju/ubuntu@22.04/arm64" fb4b46c39440
+          sudo lxc image copy ubuntu:45eac243980b local:
+          sudo lxc image alias create "juju/ubuntu@22.04/arm64" 45eac243980b
       - name: Run spread job
         timeout-minutes: 60
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -114,6 +114,11 @@ jobs:
         with:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
+      # TODO Remove pinned image when problem is resolved on jammy
+      - name: Pin lxc image for jammy
+        run: |
+          sudo lxc image copy ubuntu:568f69ff1166 local:
+          sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
       - name: Run spread job
         timeout-minutes: 60
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -119,8 +119,8 @@ jobs:
         run: |
           sudo lxc image copy ubuntu:568f69ff1166 local:
           sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
-          sudo lxc image copy ubuntu:45eac243980b local:
-          sudo lxc image alias create "juju/ubuntu@22.04/arm64" 45eac243980b
+          sudo lxc image copy ubuntu:60d56aa663ed local:
+          sudo lxc image alias create "juju/ubuntu@22.04/arm64" 60d56aa663ed
       - name: Run spread job
         timeout-minutes: 60
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -117,8 +117,10 @@ jobs:
       # TODO Remove pinned image when problem is resolved on jammy
       - name: Pin lxc image for jammy
         run: |
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc image copy ubuntu:82b997ec581b local: --alias 'juju/ubuntu@22.04/amd64'
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc image copy ubuntu:60d56aa663ed local: --alias 'juju/ubuntu@22.04/arm64'
+          sudo lxc image copy ubuntu:568f69ff1166 local:
+          sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
+          sudo lxc image copy ubuntu:60d56aa663ed local:
+          sudo lxc image alias create "juju/ubuntu@22.04/arm64" 60d56aa663ed
       - name: Run spread job
         timeout-minutes: 60
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -117,8 +117,12 @@ jobs:
       # TODO Remove pinned image when problem is resolved on jammy
       - name: Pin lxc image for jammy
         run: |
-          sudo lxc image copy ubuntu:568f69ff1166 local:
-          sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
+          if [[ '${{ inputs.architecture }}' == 'amd64' ]]
+          then
+            sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc image copy ubuntu:82b997ec581b local: --alias 'juju/ubuntu@22.04/amd64'
+          else
+            sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc image copy ubuntu:60d56aa663ed local: --alias 'juju/ubuntu@22.04/arm64'
+          fi
       - name: Run spread job
         timeout-minutes: 60
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -117,12 +117,8 @@ jobs:
       # TODO Remove pinned image when problem is resolved on jammy
       - name: Pin lxc image for jammy
         run: |
-          if [[ '${{ inputs.architecture }}' == 'amd64' ]]
-          then
-            sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc image copy ubuntu:82b997ec581b local: --alias 'juju/ubuntu@22.04/amd64'
-          else
-            sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc image copy ubuntu:60d56aa663ed local: --alias 'juju/ubuntu@22.04/arm64'
-          fi
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc image copy ubuntu:82b997ec581b local: --alias 'juju/ubuntu@22.04/amd64'
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc image copy ubuntu:60d56aa663ed local: --alias 'juju/ubuntu@22.04/arm64'
       - name: Run spread job
         timeout-minutes: 60
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -119,6 +119,8 @@ jobs:
         run: |
           sudo lxc image copy ubuntu:568f69ff1166 local:
           sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
+          sudo lxc image copy ubuntu:60d56aa663ed local:
+          sudo lxc image alias create "juju/ubuntu@22.04/arm64" 60d56aa663ed
       - name: Run spread job
         timeout-minutes: 60
         id: spread

--- a/spread.yaml
+++ b/spread.yaml
@@ -109,8 +109,6 @@ backends:
           username: ubuntu
       - self-hosted-linux-arm64-noble-large:
           username: ubuntu
-      - ubuntu-24.04-arm:
-          username: runner
 
 suites:
   tests/spread/:

--- a/spread.yaml
+++ b/spread.yaml
@@ -109,6 +109,8 @@ backends:
           username: ubuntu
       - self-hosted-linux-arm64-noble-large:
           username: ubuntu
+      - ubuntu-24.04-arm:
+          username: runner
 
 suites:
   tests/spread/:

--- a/tests/spread/test_restore_verification_failed.py/task.yaml
+++ b/tests/spread/test_restore_verification_failed.py/task.yaml
@@ -3,7 +3,9 @@ environment:
   TEST_MODULE: backup/test_restore_verification_failed.py
 systems:
   - self-hosted-linux-amd64-noble-medium
-  - self-hosted-linux-arm64-noble-medium
+  # s3-integrator requires ubuntu22.04 which is broken and no workaround is known
+  # https://bugs.launchpad.net/snapd/+bug/2127244
+  # self-hosted-linux-arm64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/test_restore_verification_failed.py/task.yaml
+++ b/tests/spread/test_restore_verification_failed.py/task.yaml
@@ -3,7 +3,7 @@ environment:
   TEST_MODULE: backup/test_restore_verification_failed.py
 systems:
   - self-hosted-linux-amd64-noble-medium
-  - self-hosted-linux-arm64-noble-medium
+  - ubuntu-24.04-arm
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/test_restore_verification_failed.py/task.yaml
+++ b/tests/spread/test_restore_verification_failed.py/task.yaml
@@ -3,7 +3,7 @@ environment:
   TEST_MODULE: backup/test_restore_verification_failed.py
 systems:
   - self-hosted-linux-amd64-noble-medium
-  - ubuntu-24.04-arm
+  - self-hosted-linux-arm64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/test_s3_backup_restore.py/task.yaml
+++ b/tests/spread/test_s3_backup_restore.py/task.yaml
@@ -3,7 +3,9 @@ environment:
   TEST_MODULE: backup/test_s3_backup_restore.py
 systems:
   - self-hosted-linux-amd64-noble-medium
-  - self-hosted-linux-arm64-noble-medium
+  # s3-integrator requires ubuntu22.04 which is broken and no workaround is known
+  # https://bugs.launchpad.net/snapd/+bug/2127244
+  # self-hosted-linux-arm64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/test_s3_backup_restore.py/task.yaml
+++ b/tests/spread/test_s3_backup_restore.py/task.yaml
@@ -3,7 +3,7 @@ environment:
   TEST_MODULE: backup/test_s3_backup_restore.py
 systems:
   - self-hosted-linux-amd64-noble-medium
-  - self-hosted-linux-arm64-noble-medium
+  - ubuntu-24.04-arm
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/test_s3_backup_restore.py/task.yaml
+++ b/tests/spread/test_s3_backup_restore.py/task.yaml
@@ -3,7 +3,7 @@ environment:
   TEST_MODULE: backup/test_s3_backup_restore.py
 systems:
   - self-hosted-linux-amd64-noble-medium
-  - ubuntu-24.04-arm
+  - self-hosted-linux-arm64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:


### PR DESCRIPTION
## Description of issue or feature:
There is an issue with the jammy image used by lxd which is causing charms running on 22.04 (eg. s3-integrator) to be stuck in "waiting for machine" state and breaking integration tests.

This is caused by a kernel issue related to snapd. For more details, follow [here](https://bugs.launchpad.net/snapd/+bug/2127244).

## Solution:
- pin the `amd64` image to a working one
- disable the integration tests on arm for `backup_restore_s3` and `restore_verification` (they are still run on amd)

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [X] Integration tests
