### PR TITLE
[DPE-9136] test: rewrites backup integration tests with jubilant

### DIFF
--- a/tests/integration/backup/test_restore_verification_failed.py
+++ b/tests/integration/backup/test_restore_verification_failed.py
@@ -138,7 +138,7 @@ async def test_restore_verification_failed(juju_lxd_model: Juju):
     restore_backup_response = juju_lxd_model.run(
         leader_unit, "restore", params={"backup-id": backup_id}
     )
-    assert restore_backup_response.results.get("return-code") == 0, "restore action failed"
+    assert restore_backup_response.return_code == 0, "restore action failed"
 
     # the restore will fail because the current password is not valid for the backup-file
     juju_lxd_model.wait(

--- a/tests/integration/backup/test_restore_verification_failed.py
+++ b/tests/integration/backup/test_restore_verification_failed.py
@@ -5,22 +5,22 @@
 import logging
 
 import pytest
-from pytest_operator.plugin import OpsTest
+from jubilant import Juju
 
 from literals import INTERNAL_USER, PEER_RELATION
 from statuses import BackupStatuses
 
 from ..helpers import (
     APP_NAME,
-    add_secret,
-    get_cluster_endpoints,
+    get_cluster_endpoints_jubilant,
     get_cluster_members,
     get_key,
-    get_secret_by_label,
+    get_leader_unit_name,
+    get_secret_by_label_jubilant,
     put_key,
-    set_password,
+    set_password_jubilant,
 )
-from ..helpers_deployment import wait_until
+from ..helpers_deployment import apps_active_and_agents_idle, does_status_match
 
 logger = logging.getLogger(__name__)
 
@@ -33,31 +33,40 @@ backup_id = ""
 
 @pytest.mark.abort_on_fail
 async def test_deploy_and_configure(
-    charm: str, ops_test: OpsTest, storage_credentials, storage_config
+    charm: str, juju_lxd_model: Juju, storage_credentials, storage_config
 ) -> None:
     """Deploy and configure the charm and s3-integrator."""
-    await ops_test.model.deploy(charm, num_units=NUM_UNITS)
-    await ops_test.model.deploy(S3_INTEGRATOR, channel="2/edge", num_units=1)
-    await wait_until(ops_test, apps=[S3_INTEGRATOR], apps_statuses=["blocked"])
+    juju_lxd_model.deploy(charm, num_units=NUM_UNITS)
+    juju_lxd_model.deploy(S3_INTEGRATOR, channel="2/edge", num_units=1)
+    juju_lxd_model.wait(
+        lambda status: does_status_match(
+            status, expected_app_statuses={S3_INTEGRATOR: ["blocked"]}
+        )
+    )
 
     logger.info(f"Configure {S3_INTEGRATOR}")
     secret_name = "s3-credentials"
-    secret_id = await add_secret(ops_test, secret_name, storage_credentials)
-    await ops_test.model.grant_secret(secret_name, S3_INTEGRATOR)
-    await ops_test.model.applications[S3_INTEGRATOR].set_config({"credentials": secret_id})
-    await ops_test.model.applications[S3_INTEGRATOR].set_config(storage_config)
-    await wait_until(ops_test, apps=[APP_NAME, S3_INTEGRATOR], apps_statuses=["active"])
+    secret_uri = juju_lxd_model.add_secret(secret_name, storage_credentials)
+    juju_lxd_model.grant_secret(secret_uri, S3_INTEGRATOR)
+    juju_lxd_model.config(S3_INTEGRATOR, values={"credentials": secret_uri})
+    juju_lxd_model.config(S3_INTEGRATOR, storage_config)
+    juju_lxd_model.wait(
+        lambda status: does_status_match(
+            status, expected_app_statuses={APP_NAME: ["active"], S3_INTEGRATOR: ["active"]}
+        )
+    )
 
 
 @pytest.mark.abort_on_fail
-async def test_s3_integration(ops_test: OpsTest, s3_bucket) -> None:
+async def test_s3_integration(juju_lxd_model: Juju, s3_bucket) -> None:
     """Integrate charm and s3-integrator."""
-    await ops_test.model.integrate(APP_NAME, S3_INTEGRATOR)
-    await wait_until(
-        ops_test,
-        apps=[APP_NAME, S3_INTEGRATOR],
-        apps_statuses=["active"],
-        units_statuses=["active"],
+    juju_lxd_model.integrate(APP_NAME, S3_INTEGRATOR)
+    juju_lxd_model.wait(
+        lambda status: does_status_match(
+            status,
+            expected_app_statuses={APP_NAME: ["active"], S3_INTEGRATOR: ["active"]},
+            expected_unit_statuses={APP_NAME: ["active"], S3_INTEGRATOR: ["active"]},
+        )
     )
 
     # bucket should be created when integrating both
@@ -65,14 +74,14 @@ async def test_s3_integration(ops_test: OpsTest, s3_bucket) -> None:
 
 
 @pytest.mark.abort_on_fail
-async def test_create_backup(ops_test: OpsTest) -> None:
+async def test_create_backup(juju_lxd_model: Juju) -> None:
     """Create a backup and upload to s3-storage."""
     global backup_id
 
     # Before creating a backup, enter some data
-    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
+    secret = get_secret_by_label_jubilant(juju_lxd_model, label=f"{PEER_RELATION}.{APP_NAME}.app")
     initial_password = secret.get(f"{INTERNAL_USER}-password")
-    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    endpoints = get_cluster_endpoints_jubilant(juju_lxd_model, APP_NAME)
     assert (
         put_key(
             endpoints,
@@ -88,21 +97,17 @@ async def test_create_backup(ops_test: OpsTest) -> None:
         == TEST_VALUE
     )
 
-    for unit in ops_test.model.applications[APP_NAME].units:
-        if await unit.is_leader_from_status():
-            leader_unit = unit
-    logger.info(f"Creating backup on unit {leader_unit.name}")
+    leader_unit = get_leader_unit_name(juju_lxd_model, APP_NAME)
+    logger.info(f"Creating backup on unit {leader_unit}")
 
     # `create-backup` will upload the backup to storage
-    create_action = await leader_unit.run_action("create-backup")
-    create_backup_response = await create_action.wait()
+    create_backup_response = juju_lxd_model.run(leader_unit, "create-backup")
 
     backup_id = create_backup_response.results.get("backup-id", "")
     assert backup_id, "No backup-id in response"
 
     # `list-backups` will look up the backups in storage
-    list_action = await leader_unit.run_action("list-backups")
-    list_backups_response = await list_action.wait()
+    list_backups_response = juju_lxd_model.run(leader_unit, "list-backups")
     backups = list_backups_response.results.get("backups", "")
     # example: 'backup-id | backup-status\n--------------------\n2025-04-01T08:40:45Z  | finished'
     assert backups.split("\n")[2].startswith(backup_id), (
@@ -117,34 +122,36 @@ async def test_create_backup(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.abort_on_fail
-async def test_restore_verification_failed(ops_test: OpsTest):
+async def test_restore_verification_failed(juju_lxd_model: Juju):
     """Restore a backup with invalid admin password."""
     logger.info("Configure admin credentials in etcd")
     invalid_password = "invalid_password"
-    await set_password(ops_test, invalid_password)
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+    set_password_jubilant(juju_lxd_model, invalid_password)
+    juju_lxd_model.wait(
+        lambda status: apps_active_and_agents_idle(status, APP_NAME, unit_count=NUM_UNITS)
+    )
 
-    for unit in ops_test.model.applications[APP_NAME].units:
-        if await unit.is_leader_from_status():
-            leader_unit = unit
+    leader_unit = get_leader_unit_name(juju_lxd_model, APP_NAME)
 
     # download the backup from storage and try to restore it
     logger.info(f"Restoring backup {backup_id}")
-    restore_action = await leader_unit.run_action("restore", **{"backup-id": backup_id})
-    restore_backup_response = await restore_action.wait()
+    restore_backup_response = juju_lxd_model.run(
+        leader_unit, "restore", params={"backup-id": backup_id}
+    )
     assert restore_backup_response.results.get("return-code") == 0, "restore action failed"
 
     # the restore will fail because the current password is not valid for the backup-file
-    await wait_until(
-        ops_test,
-        apps=[APP_NAME],
-        units_full_statuses={
-            APP_NAME: [BackupStatuses.RESTORE_VERIFICATION_FAILED.value],
-        },
+    juju_lxd_model.wait(
+        lambda status: does_status_match(
+            status,
+            expected_unit_statuses={
+                APP_NAME: [BackupStatuses.RESTORE_VERIFICATION_FAILED.value],
+            },
+        )
     )
 
     # ensure test data was not restored
-    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    endpoints = get_cluster_endpoints_jubilant(juju_lxd_model, APP_NAME)
     assert not (
         get_key(endpoints, user=INTERNAL_USER, password=invalid_password, key=TEST_KEY)
         == TEST_VALUE

--- a/tests/integration/backup/test_restore_verification_failed.py
+++ b/tests/integration/backup/test_restore_verification_failed.py
@@ -32,7 +32,7 @@ backup_id = ""
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_and_configure(
+def test_deploy_and_configure(
     charm: str, juju_lxd_model: Juju, storage_credentials, storage_config
 ) -> None:
     """Deploy and configure the charm and s3-integrator."""
@@ -58,7 +58,7 @@ async def test_deploy_and_configure(
 
 
 @pytest.mark.abort_on_fail
-async def test_s3_integration(juju_lxd_model: Juju, s3_bucket) -> None:
+def test_s3_integration(juju_lxd_model: Juju, s3_bucket) -> None:
     """Integrate charm and s3-integrator."""
     juju_lxd_model.integrate(APP_NAME, S3_INTEGRATOR)
     juju_lxd_model.wait(
@@ -74,7 +74,7 @@ async def test_s3_integration(juju_lxd_model: Juju, s3_bucket) -> None:
 
 
 @pytest.mark.abort_on_fail
-async def test_create_backup(juju_lxd_model: Juju) -> None:
+def test_create_backup(juju_lxd_model: Juju) -> None:
     """Create a backup and upload to s3-storage."""
     global backup_id
 
@@ -122,7 +122,7 @@ async def test_create_backup(juju_lxd_model: Juju) -> None:
 
 
 @pytest.mark.abort_on_fail
-async def test_restore_verification_failed(juju_lxd_model: Juju):
+def test_restore_verification_failed(juju_lxd_model: Juju):
     """Restore a backup with invalid admin password."""
     logger.info("Configure admin credentials in etcd")
     invalid_password = "invalid_password"

--- a/tests/integration/backup/test_s3_backup_restore.py
+++ b/tests/integration/backup/test_s3_backup_restore.py
@@ -125,7 +125,7 @@ async def test_restore_backup_on_same_cluster(juju_lxd_model: Juju) -> None:
     # download the backup from storage and restore it
     logger.info(f"Restoring backup {backup_id}")
     restore_backup_response = juju_lxd_model.run(leader_unit, "restore", {"backup-id": backup_id})
-    assert restore_backup_response.results.get("return-code") == 0, "restore failed"
+    assert restore_backup_response.return_code == 0, "restore failed"
 
     # wait for the restore to be performed across all units and check the restored data
     juju_lxd_model.wait(
@@ -144,6 +144,7 @@ async def test_restore_backup_on_different_cluster(charm: str, juju_lxd_model: J
     logger.info("Remove existing etcd cluster and deploy a new one.")
     juju_lxd_model.remove_application(APP_NAME)
     juju_lxd_model.remove_secret(identifier="system_users_secret")
+    juju_lxd_model.wait(lambda status: status.apps.get(APP_NAME) is None)
 
     juju_lxd_model.deploy(charm, num_units=NUM_UNITS)
     juju_lxd_model.wait(

--- a/tests/integration/backup/test_s3_backup_restore.py
+++ b/tests/integration/backup/test_s3_backup_restore.py
@@ -5,19 +5,19 @@
 import logging
 
 import pytest
-from pytest_operator.plugin import OpsTest
+from jubilant import Juju
 
 from literals import INTERNAL_USER
 
 from ..helpers import (
     APP_NAME,
-    add_secret,
-    get_cluster_endpoints,
+    get_cluster_endpoints_jubilant,
     get_key,
+    get_leader_unit_name,
     put_key,
-    set_password,
+    set_password_jubilant,
 )
-from ..helpers_deployment import wait_until
+from ..helpers_deployment import apps_active_and_agents_idle, does_status_match
 
 logger = logging.getLogger(__name__)
 
@@ -31,35 +31,44 @@ backup_id = ""
 
 @pytest.mark.abort_on_fail
 async def test_deploy_and_configure(
-    charm: str, ops_test: OpsTest, storage_credentials, storage_config
+    charm: str, juju_lxd_model: Juju, storage_credentials, storage_config
 ) -> None:
     """Deploy and configure the charm and s3-integrator."""
-    await ops_test.model.deploy(charm, num_units=NUM_UNITS)
-    await ops_test.model.deploy(S3_INTEGRATOR, channel="2/edge", num_units=1)
-    await wait_until(ops_test, apps=[S3_INTEGRATOR], apps_statuses=["blocked"])
+    juju_lxd_model.deploy(charm, num_units=NUM_UNITS)
+    juju_lxd_model.deploy(S3_INTEGRATOR, channel="2/edge", num_units=1)
+    juju_lxd_model.wait(
+        lambda status: does_status_match(
+            status, expected_app_statuses={S3_INTEGRATOR: ["blocked"]}
+        )
+    )
 
     logger.info(f"Configure {S3_INTEGRATOR}")
     secret_name = "s3-credentials"
-    secret_id = await add_secret(ops_test, secret_name, storage_credentials)
-    await ops_test.model.grant_secret(secret_name, S3_INTEGRATOR)
-    await ops_test.model.applications[S3_INTEGRATOR].set_config({"credentials": secret_id})
-    await ops_test.model.applications[S3_INTEGRATOR].set_config(storage_config)
-    await wait_until(ops_test, apps=[APP_NAME, S3_INTEGRATOR], apps_statuses=["active"])
+    secret_uri = juju_lxd_model.add_secret(secret_name, storage_credentials)
+    juju_lxd_model.grant_secret(secret_uri, S3_INTEGRATOR)
+    juju_lxd_model.config(S3_INTEGRATOR, {"credentials": secret_uri})
+    juju_lxd_model.config(S3_INTEGRATOR, storage_config)
+    juju_lxd_model.wait(
+        lambda status: does_status_match(
+            status, expected_app_statuses={APP_NAME: ["active"], S3_INTEGRATOR: ["active"]}
+        )
+    )
 
     logger.info("Configure admin credentials in etcd")
-    await set_password(ops_test, PASSWORD)
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+    set_password_jubilant(juju_lxd_model, PASSWORD)
+    juju_lxd_model.wait(
+        lambda status: apps_active_and_agents_idle(status, APP_NAME, unit_count=NUM_UNITS)
+    )
 
 
 @pytest.mark.abort_on_fail
-async def test_s3_integration(ops_test: OpsTest, s3_bucket) -> None:
+async def test_s3_integration(juju_lxd_model: Juju, s3_bucket) -> None:
     """Integrate charm and s3-integrator."""
-    await ops_test.model.integrate(APP_NAME, S3_INTEGRATOR)
-    await wait_until(
-        ops_test,
-        apps=[APP_NAME, S3_INTEGRATOR],
-        apps_statuses=["active"],
-        units_statuses=["active"],
+    juju_lxd_model.integrate(APP_NAME, S3_INTEGRATOR)
+    juju_lxd_model.wait(
+        lambda status: does_status_match(
+            status, expected_app_statuses={APP_NAME: ["active"], S3_INTEGRATOR: ["active"]}
+        )
     )
 
     # bucket should be created when integrating both
@@ -67,12 +76,12 @@ async def test_s3_integration(ops_test: OpsTest, s3_bucket) -> None:
 
 
 @pytest.mark.abort_on_fail
-async def test_create_backup(ops_test: OpsTest) -> None:
+async def test_create_backup(juju_lxd_model: Juju) -> None:
     """Create a backup and upload to s3-storage."""
     global backup_id
 
     # Before creating a backup, enter some data
-    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    endpoints = get_cluster_endpoints_jubilant(juju_lxd_model, APP_NAME)
     assert (
         put_key(
             endpoints,
@@ -85,21 +94,17 @@ async def test_create_backup(ops_test: OpsTest) -> None:
     )
     assert get_key(endpoints, user=INTERNAL_USER, password=PASSWORD, key=TEST_KEY) == TEST_VALUE
 
-    for unit in ops_test.model.applications[APP_NAME].units:
-        if await unit.is_leader_from_status():
-            leader_unit = unit
-    logger.info(f"Creating backup on unit {leader_unit.name}")
+    leader_unit = get_leader_unit_name(juju_lxd_model, APP_NAME)
+    logger.info(f"Creating backup on unit {leader_unit}")
 
     # `create-backup` will upload the backup to storage
-    create_action = await leader_unit.run_action("create-backup")
-    create_backup_response = await create_action.wait()
+    create_backup_response = juju_lxd_model.run(leader_unit, "create-backup")
 
     backup_id = create_backup_response.results.get("backup-id", "")
     assert backup_id, "No backup-id in response"
 
     # `list-backups` will look up the backups in storage
-    list_action = await leader_unit.run_action("list-backups")
-    list_backups_response = await list_action.wait()
+    list_backups_response = juju_lxd_model.run(leader_unit, "list-backups")
     backups = list_backups_response.results.get("backups", "")
     # example: 'backup-id | backup-status\n--------------------\n2025-04-01T08:40:45Z  | finished'
     assert backups.split("\n")[2].startswith(backup_id), (
@@ -113,64 +118,69 @@ async def test_create_backup(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.abort_on_fail
-async def test_restore_backup_on_same_cluster(ops_test: OpsTest) -> None:
+async def test_restore_backup_on_same_cluster(juju_lxd_model: Juju) -> None:
     """Restore a backup and check if data is recovered."""
-    for unit in ops_test.model.applications[APP_NAME].units:
-        if await unit.is_leader_from_status():
-            leader_unit = unit
+    leader_unit = get_leader_unit_name(juju_lxd_model, APP_NAME)
 
     # download the backup from storage and restore it
     logger.info(f"Restoring backup {backup_id}")
-    restore_action = await leader_unit.run_action("restore", **{"backup-id": backup_id})
-    restore_backup_response = await restore_action.wait()
+    restore_backup_response = juju_lxd_model.run(leader_unit, "restore", {"backup-id": backup_id})
     assert restore_backup_response.results.get("return-code") == 0, "restore failed"
 
     # wait for the restore to be performed across all units and check the restored data
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+    juju_lxd_model.wait(
+        lambda status: apps_active_and_agents_idle(status, APP_NAME, unit_count=NUM_UNITS)
+    )
 
-    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    endpoints = get_cluster_endpoints_jubilant(juju_lxd_model, APP_NAME)
     assert get_key(endpoints, user=INTERNAL_USER, password=PASSWORD, key=TEST_KEY) == TEST_VALUE, (
         "data not recovered"
     )
 
 
 @pytest.mark.abort_on_fail
-async def test_restore_backup_on_different_cluster(charm: str, ops_test: OpsTest):
+async def test_restore_backup_on_different_cluster(charm: str, juju_lxd_model: Juju):
     """Restore a backup and check if data is recovered."""
     logger.info("Remove existing etcd cluster and deploy a new one.")
-    await ops_test.model.remove_application(APP_NAME, block_until_done=True)
-    await ops_test.model.remove_secret(secret_name="system_users_secret")
+    juju_lxd_model.remove_application(APP_NAME)
+    juju_lxd_model.remove_secret(identifier="system_users_secret")
 
-    await ops_test.model.deploy(charm, num_units=NUM_UNITS)
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS, idle_period=60)
-
-    logger.info("Configure admin credentials in etcd")
-    await set_password(ops_test, PASSWORD)
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
-
-    logger.info(f"Integrate the newly deployed application with {S3_INTEGRATOR}")
-    await ops_test.model.integrate(APP_NAME, S3_INTEGRATOR)
-    await wait_until(
-        ops_test,
-        apps=[APP_NAME, S3_INTEGRATOR],
-        apps_statuses=["active"],
-        units_statuses=["active"],
+    juju_lxd_model.deploy(charm, num_units=NUM_UNITS)
+    juju_lxd_model.wait(
+        lambda status: apps_active_and_agents_idle(
+            status, APP_NAME, unit_count=NUM_UNITS, idle_period=60
+        )
     )
 
-    for unit in ops_test.model.applications[APP_NAME].units:
-        if await unit.is_leader_from_status():
-            leader_unit = unit
+    logger.info("Configure admin credentials in etcd")
+    set_password_jubilant(juju_lxd_model, PASSWORD)
+    juju_lxd_model.wait(
+        lambda status: apps_active_and_agents_idle(status, APP_NAME, unit_count=NUM_UNITS)
+    )
+
+    logger.info(f"Integrate the newly deployed application with {S3_INTEGRATOR}")
+    juju_lxd_model.integrate(APP_NAME, S3_INTEGRATOR)
+    juju_lxd_model.wait(
+        lambda status: does_status_match(
+            status,
+            expected_app_statuses={APP_NAME: ["active"], S3_INTEGRATOR: ["active"]},
+            expected_unit_statuses={APP_NAME: ["active"], S3_INTEGRATOR: ["active"]},
+        )
+    )
+
+    leader_unit = get_leader_unit_name(juju_lxd_model, APP_NAME)
 
     # download the backup from storage and restore it
     logger.info(f"Restoring backup {backup_id}")
-    restore_action = await leader_unit.run_action("restore", **{"backup-id": backup_id})
-    restore_backup_response = await restore_action.wait()
+    restore_backup_response = juju_lxd_model.run(leader_unit, "restore", {"backup-id": backup_id})
     assert restore_backup_response.results.get("return-code") == 0, "restore failed"
 
     # wait for the restore to be performed across all units and check the restored data
-    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+    juju_lxd_model.wait(
+        lambda status: apps_active_and_agents_idle(status, APP_NAME, unit_count=NUM_UNITS)
+    )
 
-    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    endpoints = get_cluster_endpoints_jubilant(juju_lxd_model, APP_NAME)
     assert get_key(endpoints, user=INTERNAL_USER, password=PASSWORD, key=TEST_KEY) == TEST_VALUE, (
         "data not recovered"
     )

--- a/tests/integration/backup/test_s3_backup_restore.py
+++ b/tests/integration/backup/test_s3_backup_restore.py
@@ -30,7 +30,7 @@ backup_id = ""
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_and_configure(
+def test_deploy_and_configure(
     charm: str, juju_lxd_model: Juju, storage_credentials, storage_config
 ) -> None:
     """Deploy and configure the charm and s3-integrator."""
@@ -62,7 +62,7 @@ async def test_deploy_and_configure(
 
 
 @pytest.mark.abort_on_fail
-async def test_s3_integration(juju_lxd_model: Juju, s3_bucket) -> None:
+def test_s3_integration(juju_lxd_model: Juju, s3_bucket) -> None:
     """Integrate charm and s3-integrator."""
     juju_lxd_model.integrate(APP_NAME, S3_INTEGRATOR)
     juju_lxd_model.wait(
@@ -76,7 +76,7 @@ async def test_s3_integration(juju_lxd_model: Juju, s3_bucket) -> None:
 
 
 @pytest.mark.abort_on_fail
-async def test_create_backup(juju_lxd_model: Juju) -> None:
+def test_create_backup(juju_lxd_model: Juju) -> None:
     """Create a backup and upload to s3-storage."""
     global backup_id
 
@@ -118,7 +118,7 @@ async def test_create_backup(juju_lxd_model: Juju) -> None:
 
 
 @pytest.mark.abort_on_fail
-async def test_restore_backup_on_same_cluster(juju_lxd_model: Juju) -> None:
+def test_restore_backup_on_same_cluster(juju_lxd_model: Juju) -> None:
     """Restore a backup and check if data is recovered."""
     leader_unit = get_leader_unit_name(juju_lxd_model, APP_NAME)
 
@@ -139,7 +139,7 @@ async def test_restore_backup_on_same_cluster(juju_lxd_model: Juju) -> None:
 
 
 @pytest.mark.abort_on_fail
-async def test_restore_backup_on_different_cluster(charm: str, juju_lxd_model: Juju):
+def test_restore_backup_on_different_cluster(charm: str, juju_lxd_model: Juju):
     """Restore a backup and check if data is recovered."""
     logger.info("Remove existing etcd cluster and deploy a new one.")
     juju_lxd_model.remove_application(APP_NAME)

--- a/tests/integration/backup/test_s3_backup_restore.py
+++ b/tests/integration/backup/test_s3_backup_restore.py
@@ -174,7 +174,7 @@ async def test_restore_backup_on_different_cluster(charm: str, juju_lxd_model: J
     # download the backup from storage and restore it
     logger.info(f"Restoring backup {backup_id}")
     restore_backup_response = juju_lxd_model.run(leader_unit, "restore", {"backup-id": backup_id})
-    assert restore_backup_response.results.get("return-code") == 0, "restore failed"
+    assert restore_backup_response.return_code == 0, "restore failed"
 
     # wait for the restore to be performed across all units and check the restored data
     juju_lxd_model.wait(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -633,6 +633,19 @@ def get_etcd_version(
         raise
 
 
+def get_leader_unit_name(juju: Juju, app: str = APP_NAME) -> str:
+    """Retrieve the leader unit's name.
+
+    Raises:
+        RuntimeError: if no leader unit is found.
+    """
+    for name, unit in juju.status().get_units(app).items():
+        if unit.leader:
+            return name
+
+    raise RuntimeError(f"No leader unit found for app {app}")
+
+
 def get_leader_unit_ip(juju: Juju, app: str = APP_NAME) -> str:
     """Retrieve the leader unit's public address.
 

--- a/tests/integration/helpers_deployment.py
+++ b/tests/integration/helpers_deployment.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 import jubilant
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from dateutil.parser import parse
+from jubilant.statustypes import StatusInfo
 from ops import StatusBase
 from pytest_operator.plugin import OpsTest
 from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
@@ -115,6 +116,9 @@ def _progress_line(units: List[Unit]) -> str:
         )
 
     return log
+
+
+ExpectedStatus = StatusObject | str
 
 
 async def get_unit_hostname(ops_test: OpsTest, unit_id: int, app: str) -> str:
@@ -268,6 +272,28 @@ def does_message_match(expected_status_message: str, status: StatusObject) -> bo
     except KeyError as e:
         logger.error(f"Error attempting to convert StatusObject to ops.StatusBase: {e}")
         return False
+
+
+def does_message_match_jubilant(model_status: StatusInfo, expected_status: ExpectedStatus) -> bool:
+    """Check if the status message matches the expected message."""
+    if isinstance(expected_status, StatusObject):
+        try:
+            juju_status = StatusBase.from_name(expected_status.status, expected_status.message)
+            current_status = model_status.message
+            return (
+                current_status == juju_status.message
+                or current_status.startswith(juju_status.message)
+                or juju_status.message.startswith(f"{current_status:.40}")
+                or (
+                    expected_status.short_message is not None
+                    and expected_status.short_message in current_status
+                )
+            )
+        except KeyError as e:
+            logger.error(f"Error attempting to convert StatusObject to ops.StatusBase: {e}")
+            return False
+    else:
+        return model_status.current == expected_status
 
 
 def _is_every_condition_on_units_met(
@@ -506,16 +532,16 @@ async def wait_until(  # noqa: C901
 
 def does_status_match(
     model_status: jubilant.Status,
-    expected_unit_statuses: dict[str, List[StatusObject]] | None = None,
-    expected_app_statuses: dict[str, List[StatusObject]] | None = None,
+    expected_unit_statuses: dict[str, List[ExpectedStatus]] | None = None,
+    expected_app_statuses: dict[str, List[ExpectedStatus]] | None = None,
     num_units: dict[str, int] | None = None,
 ) -> bool:
     """Check that current app and/or unit status matches expectation for given apps.
 
     Args:
         model_status: represents the jubilant model's current status
-        expected_unit_statuses: dict mapping app name to list of expected StatusObject for units
-        expected_app_statuses: dict mapping app name to its list of expected StatusObject
+        expected_unit_statuses: dict mapping app name to list of ExpectedStatus for units
+        expected_app_statuses: dict mapping app name to its list of ExpectedStatus
         num_units: dict mapping app name to expected number of units
     """
     return (
@@ -532,18 +558,18 @@ def does_status_match(
 
 
 def _does_unit_workload_status_match(
-    model_status: jubilant.Status, expected_statuses: dict[str, List[StatusObject]]
+    model_status: jubilant.Status, expected_statuses: dict[str, List[ExpectedStatus]]
 ) -> bool:
     """Check that current workload status matches expectation for given apps' units.
 
     Args:
         model_status: represents the jubilant model's current status
-        expected_statuses: dict mapping app names to list of expected StatusObject
+        expected_statuses: dict mapping app names to list of ExpectedStatus
     """
     return all(
         all(
             any(
-                does_message_match(unit_status.workload_status.message, status)
+                does_message_match_jubilant(unit_status.workload_status, status)
                 for status in expected_status
             )
             for unit_status in model_status.get_units(app).values()
@@ -553,17 +579,17 @@ def _does_unit_workload_status_match(
 
 
 def _does_app_status_match(
-    model_status: jubilant.Status, expected_statuses: dict[str, List[StatusObject]]
+    model_status: jubilant.Status, expected_statuses: dict[str, List[ExpectedStatus]]
 ) -> bool:
     """Check that current app status matches expectation for given apps.
 
     Args:
         model_status: represents the jubilant model's current status
-        expected_statuses: dict mapping app names to list of expected StatusObject
+        expected_statuses: dict mapping app names to list of ExpectedStatus
     """
     return all(
         any(
-            does_message_match(model_status.apps.get(app).app_status.message, status)
+            does_message_match_jubilant(model_status.apps.get(app).app_status, status)
             for status in expected_status
         )
         for app, expected_status in expected_statuses.items()


### PR DESCRIPTION
## Description of issue or feature:
This PR addresses [DPE-9136](https://warthogs.atlassian.net/browse/DPE-9136) and consists of changes to the backups and restore integration tests; it rewrites them to use jubilant.

## Solution:
- rewrites tests in `test_restore_verification_failed.py` and `test_s3_backup_restore.py` files to use Jubilant
- modifies a few helpers as required 

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [x] Integration tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


[DPE-9136]: https://warthogs.atlassian.net/browse/DPE-9136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