### PR TITLE
switch s3 integrator channel in integration tests

### DIFF
--- a/terraform/charm/variables.tf
+++ b/terraform/charm/variables.tf
@@ -10,7 +10,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = "3.5/edge"
+  default     = "3.6/stable"
 }
 
 variable "base" {

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -8,7 +8,7 @@ variable "etcd" {
     model             = string
     base              = optional(string, "ubuntu@24.04")
     config            = optional(map(string), {})
-    channel           = optional(string, "3.5/edge")
+    channel           = optional(string, "3.6/stable")
     revision          = optional(string, null)
     units             = optional(number, 3)
     constraints       = optional(string, "arch=amd64")

--- a/tests/integration/backup/test_restore_verification_failed.py
+++ b/tests/integration/backup/test_restore_verification_failed.py
@@ -36,7 +36,7 @@ async def test_deploy_and_configure(
 ) -> None:
     """Deploy and configure the charm and s3-integrator."""
     await ops_test.model.deploy(charm, num_units=NUM_UNITS)
-    await ops_test.model.deploy(S3_INTEGRATOR, channel="latest/stable", num_units=1)
+    await ops_test.model.deploy(S3_INTEGRATOR, channel="1/stable", num_units=1)
     await wait_until(ops_test, apps=[S3_INTEGRATOR], apps_statuses=["blocked"])
 
     logger.info(f"Configure {S3_INTEGRATOR}")

--- a/tests/integration/backup/test_s3_backup_restore.py
+++ b/tests/integration/backup/test_s3_backup_restore.py
@@ -34,7 +34,7 @@ async def test_deploy_and_configure(
 ) -> None:
     """Deploy and configure the charm and s3-integrator."""
     await ops_test.model.deploy(charm, num_units=NUM_UNITS)
-    await ops_test.model.deploy(S3_INTEGRATOR, channel="latest/stable", num_units=1)
+    await ops_test.model.deploy(S3_INTEGRATOR, channel="1/stable", num_units=1)
     await wait_until(ops_test, apps=[S3_INTEGRATOR], apps_statuses=["blocked"])
 
     logger.info(f"Configure {S3_INTEGRATOR}")


### PR DESCRIPTION
## Description of issue or feature:
The s3 integrator in channel `latest/stable` is deprecated and will be discontinued in 2026.

## Solution:
Backup/restore integration tests: switch s3 integrator to channel `1/stable`.

Unrelated change:
- fix the default channel to deploy `charmed-etcd` in Terraform modules

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [X] Integration tests
