### PR TITLE
[DPE-8405] deploy `stable` revisions of the snap

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -8,6 +8,6 @@ name = "charmed-etcd"
 
 [snap.revisions]
 # amd64
-x86_64 = "23"
+x86_64 = "25"
 # arm64
-aarch64 = "24"
+aarch64 = "26"


### PR DESCRIPTION
## Description of issue or feature:
For the upcoming `stable` release, we want to use the snap revisions that have been published to `stable`.

## Solution:
update snap revisions in `refresh_versions.toml`.

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [X] Integration tests