### PR TITLE
[DPE-9097] update rust toolchain

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/tests/integration/client_relations/requirer-charm/charmcraft.yaml
+++ b/tests/integration/client_relations/requirer-charm/charmcraft.yaml
@@ -29,7 +29,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging


### PR DESCRIPTION
## Description of issue or feature:
Because of an outdated rust version, building the charm cache for etcd fails ([see ccc-hub](https://github.com/canonical/charmcraftcache-hub/actions/runs/20833028076/job/59851698844#step:8:479)).

## Solution:
update rust used for charm build to 1.92.0

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [X] Integration tests