### PR TITLE
[DPE-8989] Bugfix: allow same TLS-provider as client application

### DIFF
--- a/lib/charms/data_platform_libs/v1/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v1/data_interfaces.py
@@ -2400,12 +2400,7 @@ class ResourceProviderEventHandler(EventHandlers, Generic[TRequirerCommonModel])
         repository = OpsRelationRepository(self.model, relation, component=relation.app)
         version = repository.get_field("version") or "v0"
 
-        try:
-            old_mtls_cert = event.secret.get_content().get("mtls-cert")
-        except ModelError as e:
-            logging.warning("Could not retrieve old mtls-cert: %s", e)
-            old_mtls_cert = None
-
+        old_mtls_cert = event.secret.get_content(refresh=True).get("mtls-cert")
         logger.info("mtls-cert-updated")
 
         # V0, just fire the event.

--- a/lib/charms/data_platform_libs/v1/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v1/data_interfaces.py
@@ -2400,7 +2400,12 @@ class ResourceProviderEventHandler(EventHandlers, Generic[TRequirerCommonModel])
         repository = OpsRelationRepository(self.model, relation, component=relation.app)
         version = repository.get_field("version") or "v0"
 
-        old_mtls_cert = event.secret.get_content().get("mtls-cert")
+        try:
+            old_mtls_cert = event.secret.get_content().get("mtls-cert")
+        except ModelError as e:
+            logging.warning("Could not retrieve old mtls-cert: %s", e)
+            old_mtls_cert = None
+
         logger.info("mtls-cert-updated")
 
         # V0, just fire the event.

--- a/lib/charms/data_platform_libs/v1/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v1/data_interfaces.py
@@ -2400,7 +2400,12 @@ class ResourceProviderEventHandler(EventHandlers, Generic[TRequirerCommonModel])
         repository = OpsRelationRepository(self.model, relation, component=relation.app)
         version = repository.get_field("version") or "v0"
 
-        old_mtls_cert = event.secret.get_content(refresh=True).get("mtls-cert")
+        try:
+            old_mtls_cert = event.secret.get_content().get("mtls-cert")
+        except ModelError as e:
+            logger.warning("Could not get old mtls-cert: %s", e)
+            old_mtls_cert = None
+
         logger.info("mtls-cert-updated")
 
         # V0, just fire the event.

--- a/src/charm.py
+++ b/src/charm.py
@@ -354,15 +354,14 @@ class EtcdOperatorCharm(ops.CharmBase):
                     component_name=self.cluster_manager.name,
                     statuses_state=self.state.statuses,
                 )
-                return
             except CalledProcessError:
                 logger.warning("Health check failed, TLS client certificates expired")
-
-        self.state.statuses.delete(
-            ClusterStatuses.RESTART_FAILED.value,
-            scope="unit",
-            component=self.cluster_manager.name,
-        )
+        else:
+            self.state.statuses.delete(
+                ClusterStatuses.RESTART_FAILED.value,
+                scope="unit",
+                component=self.cluster_manager.name,
+            )
 
         if self.state.unit_server.tls_peer_ca_rotation_state == TLSCARotationState.NEW_CA_DETECTED:
             self.tls_manager.set_ca_rotation_state(TLSType.PEER, TLSCARotationState.NEW_CA_ADDED)

--- a/src/events/etcd.py
+++ b/src/events/etcd.py
@@ -771,5 +771,7 @@ class EtcdEvents(Object):
                 self.charm.external_clients_manager.update_client_relations_data(
                     etcd_version=self.charm.cluster_manager.get_version()
                 )
+            # Pydantic serialization error: temporary workaround because of
+            # https://github.com/canonical/data-platform-libs/issues/251
             except (KeyError, PydanticSerializationError) as e:
                 logger.error(f"Error updating client relations data: {e}")

--- a/src/events/external_clients.py
+++ b/src/events/external_clients.py
@@ -364,7 +364,7 @@ class ExternalClientsEvents(Object):
         if all_cas != self.charm.tls_manager.load_trusted_ca(TLSType.CLIENT):
             logger.debug("CAs have changed, updating client truststore")
             self.charm.tls_manager.update_cas(all_cas, TLSType.CLIENT)
