### PR TITLE
Add pydantic serialization exception for update client relations

### DIFF
--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -765,6 +765,7 @@ class EtcdEvents(Object):
         return ""
 
     def _update_client_relations(self) -> None:
+        """Update client relations data for external clients if TLS is enabled."""
         if self.charm.state.unit_server.tls_client_state == TLSState.TLS:
             try:
                 self.charm.external_clients_manager.update_client_relations_data(

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -19,6 +19,7 @@ from ops.charm import (
     RelationJoinedEvent,
 )
 from ops.model import ModelError, SecretNotFoundError
+from pydantic_core import PydanticSerializationError
 from requests.exceptions import RequestException
 
 from common.exceptions import (
@@ -769,5 +770,5 @@ class EtcdEvents(Object):
                 self.charm.external_clients_manager.update_client_relations_data(
                     etcd_version=self.charm.cluster_manager.get_version()
                 )
-            except KeyError as e:
-                logger.warning(f"Error updating client relations data: {e}")
+            except (KeyError, PydanticSerializationError) as e:
+                logger.error(f"Error updating client relations data: {e}")


### PR DESCRIPTION
## Description of issue or feature:
Fixes #187 
This pull request introduces improved error handling when updating client relations data in `src/events/etcd.py`. It adds support for catching serialization errors and logs them as errors rather than warnings.

## Solution:

* Added import of `PydanticSerializationError` from `pydantic_core` to handle serialization exceptions that may occur during client relations updates.
* Updated the `_update_client_relations` method to catch both `KeyError` and `PydanticSerializationError`, and changed the log level from warning to error for these exceptions.
* [Created an issue for the problem on data_interfaces](https://github.com/canonical/data-platform-libs/issues/251).

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [ ] Integration tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
