### PR TITLE
[DPE-8405] Improve integration test stability

### DIFF
--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -54,15 +54,15 @@ async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> 
     destroy_unit_cmd = f"remove-unit {unit_to_remove.name} --model={ops_test.model.info.name} --force --no-wait --no-prompt"
     return_code, _, _ = await ops_test.juju(*destroy_unit_cmd.split())
     assert return_code == 0, "Failed to remove unit"
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS - 1)
+
+    # wait for the next `update_status` for the cluster membership to be updated
+    async with ops_test.fast_forward("15s"):
+        await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS - 1)
 
     endpoints = get_cluster_endpoints(ops_test, APP_NAME)
     secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
     password = secret.get(f"{INTERNAL_USER}-password")
     assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
-    # wait for the next `update_status` for the cluster membership to be updated
-    async with ops_test.fast_forward("15s"):
-        await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS - 1)
 
     cluster_members = get_cluster_members(endpoints)
     member_names = [member["name"] for member in cluster_members]

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -59,12 +59,10 @@ async def test_membership_reconfiguration_after_unit_loss(ops_test: OpsTest) -> 
     endpoints = get_cluster_endpoints(ops_test, APP_NAME)
     secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
     password = secret.get(f"{INTERNAL_USER}-password")
-
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
     # wait for the next `update_status` for the cluster membership to be updated
-    async with ops_test.fast_forward("5s"):
-        assert_continuous_writes_increasing(
-            endpoints=endpoints, user=INTERNAL_USER, password=password
-        )
+    async with ops_test.fast_forward("15s"):
+        await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS - 1)
 
     cluster_members = get_cluster_members(endpoints)
     member_names = [member["name"] for member in cluster_members]

--- a/tests/integration/ha/upgrades/test_upgrade_cluster_size_related_tests.py
+++ b/tests/integration/ha/upgrades/test_upgrade_cluster_size_related_tests.py
@@ -277,4 +277,3 @@ async def test_scale_down_during_upgrade(charm: str, ops_test: OpsTest) -> None:
     assert_continuous_writes_consistent(
         endpoints=updated_endpoints, user=INTERNAL_USER, password=password, ignore_revision=True
     )
-    await ops_test.model.remove_application(APP_NAME, block_until_done=True)

--- a/tests/integration/ha/upgrades/test_upgrade_edge_cases.py
+++ b/tests/integration/ha/upgrades/test_upgrade_edge_cases.py
@@ -370,5 +370,3 @@ async def test_tls_cert_rotation_during_upgrade(charm: str, ops_test: OpsTest) -
     # clean up and remove the application to allow for further upgrade tests
     stop_continuous_writes()
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
-    await ops_test.model.remove_application(APP_NAME, block_until_done=True)
-    await ops_test.model.remove_application(TLS_NAME, block_until_done=True)


### PR DESCRIPTION
## Description of issue or feature:
With the recent intensity of integration testing, we have experienced some failures on a few tests because of the test flow.

## Solution:
- disaster recovery test: the `update_status` event needs to happen to remove cluster members that are gone
- upgrades tests: no need to wait for application removal at the end of the tests

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [X] Integration tests