-            self.charm.rolling_restart()
+            self.charm.rolling_restart("_restart_ca_rotation")
 
     def _exists_preventing_reason(self) -> bool:
         """Check if there is any reason preventing handling external clients relations.

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -21,6 +21,7 @@ from ops import (
     SecretChangedEvent,
 )
 from ops.framework import EventBase, Object
+from pydantic_core import PydanticSerializationError
 
 from literals import (
     CLIENT_TLS_RELATION_NAME,
@@ -252,7 +253,9 @@ class TLSEvents(Object):
                         self.charm.external_clients_manager.update_client_relations_data(
                             etcd_version=self.charm.cluster_manager.get_version()
                         )
-                    except KeyError as e:
+                    # Pydantic serialization error: temporary workaround because of
+                    # https://github.com/canonical/data-platform-libs/issues/251
+                    except (KeyError, PydanticSerializationError) as e:
                         logger.warning(f"Error updating client relations data: {e}")
             self.clean_ca_event.emit(cert_type=cert_type)
             return

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -177,10 +177,7 @@ class TLSManager(ManagerStatusProtocol):
                 if cert_type == TLSType.PEER
                 else server.tls_client_ca_rotation_state
             )
-            if server_ca_rotation_state in [
-                TLSCARotationState.NO_ROTATION,
-                TLSCARotationState.NEW_CA_DETECTED,
-            ]:
+            if server_ca_rotation_state == TLSCARotationState.NEW_CA_DETECTED:
                 return False
         return True
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -172,12 +172,18 @@ class TLSManager(ManagerStatusProtocol):
             cert_type (TLSType): The certificate type.
         """
         for server in self.state.servers:
-            server_ca_rotation_state = (
-                server.tls_peer_ca_rotation_state
-                if cert_type == TLSType.PEER
-                else server.tls_client_ca_rotation_state
-            )
-            if server_ca_rotation_state == TLSCARotationState.NEW_CA_DETECTED:
+            if cert_type == TLSType.PEER and server.tls_peer_ca_rotation_state in [
+                TLSCARotationState.NO_ROTATION,
+                TLSCARotationState.NEW_CA_DETECTED,
+            ]:
+                return False
+
+            # not all units must be in CA rotation state for client TLS because
+            # the client CA might already have been updated via the client relation
+            if (
+                cert_type == TLSType.CLIENT
+                and server.tls_client_ca_rotation_state == TLSCARotationState.NEW_CA_DETECTED
+            ):
                 return False
         return True
 

--- a/tests/integration/client_relations/test_client_relations.py
+++ b/tests/integration/client_relations/test_client_relations.py
@@ -360,7 +360,7 @@ async def test_different_tls_providers(ops_test: OpsTest) -> None:
     model = ops_test.model_full_name
 
     logger.info("Remove TLS relation for requirer.")
-    await requirer_app.remove_relation("tls-certificates", f"{TLS_NAME}:tls-certificates")
+    await requirer_app.remove_relation("certificates", f"{TLS_NAME}:certificates")
     await wait_until(ops_test, apps=[REQUIRER_NAME], idle_period=10)
 
     logger.info("Integrate requirer with different TLS provider and etcd again.")

--- a/tests/integration/client_relations/test_client_relations.py
+++ b/tests/integration/client_relations/test_client_relations.py
@@ -122,7 +122,7 @@ async def test_build_and_deploy(
     logger.info("Integrating peer-certificates and client-certificates relations")
     await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", TLS_NAME)
     await ops_test.model.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
-    await ops_test.model.integrate(REQUIRER_NAME, REQUIRER_TLS_NAME)
+    await ops_test.model.integrate(REQUIRER_NAME, TLS_NAME)
     await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME, TLS_NAME, REQUIRER_TLS_NAME])
 
 

--- a/tests/integration/client_relations/test_client_relations.py
+++ b/tests/integration/client_relations/test_client_relations.py
@@ -353,6 +353,64 @@ async def test_remove_client_relation(ops_test: OpsTest) -> None:
 @pytest.mark.abort_on_fail
 @pytest.mark.v0
 @pytest.mark.v1
