### PR TITLE
[DPE-8678] Duplicate private key as fallback

### DIFF
--- a/docs/how-to/tls/manage-private-keys.md
+++ b/docs/how-to/tls/manage-private-keys.md
@@ -18,7 +18,7 @@ Now that the secret is stored, you can grant the secret to the application using
 
 ```{terminal}
 :scroll:
-:input: juju grant charmed-etcd tls-peer-private-key
+:input: juju grant-secret tls-peer-private-key charmed-etcd
 ```
 
 ## Reference the secret in the charm configuration

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -13,6 +13,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
     DataPeerData,
     DataPeerUnitData,
 )
+from charms.tls_certificates_interface.v4.tls_certificates import PrivateKey
 from ops.model import Application, Relation, Unit
 
 from literals import (
@@ -217,6 +218,24 @@ class EtcdCluster(RelationState):
         """Retrieve the credentials for the internal admin user."""
         if password := self.relation_data.get(f"{INTERNAL_USER}-password"):
             return {INTERNAL_USER: password}
+
+        return {}
+
+    @property
+    def tls_client_private_key(self) -> dict[str, PrivateKey]:
+        """Retrieve the private key for client TLS."""
+        if private_key := self.relation_data.get("tls-client-private-key"):
+            private_key = PrivateKey(raw=private_key)
+            return {"key": private_key}
+
+        return {}
+
+    @property
+    def tls_peer_private_key(self) -> dict[str, PrivateKey]:
+        """Retrieve the private key for peer TLS."""
+        if private_key := self.relation_data.get("tls-peer-private-key"):
+            private_key = PrivateKey(raw=private_key)
+            return {"key": private_key}
 
         return {}
 

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -222,22 +222,22 @@ class EtcdCluster(RelationState):
         return {}
 
     @property
-    def tls_client_private_key(self) -> dict[str, PrivateKey]:
+    def tls_client_private_key(self) -> PrivateKey | None:
         """Retrieve the private key for client TLS."""
         if private_key := self.relation_data.get("tls-client-private-key"):
             private_key = PrivateKey(raw=private_key)
-            return {"key": private_key}
+            return private_key
 
-        return {}
+        return None
 
     @property
-    def tls_peer_private_key(self) -> dict[str, PrivateKey]:
+    def tls_peer_private_key(self) -> PrivateKey | None:
         """Retrieve the private key for peer TLS."""
         if private_key := self.relation_data.get("tls-peer-private-key"):
             private_key = PrivateKey(raw=private_key)
-            return {"key": private_key}
+            return private_key
 
-        return {}
+        return None
 
     @property
     def auth_enabled(self) -> bool:

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -82,17 +82,7 @@ class TLSEvents(Object):
                     peer_private_key_id
                 )
             ) is None:
-                self.charm.state.statuses.add(
-                    TLSStatuses.TLS_INVALID_PRIVATE_KEY.value,
-                    scope="unit",
-                    component=self.charm.tls_manager.name,
-                )
-            else:
-                self.charm.state.statuses.delete(
-                    TLSStatuses.TLS_INVALID_PRIVATE_KEY.value,
-                    scope="unit",
-                    component=self.charm.tls_manager.name,
-                )
+                peer_private_key = self.charm.state.cluster.tls_peer_private_key.get("key", None)
 
         if client_private_key_id := self.charm.config.get(TLS_CLIENT_PRIVATE_KEY_CONFIG):
             if (
@@ -100,16 +90,8 @@ class TLSEvents(Object):
                     client_private_key_id
                 )
             ) is None:
