### PR TITLE
[DPE-8405] Minor docs adjustments for stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ juju add-model sample-model
 To deploy a single unit of charmed etcd, run the following command:
 
 ```shell
-juju deploy charmed-etcd --channel 3.6/edge
+juju deploy charmed-etcd
 ```
 
 To deploy charmed etcd with multiple units, specify the number of desired units with the `-n` option:
 
 ```shell
-juju deploy charmed-etcd --channel 3.6/edge -n 3
+juju deploy charmed-etcd -n 3
 ```
 
 Charmed etcd can be scaled out using the `juju add-unit` command:

--- a/docs/how-to/migrate-to-charmed-etcd.md
+++ b/docs/how-to/migrate-to-charmed-etcd.md
@@ -94,7 +94,7 @@ Ensure your backup file was uploaded correctly by repeating the `s3cmd ls s3://e
 Now it's time to deploy charmed etcd. Run the following command to deploy a 3-unit cluster:
 
 ```text
-juju deploy charmed-etcd --channel 3.6/edge -n 3
+juju deploy charmed-etcd -n 3
 ```
 
 Wait for the deployment to become available by checking `watch juju status --color`:

--- a/docs/how-to/tls/enable-tls.md
+++ b/docs/how-to/tls/enable-tls.md
@@ -195,7 +195,7 @@ You can also deploy the cluster with encryption enabled from the start by integr
 
 ```text
 juju deploy self-signed-certificates --channel edge
-juju deploy charmed-etcd -n 3 --channel 3.6/edge
+juju deploy charmed-etcd -n 3
 juju integrate self-signed-certificates:certificates charmed-etcd:client-certificates
 juju integrate self-signed-certificates:certificates charmed-etcd:peer-certificates
 ```

--- a/docs/how-to/tune-settings.md
+++ b/docs/how-to/tune-settings.md
@@ -18,7 +18,7 @@ In the following example, we will set `heartbeat-interval` to 300 milliseconds a
 You can either configure these settings at deploy time by adding the configuration to your deploy-command, for example:
 
 ```text
-juju deploy charmed-etcd --channel 3.6/edge -n 3 --config heartbeat-interval=300 --config election-timeout=3000
+juju deploy charmed-etcd -n 3 --config heartbeat-interval=300 --config election-timeout=3000
 ```
 
 Or you can set them on your existing charmed etcd application by running `juju config <application-name>...`, for example:

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,12 +8,6 @@ Etcd is a distributed, reliable key-value store for the most critical data of di
 
 Charmed etcd is equipped with several features to securely store and scale complicated data workloads, including TLS encryption, horizontal scaling, password rotation, and easy integration with client applications.
 
-```{note}
-This new charm is still under development on the [`beta` track](https://charmhub.io/charmed-etcd?channel=3.6/beta). You're welcome to explore it and share your feedback as we continue to improve it.
-
-**Please wait for the upcoming stable release before deploying charmed etcd in production environments.**
-```
-
 ## In this documentation
 
 |                                                                                                        |                                                                                                      |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -15,5 +15,5 @@ The following guides contain technical specifications, release notes, and other 
 :titlesonly:
 :maxdepth: 2
 
-Versions <versions>
+Releases <releases>
 ```

--- a/docs/reference/releases.md
+++ b/docs/reference/releases.md
@@ -1,4 +1,4 @@
-# Charmed etcd versions
+# Charmed etcd releases
 
 Charmed etcd is shipped in the following [tracks](https://documentation.ubuntu.com/juju/3.6/reference/charm/#track): 
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -126,7 +126,7 @@ etcd   dev-controller  localhost/localhost  3.6.0    unsupported  17:26:15Z
 To deploy charmed etcd, all you need to do is run the following command:
 
 ```text
-juju deploy charmed-etcd -n 3 --channel 3.6/edge
+juju deploy charmed-etcd -n 3
 ```
 
 ```{note}


### PR DESCRIPTION
The PR adjusts the user documentation after the recent stable release:
- Rename the `releases` page
- Remove the information about `beta` status of the operator
- Remove `--channel 3.6/edge` from `deploy` commands (no longer required)