+async def test_different_tls_providers(ops_test: OpsTest) -> None:
+    """Ensure a CA rotation also works when using separate TLS providers."""
+    requirer_app: Application = ops_test.model.applications[REQUIRER_NAME]
+    requirer_unit: Unit = requirer_app.units[0]
+    model = ops_test.model_full_name
+
+    logger.info("Remove TLS relation for requirer.")
+    await requirer_app.remove_relation("tls-certificates", f"{TLS_NAME}:tls-certificates")
+    await wait_until(ops_test, apps=[REQUIRER_NAME], idle_period=10)
+
+    logger.info("Integrate requirer with different TLS provider and etcd again.")
+    await ops_test.model.integrate(REQUIRER_NAME, REQUIRER_TLS_NAME)
+    await ops_test.model.integrate(APP_NAME, REQUIRER_NAME)
+    await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME], idle_period=10)
+
+    logger.info("Getting current server ca")
+    action = await requirer_unit.run_action("get-credentials")
+    action = await action.wait()
+
+    assert action.status == "completed", "Action should succeed"
+    old_ca = action.results["tls-ca"]
+
+    # Update common name on TLS provider for etcd
+    logger.info("Updating common name on TLS provider")
+    tls_operator: Application = ops_test.model.applications[TLS_NAME]
+    await tls_operator.set_config({"ca-common-name": "EVEN_NEWER_CA"})
+
+    # wait for model to settle
+    await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME, TLS_NAME])
+
+    logger.info("Getting new server ca")
+    action = await requirer_unit.run_action("get-credentials")
+    action = await action.wait()
+    assert action.status == "completed", "Action should succeed"
+    new_ca = action.results["tls-ca"]
+    assert old_ca != new_ca, "CA should be updated"
+
+    logger.info("Ensure updated mtls-certs are trusted on etcd")
+    mtls_certs = await get_requirer_mtls_certificates(ops_test)
+    assert mtls_certs, "failed to get the new mtls certs from requirer TLS provider"
+
+    for unit in ops_test.model.applications[APP_NAME].units:
+        client_cas = get_certificate_from_unit(model, unit.name, TLSType.CLIENT, is_ca=True)
+        for mtls_cert in mtls_certs:
+            assert mtls_cert in client_cas, f"new mtls cert not in trusted CAs for {unit.name}"
+
+    logger.info("Removing client relation")
+    await requirer_app.remove_relation(
+        EXTERNAL_CLIENTS_RELATION, f"{APP_NAME}:{EXTERNAL_CLIENTS_RELATION}"
+    )
+
+    # wait for model to settle
+    await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME])
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.v0
+@pytest.mark.v1
 async def test_certificate_transfer(ops_test: OpsTest) -> None:
     """Test if the certificate transfer interface works correctly."""
     # integrate etcd with requirer tls provider on certificate_transfer relation

--- a/tests/integration/client_relations/test_client_relations.py
+++ b/tests/integration/client_relations/test_client_relations.py
@@ -122,7 +122,7 @@ async def test_build_and_deploy(
     logger.info("Integrating peer-certificates and client-certificates relations")
     await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", TLS_NAME)
     await ops_test.model.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
-    await ops_test.model.integrate(REQUIRER_NAME, REQUIRER_TLS_NAME)
+    await ops_test.model.integrate(REQUIRER_NAME, TLS_NAME)
     await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME, TLS_NAME, REQUIRER_TLS_NAME])
 
 
@@ -247,7 +247,7 @@ async def test_update_mtls_cert(ops_test: OpsTest) -> None:
 @pytest.mark.abort_on_fail
 @pytest.mark.v0
 @pytest.mark.v1
-async def test_updates_ca_certificates(ops_test: OpsTest) -> None:
+async def test_update_ca_certificates(ops_test: OpsTest) -> None:
     """Update the common name used by the requirer app."""
     requirer_app: Application = ops_test.model.applications[REQUIRER_NAME]
     requirer_unit: Unit = requirer_app.units[0]
@@ -261,17 +261,14 @@ async def test_updates_ca_certificates(ops_test: OpsTest) -> None:
     assert action.status == "completed", "Action should succeed"
     old_ca = action.results["tls-ca"]
 
-    # Update common name on TLS provider for etcd
+    # Update common name on TLS provider for etcd and the client application
     logger.debug("Updating common name on TLS provider")
 
-    etcd_tls_operator: Application = ops_test.model.applications[TLS_NAME]
-    await etcd_tls_operator.set_config({"ca-common-name": "NEW_CN_CA"})
-
-    requirer_tls_operator: Application = ops_test.model.applications[REQUIRER_TLS_NAME]
-    await requirer_tls_operator.set_config({"ca-common-name": "NEW_CN_CA"})
+    tls_operator: Application = ops_test.model.applications[TLS_NAME]
+    await tls_operator.set_config({"ca-common-name": "NEW_CN_CA"})
 
     # wait for model to settle
-    await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME, TLS_NAME, REQUIRER_TLS_NAME])
+    await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME, TLS_NAME])
 
     logger.debug("Getting new server ca")
     action = await requirer_unit.run_action("get-credentials")

