### PR TITLE
fix flakey unit test

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -967,7 +967,11 @@ def test_unit_removal():
         endpoint=STATUS_PEERS_RELATION,
     )
     data_storage = testing.Storage("data")
-    state_in = testing.State(storages=[data_storage], relations={relation, status_peer_relation})
+    state_in = testing.State(
+        storages=[data_storage],
+        relations={relation, status_peer_relation},
+        planned_units=1,
+    )
 
     # test the happy path
     with (


### PR DESCRIPTION
## Description of issue or feature:
Since recently, the unit test for removal of a unit started to fail (see [example1](https://github.com/canonical/charmed-etcd-operator/actions/runs/19054645842/job/54422242315) or [example 2](https://github.com/canonical/charmed-etcd-operator/actions/runs/19099391500/job/54567324710?pr=167#step:4:683)). The failure rate on CI was about 50%, but could not be reproduced locally.

## Solution:
The unit test's state needs to be set up more accurately to correctly test the expected workflow (10 out of 10 test runs succeeded).

## How was this change tested?
- [ ] Manually
- [X] Unit tests
- [ ] Integration tests