### PR TITLE
DO NOT MERGE: Test juju 4/candidate

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -160,6 +160,10 @@ jobs:
         timeout-minutes: 3
         if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
         run: sudo juju debug-log --color --replay --no-tail | tee ~/logs/juju-debug-log.txt
+      - name: juju controller-log
+        timeout-minutes: 3
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        run: sudo juju debug-log --model controller --color --replay --no-tail | tee ~/logs/juju-controller-log.txt
       - name: jhack tail
         timeout-minutes: 3
         if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}

--- a/spread.yaml
+++ b/spread.yaml
@@ -119,7 +119,7 @@ path: /root/spread_project
 kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
-  CONCIERGE_JUJU_CHANNEL: 3.6/stable
+  CONCIERGE_JUJU_CHANNEL: 4/candidate
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"


### PR DESCRIPTION
**THIS PR SHOULD NOT BE MERGED**

## Description of issue or feature:
Run integration tests against the release candidate of Juju 4.0

## Solution:
- Deploy Juju from channel `4/candidate`
- add output for the controller logs for better debugging

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [X] Integration tests