### PR TITLE
pin-juju-tf-provider

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
   unit-test:
     name: Unit test charm
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/terraform/charm/versions.tf
+++ b/terraform/charm/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0, <= 0.23.1"
+      version = ">= 0.20.0, <= 0.23.1"
     }
   }
 }

--- a/terraform/charm/versions.tf
+++ b/terraform/charm/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.14.0, <= 0.23.1"
     }
   }
 }

--- a/terraform/product/versions.tf
+++ b/terraform/product/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0, <= 0.23.1"
+      version = ">= 0.20.0, <= 0.23.1"
     }
   }
 }

--- a/terraform/product/versions.tf
+++ b/terraform/product/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.14.0, <= 0.23.1"
     }
   }
 }


### PR DESCRIPTION
## Description of issue or feature:
The recently released Terraform provider `1.0.0` for Juju includes a breaking change and breaks the Terraform tests in CI.

## Solution:
restrict Juju Terraform provider because of breaking change in 1.0.0

Unrelated Change:
- Because of apparently high load on infrastructure, unit tests have occasionally exceeded the 5 min timeout -> increase timeout to 10 mins.

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [X] Integration tests