--- a/tests/integration/client_relations/test_client_relations.py
+++ b/tests/integration/client_relations/test_client_relations.py
@@ -363,8 +363,11 @@ async def test_different_tls_providers(ops_test: OpsTest) -> None:
     await requirer_app.remove_relation("certificates", f"{TLS_NAME}:certificates")
     await wait_until(ops_test, apps=[REQUIRER_NAME], idle_period=10)
 
-    logger.info("Integrate requirer with different TLS provider and etcd again.")
+    logger.info("Integrate requirer with different TLS provider.")
     await ops_test.model.integrate(REQUIRER_NAME, REQUIRER_TLS_NAME)
+    await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME], idle_period=10)
+
+    logger.info("Integrate requirer with etcd again.")
     await ops_test.model.integrate(APP_NAME, REQUIRER_NAME)
     await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME], idle_period=10)
 

--- a/tests/integration/client_relations/test_client_relations.py
+++ b/tests/integration/client_relations/test_client_relations.py
@@ -356,7 +356,6 @@ async def test_remove_client_relation(ops_test: OpsTest) -> None:
 async def test_different_tls_providers(ops_test: OpsTest) -> None:
     """Ensure a CA rotation also works when using separate TLS providers."""
     requirer_app: Application = ops_test.model.applications[REQUIRER_NAME]
-    requirer_unit: Unit = requirer_app.units[0]
     model = ops_test.model_full_name
 
     logger.info("Remove TLS relation for requirer.")

--- a/tests/integration/client_relations/test_client_relations.py
+++ b/tests/integration/client_relations/test_client_relations.py
@@ -380,7 +380,7 @@ async def test_different_tls_providers(ops_test: OpsTest) -> None:
 
     # Update common name on TLS provider for etcd
     logger.info("Updating common name on TLS provider")
-    tls_operator: Application = ops_test.model.applications[TLS_NAME]
+    tls_operator: Application = ops_test.model.applications[REQUIRER_TLS_NAME]
     await tls_operator.set_config({"ca-common-name": "EVEN_NEWER_CA"})
 
     # wait for model to settle

--- a/tests/integration/client_relations/test_client_relations.py
+++ b/tests/integration/client_relations/test_client_relations.py
@@ -371,27 +371,13 @@ async def test_different_tls_providers(ops_test: OpsTest) -> None:
     await ops_test.model.integrate(APP_NAME, REQUIRER_NAME)
     await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME], idle_period=10)
 
-    logger.info("Getting current server ca")
-    action = await requirer_unit.run_action("get-credentials")
-    action = await action.wait()
-
-    assert action.status == "completed", "Action should succeed"
-    old_ca = action.results["tls-ca"]
-
-    # Update common name on TLS provider for etcd
+    # Update common name on TLS provider for client application
     logger.info("Updating common name on TLS provider")
     tls_operator: Application = ops_test.model.applications[REQUIRER_TLS_NAME]
     await tls_operator.set_config({"ca-common-name": "EVEN_NEWER_CA"})
 
     # wait for model to settle
     await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME, TLS_NAME])
-
-    logger.info("Getting new server ca")
-    action = await requirer_unit.run_action("get-credentials")
-    action = await action.wait()
-    assert action.status == "completed", "Action should succeed"
-    new_ca = action.results["tls-ca"]
-    assert old_ca != new_ca, "CA should be updated"
 
     logger.info("Ensure updated mtls-certs are trusted on etcd")
     mtls_certs = await get_requirer_mtls_certificates(ops_test)

--- a/tests/integration/client_relations/test_client_relations.py
+++ b/tests/integration/client_relations/test_client_relations.py
@@ -122,7 +122,7 @@ async def test_build_and_deploy(
     logger.info("Integrating peer-certificates and client-certificates relations")
     await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", TLS_NAME)
     await ops_test.model.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
-    await ops_test.model.integrate(REQUIRER_NAME, TLS_NAME)
+    await ops_test.model.integrate(REQUIRER_NAME, REQUIRER_TLS_NAME)
     await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME, TLS_NAME, REQUIRER_TLS_NAME])
 
 
@@ -216,11 +216,11 @@ async def test_update_mtls_cert(ops_test: OpsTest) -> None:
     """Test updating the common name used by the requirer app."""
     old_mtls_certs = await get_requirer_mtls_certificates(ops_test)
     assert old_mtls_certs, "failed to get the old mtls certs from requirer TLS provider"
