### PR TITLE
unpin juju agent

### DIFF
--- a/concierge.yaml
+++ b/concierge.yaml
@@ -4,7 +4,7 @@ juju:
 providers:
   lxd:
     enable: true
-    bootstrap: false
+    bootstrap: true
 host:
   snaps:
     jhack:

--- a/spread.yaml
+++ b/spread.yaml
@@ -128,8 +128,6 @@ prepare: |
 
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace
-  /snap/bin/juju bootstrap localhost concierge-lxd --verbose --model-default 'logging-config=<root>=INFO; unit=DEBUG' --agent-version=3.6.9
-  /snap/bin/juju add-model -c concierge-lxd testing
 
   pipx install tox poetry
 prepare-each: |

--- a/tests/integration/backup/test_s3_backup_restore.py
+++ b/tests/integration/backup/test_s3_backup_restore.py
@@ -141,6 +141,8 @@ async def test_restore_backup_on_different_cluster(charm: str, ops_test: OpsTest
     """Restore a backup and check if data is recovered."""
     logger.info("Remove existing etcd cluster and deploy a new one.")
     await ops_test.model.remove_application(APP_NAME, block_until_done=True)
+    await ops_test.model.remove_secret(secret_name="system_users_secret")
+
     await ops_test.model.deploy(charm, num_units=NUM_UNITS)
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS, idle_period=60)
 


### PR DESCRIPTION
## Description of issue or feature:
Because of a regression introduced in Juju release 3.6.10 (see https://github.com/juju/juju/issues/20714). we had pinned the juju-agent version to 3.6.9 when bootstrapping LXD clouds for integration tests. Now that Juju 3.6.11 has been released, we can revert that workaround.

## Solution:
unpin bootstrap agent

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [X] Integration tests
