### PR TITLE
[DPE-8885] Unblock integration tests in CI

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -24,19 +24,24 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up environment
         run: |
-          sudo snap install charmcraft --classic
+          sudo snap install go --classic
+          go install github.com/snapcore/spread/cmd/spread@latest
           pipx install tox poetry
       - name: Collect spread jobs
         id: collect-jobs
         shell: python
         run: |
           import json
+          import pathlib
           import os
           import subprocess
 
           spread_jobs = (
               subprocess.run(
-                  ["charmcraft", "test", "--list", "github-ci"], capture_output=True, check=True, text=True
+                  [pathlib.Path.home() / "go/bin/spread", "-list", "github-ci"],
+                  capture_output=True,
+                  check=True,
+                  text=True,
               )
               .stdout.strip()
               .split("\n")

--- a/tests/integration/backup/test_restore_verification_failed.py
+++ b/tests/integration/backup/test_restore_verification_failed.py
@@ -46,13 +46,6 @@ async def test_deploy_and_configure(
     await ops_test.model.grant_secret(secret_name, S3_INTEGRATOR)
     await ops_test.model.applications[S3_INTEGRATOR].set_config({"credentials": secret_id})
     await ops_test.model.applications[S3_INTEGRATOR].set_config(storage_config)
-
-    s3_unit = ops_test.model.applications[S3_INTEGRATOR].units[0]
-    set_credentials_action = await s3_unit.run_action(
-        "sync-s3-credentials",
-        **storage_credentials,
-    )
-    await set_credentials_action.wait()
     await wait_until(ops_test, apps=[APP_NAME, S3_INTEGRATOR], apps_statuses=["active"])
 
 

--- a/tests/integration/backup/test_restore_verification_failed.py
+++ b/tests/integration/backup/test_restore_verification_failed.py
@@ -12,6 +12,7 @@ from statuses import BackupStatuses
 
 from ..helpers import (
     APP_NAME,
+    add_secret,
     get_cluster_endpoints,
     get_cluster_members,
     get_key,
@@ -35,14 +36,15 @@ async def test_deploy_and_configure(
     charm: str, ops_test: OpsTest, storage_credentials, storage_config
 ) -> None:
     """Deploy and configure the charm and s3-integrator."""
-    # workaround for https://bugs.launchpad.net/snapd/+bug/2127244
-    await ops_test.model.set_config({"image-stream": "daily"})
-
     await ops_test.model.deploy(charm, num_units=NUM_UNITS)
-    await ops_test.model.deploy(S3_INTEGRATOR, channel="1/stable", num_units=1)
+    await ops_test.model.deploy(S3_INTEGRATOR, channel="2/edge", num_units=1)
     await wait_until(ops_test, apps=[S3_INTEGRATOR], apps_statuses=["blocked"])
 
     logger.info(f"Configure {S3_INTEGRATOR}")
+    secret_name = "s3-credentials"
+    secret_id = await add_secret(ops_test, secret_name, storage_credentials)
+    await ops_test.model.grant_secret(secret_name, S3_INTEGRATOR)
+    await ops_test.model.applications[S3_INTEGRATOR].set_config({"credentials": secret_id})
     await ops_test.model.applications[S3_INTEGRATOR].set_config(storage_config)
 
     s3_unit = ops_test.model.applications[S3_INTEGRATOR].units[0]

--- a/tests/integration/backup/test_s3_backup_restore.py
+++ b/tests/integration/backup/test_s3_backup_restore.py
@@ -11,6 +11,7 @@ from literals import INTERNAL_USER
 
 from ..helpers import (
     APP_NAME,
+    add_secret,
     get_cluster_endpoints,
     get_key,
     put_key,
@@ -33,22 +34,16 @@ async def test_deploy_and_configure(
     charm: str, ops_test: OpsTest, storage_credentials, storage_config
 ) -> None:
     """Deploy and configure the charm and s3-integrator."""
-    # workaround for https://bugs.launchpad.net/snapd/+bug/2127244
-    await ops_test.model.set_config({"image-stream": "daily"})
-
     await ops_test.model.deploy(charm, num_units=NUM_UNITS)
-    await ops_test.model.deploy(S3_INTEGRATOR, channel="1/stable", num_units=1)
+    await ops_test.model.deploy(S3_INTEGRATOR, channel="2/edge", num_units=1)
     await wait_until(ops_test, apps=[S3_INTEGRATOR], apps_statuses=["blocked"])
 
     logger.info(f"Configure {S3_INTEGRATOR}")
+    secret_name = "s3-credentials"
+    secret_id = await add_secret(ops_test, secret_name, storage_credentials)
+    await ops_test.model.grant_secret(secret_name, S3_INTEGRATOR)
+    await ops_test.model.applications[S3_INTEGRATOR].set_config({"credentials": secret_id})
     await ops_test.model.applications[S3_INTEGRATOR].set_config(storage_config)
-
-    s3_unit = ops_test.model.applications[S3_INTEGRATOR].units[0]
-    set_credentials_action = await s3_unit.run_action(
-        "sync-s3-credentials",
-        **storage_credentials,
-    )
-    await set_credentials_action.wait()
     await wait_until(ops_test, apps=[APP_NAME, S3_INTEGRATOR], apps_statuses=["active"])
 
     logger.info("Configure admin credentials in etcd")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -338,11 +338,9 @@ async def add_secret(ops_test: OpsTest, secret_name: str, content: dict[str, str
         str: The secret ID.
     """
     assert ops_test.model is not None, "Model is not set"
-    return_code, std_out, std_err = await ops_test.juju(
-        "add-secret",
-        secret_name,
-        " ".join([f"{key}={value}" for key, value in content.items()]),
-    )
+    add_secret_cmd = ["add-secret", secret_name]
+    add_secret_cmd.extend([f"{key}={value}" for key, value in content.items()])
+    return_code, std_out, std_err = await ops_test.juju(*add_secret_cmd, check=True)
 
     assert return_code == 0, f"Failed to add secret: {std_err}"
     logger.info(f"Added secret {secret_name} to the model")


### PR DESCRIPTION
## Description of issue or feature:
Currently the integration test pipeline is failing and blocks any release. The PR fixes the issues and unblocks CI.

## Solution:
- Broken `collect-integration-tests` CI step: The release of charmcraft 4.0 removed the `--list` parameter from the `charmcraft test` command. We can replace `charmcraft test --list` with `spread -list`.

- Backup/Restore integration tests: The deployment of S3 integration on 22.04 once again fails. To avoid another encounters with this issue, we can instead deploy S3 integrator from the `2/edge` channel. This requires to configure credentials via user secrets.

## How was this change tested?
- [X] Manually
- [ ] Unit tests
- [X] Integration tests