-    # run juju action to update the common name
     requirer_unit: Unit = ops_test.model.applications[REQUIRER_NAME].units[0]
 
+    # run juju action to update the mtls-certificate
     action = await requirer_unit.run_action("update-mtls-certs")
-    action = await action.wait()
+    await action.wait()
 
     # wait for model to settle
     await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME], idle_period=10)
@@ -247,10 +247,11 @@ async def test_update_mtls_cert(ops_test: OpsTest) -> None:
 @pytest.mark.abort_on_fail
 @pytest.mark.v0
 @pytest.mark.v1
-async def test_etcd_updates_ca(ops_test: OpsTest) -> None:
+async def test_updates_ca_certificates(ops_test: OpsTest) -> None:
     """Update the common name used by the requirer app."""
     requirer_app: Application = ops_test.model.applications[REQUIRER_NAME]
     requirer_unit: Unit = requirer_app.units[0]
+    model = ops_test.model_full_name
 
     logger.debug("Getting current server ca")
     # write to the key prefix
@@ -266,8 +267,11 @@ async def test_etcd_updates_ca(ops_test: OpsTest) -> None:
     etcd_tls_operator: Application = ops_test.model.applications[TLS_NAME]
     await etcd_tls_operator.set_config({"ca-common-name": "NEW_CN_CA"})
 
+    requirer_tls_operator: Application = ops_test.model.applications[REQUIRER_TLS_NAME]
+    await requirer_tls_operator.set_config({"ca-common-name": "NEW_CN_CA"})
+
     # wait for model to settle
-    await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME, TLS_NAME])
+    await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME, TLS_NAME, REQUIRER_TLS_NAME])
 
     logger.debug("Getting new server ca")
     action = await requirer_unit.run_action("get-credentials")
@@ -277,6 +281,15 @@ async def test_etcd_updates_ca(ops_test: OpsTest) -> None:
     new_ca = action.results["tls-ca"]
 
     assert old_ca != new_ca, "CA should be updated"
+
+    logger.info("Ensure updated mtls-certs are trusted on etcd")
+    mtls_certs = await get_requirer_mtls_certificates(ops_test)
+    assert mtls_certs, "failed to get the new mtls certs from requirer TLS provider"
+
+    for unit in ops_test.model.applications[APP_NAME].units:
+        client_cas = get_certificate_from_unit(model, unit.name, TLSType.CLIENT, is_ca=True)
+        for mtls_cert in mtls_certs:
+            assert mtls_cert in client_cas, f"new mtls cert not in trusted CAs for {unit.name}"
 
 
 @pytest.mark.abort_on_fail

--- a/tests/unit/test_external_client_relations.py
+++ b/tests/unit/test_external_client_relations.py
@@ -840,7 +840,7 @@ def test_ecr_relation_broken_leader(cluster_tls_context, mtls_cert):
         patch("common.client.EtcdClient.remove_user") as remove_user,
         patch("managers.tls.TLSManager.collect_client_cas") as collect_client_cas,
         patch("managers.tls.TLSManager.update_cas") as update_cas,
-        patch("charm.EtcdOperatorCharm._restart") as restart,
+        patch("charm.EtcdOperatorCharm._restart_ca_rotation") as restart,
         patch("managers.tls.TLSManager.load_trusted_ca", return_value={mtls_cert}),
     ):
         manager.run()
@@ -1559,7 +1559,7 @@ def test_removing_user_crash(cluster_tls_context, mtls_cert):
         patch("common.client.EtcdClient.remove_user") as remove_user,
         patch("managers.tls.TLSManager.collect_client_cas") as collect_client_cas,
         patch("managers.tls.TLSManager.update_cas") as update_cas,
-        patch("charm.EtcdOperatorCharm._restart") as restart,
+        patch("charm.EtcdOperatorCharm._restart_ca_rotation") as restart,
     ):
         remove_user.side_effect = EtcdUserManagementError(
             "User could not be removed from etcd cluster"

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1148,24 +1148,6 @@ def test_ca_peer_rotation(certificate_available_context):
             "tls-peer-state": "tls",
             "state": "started",
         },