-                self.charm.state.statuses.add(
-                    TLSStatuses.TLS_INVALID_PRIVATE_KEY.value,
-                    scope="unit",
-                    component=self.charm.tls_manager.name,
-                )
-            else:
-                self.charm.state.statuses.delete(
-                    TLSStatuses.TLS_INVALID_PRIVATE_KEY.value,
-                    scope="unit",
-                    component=self.charm.tls_manager.name,
+                client_private_key = self.charm.state.cluster.tls_client_private_key.get(
+                    "key", None
                 )
 
         self.peer_certificate = TLSCertificatesRequiresV4(
@@ -359,10 +341,10 @@ class TLSEvents(Object):
     def _on_config_changed(self, event: ConfigChangedEvent) -> None:
         """Handle TLS related config changes."""
         if tls_peer_private_key_id := self.charm.config.get(TLS_PEER_PRIVATE_KEY_CONFIG):
-            self.update_private_key(tls_peer_private_key_id)
+            self.update_private_key(tls_peer_private_key_id, tls_type=TLSType.PEER)
 
         if tls_client_private_key_id := self.charm.config.get(TLS_CLIENT_PRIVATE_KEY_CONFIG):
-            self.update_private_key(tls_client_private_key_id)
+            self.update_private_key(tls_client_private_key_id, tls_type=TLSType.CLIENT)
 
         if not (
             self.charm.tls_manager.extra_sans_config_is_valid()
@@ -385,18 +367,22 @@ class TLSEvents(Object):
         """Handle TLS related secret changes."""
         if tls_peer_private_key_id := self.charm.config.get(TLS_PEER_PRIVATE_KEY_CONFIG):
             if tls_peer_private_key_id == event.secret.id:
-                self.update_private_key(tls_peer_private_key_id)
+                self.update_private_key(tls_peer_private_key_id, tls_type=TLSType.PEER)
 
         if tls_client_private_key_id := self.charm.config.get(TLS_CLIENT_PRIVATE_KEY_CONFIG):
             if tls_client_private_key_id == event.secret.id:
-                self.update_private_key(tls_client_private_key_id)
+                self.update_private_key(tls_client_private_key_id, tls_type=TLSType.CLIENT)
 
-    def update_private_key(self, private_key_id: str) -> None:
+    def update_private_key(self, private_key_id: str, tls_type: TLSType) -> None:
         """Update the private key in etcd."""
-        logger.debug("Updating TLS private key.")
+        logger.debug(f"Updating {tls_type.value} TLS private key.")
 
-        if self.charm.tls_manager.read_and_validate_private_key(private_key_id) is None:
+        if not (
+            private_key := self.charm.tls_manager.read_and_validate_private_key(private_key_id)
+        ):
             logger.error("Invalid private key provided, cannot update TLS certificates.")
             return
 
+        if self.charm.unit.is_leader:
+            self.charm.state.cluster.update({f"tls-{tls_type.value}-private-key": private_key.raw})
         self.refresh_tls_certificates_event.emit()

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -82,7 +82,7 @@ class TLSEvents(Object):
                     peer_private_key_id
                 )
             ) is None:
-                peer_private_key = self.charm.state.cluster.tls_peer_private_key.get("key", None)
+                peer_private_key = self.charm.state.cluster.tls_peer_private_key
 
         if client_private_key_id := self.charm.config.get(TLS_CLIENT_PRIVATE_KEY_CONFIG):
             if (
@@ -90,9 +90,7 @@ class TLSEvents(Object):
                     client_private_key_id
                 )
             ) is None:
-                client_private_key = self.charm.state.cluster.tls_client_private_key.get(
-                    "key", None
-                )
+                client_private_key = self.charm.state.cluster.tls_client_private_key
 
         self.peer_certificate = TLSCertificatesRequiresV4(
             self.charm,

--- a/src/literals.py
+++ b/src/literals.py
@@ -39,7 +39,13 @@ METRICS_PORT = 9100
 
 INTERNAL_USER = "root"
 INTERNAL_USER_PASSWORD_CONFIG = "system-users"
-SECRETS_APP = ["root-password", "s3-credentials", "azure-credentials"]
+SECRETS_APP = [
+    "root-password",
+    "s3-credentials",
+    "azure-credentials",
+    "tls-client-private-key",
+    "tls-peer-private-key",
+]
 
 DebugLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR"]
 SUBSTRATES = Literal["vm", "k8s"]


### PR DESCRIPTION
## Description of issue or feature:
If a user-provided private key has been set for TLS client or peer certificates and that private key is updated to an invalid key, the next time the certificates are refreshed, it will be done with an auto-generated key (generated by the TLS library). This is not the desired behavior, instead the previously valid private key should be kept and continue to be used.

## Solution:
The PR changes the implementation to duplicate user-provided private keys into the internal application databag. If an the private key gets updated to an invalid one, the previous key will be kept and certificates are not updated. Only if no previously valid private key is available, an auto-generated one will be used.

## How was this change tested?
- [X] Manually
- [ ] Unit tests
- [X] Integration tests

Manual tests:
1)
- enable peer TLS with auto-generated key
- provide a valid private key and check updated certs
- update to an invalid private key and check certs have not been updated
- update to a valid private key again and check certs have been updated

2)
- configure an invalid private key for client TLS
- enable client TLS and ensure an auto-generated key has been used
- update the user-provided key to a valid private key and check certs have been updated