### PR TITLE
re-enable backup integration tests on arm

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -114,11 +114,6 @@ jobs:
         with:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
-      # TODO Remove pinned image when problem is resolved on jammy
-      - name: Pin lxc image for jammy
-        run: |
-          sudo lxc image copy ubuntu:568f69ff1166 local:
-          sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
       - name: Run spread job
         timeout-minutes: 60
         id: spread

--- a/tests/integration/backup/test_restore_verification_failed.py
+++ b/tests/integration/backup/test_restore_verification_failed.py
@@ -35,6 +35,9 @@ async def test_deploy_and_configure(
     charm: str, ops_test: OpsTest, storage_credentials, storage_config
 ) -> None:
     """Deploy and configure the charm and s3-integrator."""
+    # workaround for https://bugs.launchpad.net/snapd/+bug/2127244
+    await ops_test.model.set_config({"image-stream": "daily"})
+
     await ops_test.model.deploy(charm, num_units=NUM_UNITS)
     await ops_test.model.deploy(S3_INTEGRATOR, channel="1/stable", num_units=1)
     await wait_until(ops_test, apps=[S3_INTEGRATOR], apps_statuses=["blocked"])

--- a/tests/integration/backup/test_s3_backup_restore.py
+++ b/tests/integration/backup/test_s3_backup_restore.py
@@ -33,6 +33,7 @@ async def test_deploy_and_configure(
     charm: str, ops_test: OpsTest, storage_credentials, storage_config
 ) -> None:
     """Deploy and configure the charm and s3-integrator."""
+    # workaround for https://bugs.launchpad.net/snapd/+bug/2127244
     await ops_test.model.set_config({"image-stream": "daily"})
 
     await ops_test.model.deploy(charm, num_units=NUM_UNITS)

--- a/tests/integration/backup/test_s3_backup_restore.py
+++ b/tests/integration/backup/test_s3_backup_restore.py
@@ -33,6 +33,8 @@ async def test_deploy_and_configure(
     charm: str, ops_test: OpsTest, storage_credentials, storage_config
 ) -> None:
     """Deploy and configure the charm and s3-integrator."""
+    await ops_test.model.set_config({"image-stream": "daily"})
+
     await ops_test.model.deploy(charm, num_units=NUM_UNITS)
     await ops_test.model.deploy(S3_INTEGRATOR, channel="1/stable", num_units=1)
     await wait_until(ops_test, apps=[S3_INTEGRATOR], apps_statuses=["blocked"])

--- a/tests/spread/test_restore_verification_failed.py/task.yaml
+++ b/tests/spread/test_restore_verification_failed.py/task.yaml
@@ -3,9 +3,7 @@ environment:
   TEST_MODULE: backup/test_restore_verification_failed.py
 systems:
   - self-hosted-linux-amd64-noble-medium
-  # s3-integrator requires ubuntu22.04 which is broken and no workaround is known
-  # https://bugs.launchpad.net/snapd/+bug/2127244
-  # self-hosted-linux-arm64-noble-medium
+  - self-hosted-linux-arm64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/test_s3_backup_restore.py/task.yaml
+++ b/tests/spread/test_s3_backup_restore.py/task.yaml
@@ -3,9 +3,7 @@ environment:
   TEST_MODULE: backup/test_s3_backup_restore.py
 systems:
   - self-hosted-linux-amd64-noble-medium
-  # s3-integrator requires ubuntu22.04 which is broken and no workaround is known
-  # https://bugs.launchpad.net/snapd/+bug/2127244
-  # self-hosted-linux-arm64-noble-medium
+  - self-hosted-linux-arm64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:


### PR DESCRIPTION
## Description of issue or feature:
In https://github.com/canonical/charmed-etcd-operator/pull/169 the integration tests on arm for `backup_restore_s3` and `restore_verification` have been disabled. They can be enabled again when using a different workaround instead of pinning the lxd image.

## Solution:
Use daily image stream for jammy deployments.

## How was this change tested?
- [X] Manually
- [ ] Unit tests
- [X] Integration tests