-        peers_data={
-            1: {
-                "private-ip": "localhost",
-                "client-cert-ready": "True",
-                "peer-cert-ready": "True",
-                "tls-client-state": "tls",
-                "tls-peer-state": "tls",
-                "tls-peer-ca-rotation": "new-ca-detected",
-            },
-            2: {
-                "private-ip": "localhost",
-                "client-cert-ready": "True",
-                "peer-cert-ready": "True",
-                "tls-client-state": "tls",
-                "tls-peer-state": "tls",
-                "tls-peer-ca-rotation": "new-ca-detected",
-            },
-        },
     )
     ctx = testing.Context(EtcdOperatorCharm)
     state_in = testing.State(

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1148,6 +1148,24 @@ def test_ca_peer_rotation(certificate_available_context):
             "tls-peer-state": "tls",
             "state": "started",
         },
+        peers_data={
+            1: {
+                "private-ip": "localhost",
+                "client-cert-ready": "True",
+                "peer-cert-ready": "True",
+                "tls-client-state": "tls",
+                "tls-peer-state": "tls",
+                "tls-peer-ca-rotation": "new-ca-detected",
+            },
+            2: {
+                "private-ip": "localhost",
+                "client-cert-ready": "True",
+                "peer-cert-ready": "True",
+                "tls-client-state": "tls",
+                "tls-peer-state": "tls",
+                "tls-peer-ca-rotation": "new-ca-detected",
+            },
+        },
     )
     ctx = testing.Context(EtcdOperatorCharm)
     state_in = testing.State(
@@ -1365,6 +1383,24 @@ def test_ca_client_rotation(certificate_available_context):
             "tls-client-state": "tls",
             "tls-peer-state": "tls",
             "state": "started",
+        },
+        peers_data={
+            1: {
+                "private-ip": "localhost",
+                "client-cert-ready": "True",
+                "peer-cert-ready": "True",
+                "tls-client-state": "tls",
+                "tls-peer-state": "tls",
+                "tls-client-ca-rotation": "new-ca-detected",
+            },
+            2: {
+                "private-ip": "localhost",
+                "client-cert-ready": "True",
+                "peer-cert-ready": "True",
+                "tls-client-state": "tls",
+                "tls-peer-state": "tls",
+                "tls-client-ca-rotation": "new-ca-detected",
+            },
         },
     )
     ctx = testing.Context(EtcdOperatorCharm)


### PR DESCRIPTION
This PR addresses #189 

## Description of issue or feature:
If charmed-etcd and a client application share the same TLS provider and a CA-rotation happens, there are multiple issues because of the interfering events:

1) Interfering access from client and etcd on the `mtls-cert` secret if the client uses data-interfaces v0
This results in etcd running into `hook failed: "secret-changed"` with the following error:
```
ops.model.ModelError: ERROR getting latest secret revision: secret label "etcd-client.10.2e72e7f4350be731.mtls.secret" for consumer "unit-charmed-etcd-0" already exists
```
This is possibly a data-interfaces v1 issue (see https://github.com/canonical/data-platform-libs/issues/252), or even a Juju issue.

2) Client CA not recognized as a "new" CA
A unit of etcd might receive the renewed CA first from the client application before it receives it from the TLS provider. It will add the new CA to its client truststore already. When the "new" CA is received in the  `certificate_available` event, it will not be recognized as such, and the unit will therefore not participate in the CA rotation of the cluster. The CA rotation then gets stuck and never completes.

3) Restarts interfere with each other
If multiple rolling restarts are requested at the same time, rolling ops will only send one callback per unit. That means, if etcd requests a restart because of CA rotation and, at the same time, a new client application CA also requires/requests a restart, one of the restart requests gets lost. This is known behavior, see [rolling_ops](https://github.com/canonical/charmed-etcd-operator/blob/3.6/edge/lib/charms/rolling_ops/v0/rollingops.py#L146).

## Solution:
1) Temporary fix for the `secret_changed` event handler in data-interfaces v1 until issue https://github.com/canonical/data-platform-libs/issues/252 is resolved.

2) Adjustment to the `is_new_ca_saved_on_all_servers` check in the `TLSManager`: units with no CA rotation are ignored (in case of client TLS).

3) Consider the restart request issued when updating the client mtls-certs a "ca_rotation_restart", because it also loads the truststore and can continue the ca-rotation workflow if it happens at the same time.

## Drive-by changes:
In the fashion of #188: add temporary workaround for Pydantic serialization issues. These can also occur when updating client relation data because of changes on TLS. This workaround will be removed when https://github.com/canonical/data-platform-libs/issues/251 is fixed.

## How was this change tested?
- [X] Manually
- [X] Unit tests
- [X] Integration tests

Integration test coverage has been adjusted: Client applications now use the same TLS provider as etcd to ensure a deployment scenario close to possible production setup.
