### PR TITLE
[DPE-9097] Stable release upgrades test

### DIFF
--- a/tests/integration/ha/upgrades/test_stable_release_upgrade.py
+++ b/tests/integration/ha/upgrades/test_stable_release_upgrade.py
@@ -25,8 +25,10 @@ from tests.integration.helpers_deployment import wait_until
 logger = logging.getLogger(__name__)
 
 CHARM_CHANNEL = "3.6/stable"
+# these revisions are the ones from the first stable release, they are supposed to be kept
 CHARM_REVISIONS_TO_DEPLOY = {"x86_64": 119, "aarch64": 120}
 REQUIRER_NAME = "requirer-charm"
+REQUIRER_TLS_NAME = "requirer-tls-provider"
 
 
 @pytest.fixture
@@ -37,7 +39,7 @@ def requirer_charm(platform: str) -> str:
 
 @pytest.mark.abort_on_fail
 async def test_deploy_stable_revision(ops_test: OpsTest, requirer_charm: str) -> None:
-    """Deploy the charm with the first stable release, together with a client charm and TLS."""
+    """Deploy the charm with the first stable release, in a production-like setup."""
     logger.info("Create storage pool for persistent storage")
     await ops_test.model.create_storage_pool("etcd-pool", "lxd")
     storage = {
@@ -61,6 +63,9 @@ async def test_deploy_stable_revision(ops_test: OpsTest, requirer_charm: str) ->
             application_name=REQUIRER_NAME,
         ),
         ops_test.model.deploy(TLS_NAME, channel="1/stable", config=tls_config),
+        ops_test.model.deploy(
+            TLS_NAME, channel="1/edge", application_name=REQUIRER_TLS_NAME, config=tls_config
+        ),
     )
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000, wait_for_exact_units=NUM_UNITS)
 
@@ -68,9 +73,9 @@ async def test_deploy_stable_revision(ops_test: OpsTest, requirer_charm: str) ->
     logger.info("Integrating TLS and client relations")
     await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", TLS_NAME)
     await ops_test.model.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
-    await ops_test.model.integrate(REQUIRER_NAME, TLS_NAME)
+    await ops_test.model.integrate(REQUIRER_NAME, REQUIRER_TLS_NAME)
     await ops_test.model.integrate(APP_NAME, REQUIRER_NAME)
-    await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME, TLS_NAME])
+    await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME, TLS_NAME, REQUIRER_TLS_NAME])
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/ha/upgrades/test_stable_release_upgrade.py
+++ b/tests/integration/ha/upgrades/test_stable_release_upgrade.py
@@ -10,12 +10,6 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from literals import INTERNAL_USER, PEER_RELATION
-from tests.integration.ha.helpers import (
-    assert_continuous_writes_consistent,
-    assert_continuous_writes_increasing,
-    start_continuous_writes,
-    stop_continuous_writes,
-)
 from tests.integration.ha.upgrades.literals import NUM_UNITS, WORKLOAD_VERSION
 from tests.integration.helpers import (
     APP_NAME,
@@ -44,12 +38,21 @@ def requirer_charm(platform: str) -> str:
 @pytest.mark.abort_on_fail
 async def test_deploy_stable_revision(ops_test: OpsTest, requirer_charm: str) -> None:
     """Deploy the charm with the first stable release, together with a client charm and TLS."""
+    logger.info("Create storage pool for persistent storage")
+    await ops_test.model.create_storage_pool("etcd-pool", "lxd")
+    storage = {
+        "data": {"pool": "etcd-pool", "size": 2048},
+        "archive": {"pool": "etcd-pool", "size": 2048},
+        "logs": {"pool": "etcd-pool", "size": 2048},
+    }
+
     logger.info("Deploy charm from stable, deploy TLS provider and client charm")
     tls_config = {"ca-common-name": "etcd"}
     await asyncio.gather(
         ops_test.model.deploy(
             APP_NAME,
             num_units=NUM_UNITS,
+            storage=storage,
             channel=CHARM_CHANNEL,
             revision=CHARM_REVISIONS_TO_DEPLOY[machine()],
         ),
@@ -74,12 +77,9 @@ async def test_deploy_stable_revision(ops_test: OpsTest, requirer_charm: str) ->
 async def test_upgrade_to_latest(charm: str, ops_test: OpsTest) -> None:
     """Refresh the charm and upgrade etcd, ensuring high availability while upgrading."""
     etcd_application = ops_test.model.applications[APP_NAME]
-    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    endpoints = get_cluster_endpoints(ops_test, APP_NAME, tls_enabled=True)
     secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
     password = secret.get(f"{INTERNAL_USER}-password")
-
-    # start writing data to the cluster
-    start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
     # pre-refresh-check
     for unit in etcd_application.units:
@@ -116,8 +116,6 @@ async def test_upgrade_to_latest(charm: str, ops_test: OpsTest) -> None:
         force_refresh_response = await force_refresh_action.wait()
         assert force_refresh_response.results.get("return-code") == 0, "action failed"
 
-    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
-
     await wait_until(ops_test, apps=[APP_NAME], apps_statuses=["blocked"])
     assert "resume-refresh" in etcd_application.status_message, (
         "Refresh should wait for user to continue with `resume-refresh` action"
@@ -130,20 +128,22 @@ async def test_upgrade_to_latest(charm: str, ops_test: OpsTest) -> None:
 
     # wait for upgrade to complete
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
-    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
     logger.info("Check etcd versions and cluster membership")
-    cluster_members = get_cluster_members(endpoints, user=INTERNAL_USER, password=password)
+    cluster_members = get_cluster_members(
+        endpoints, user=INTERNAL_USER, password=password, tls_enabled=True
+    )
     for unit in etcd_application.units:
-        unit_endpoint = get_unit_endpoint(ops_test, unit_name=unit.name, app_name=APP_NAME)
+        unit_endpoint = get_unit_endpoint(
+            ops_test, unit_name=unit.name, app_name=APP_NAME, tls_enabled=True
+        )
         assert (
-            get_etcd_version(unit_endpoint, user=INTERNAL_USER, password=password)
+            get_etcd_version(
+                unit_endpoint, user=INTERNAL_USER, password=password, tls_enabled=True
+            )
             == WORKLOAD_VERSION["target"]
         ), f"unit {unit.name} was not upgraded"
 
         assert any(unit.name.replace("/", "") == member["name"] for member in cluster_members), (
             f"{unit.name} is not in {cluster_members}"
         )
-
-    stop_continuous_writes()
-    assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)

--- a/tests/integration/ha/upgrades/test_stable_release_upgrade.py
+++ b/tests/integration/ha/upgrades/test_stable_release_upgrade.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from platform import machine
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from literals import INTERNAL_USER, PEER_RELATION
+from tests.integration.ha.helpers import (
+    assert_continuous_writes_consistent,
+    assert_continuous_writes_increasing,
+    start_continuous_writes,
+    stop_continuous_writes,
+)
+from tests.integration.ha.upgrades.literals import NUM_UNITS, WORKLOAD_VERSION
+from tests.integration.helpers import (
+    APP_NAME,
+    TLS_NAME,
+    get_cluster_endpoints,
+    get_cluster_members,
+    get_etcd_version,
+    get_secret_by_label,
+    get_unit_endpoint,
+)
+from tests.integration.helpers_deployment import wait_until
+
+logger = logging.getLogger(__name__)
+
+CHARM_CHANNEL = "3.6/stable"
+CHARM_REVISIONS_TO_DEPLOY = {"x86_64": 119, "aarch64": 120}
+REQUIRER_NAME = "requirer-charm"
+
+
+@pytest.fixture
+def requirer_charm(platform: str) -> str:
+    """Path to the requirer charm file to use for testing."""
+    return f"./tests/integration/client_relations/requirer-charm/requirer-charm_ubuntu@24.04-{platform}.charm"
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_stable_revision(ops_test: OpsTest, requirer_charm: str) -> None:
+    """Deploy the charm with the first stable release, together with a client charm and TLS."""
+    logger.info("Deploy charm from stable, deploy TLS provider and client charm")
+    tls_config = {"ca-common-name": "etcd"}
+    await asyncio.gather(
+        ops_test.model.deploy(
+            APP_NAME,
+            num_units=NUM_UNITS,
+            channel=CHARM_CHANNEL,
+            revision=CHARM_REVISIONS_TO_DEPLOY[machine()],
+        ),
+        ops_test.model.deploy(
+            requirer_charm,
+            application_name=REQUIRER_NAME,
+        ),
+        ops_test.model.deploy(TLS_NAME, channel="1/stable", config=tls_config),
+    )
+    await wait_until(ops_test, apps=[APP_NAME], timeout=1000, wait_for_exact_units=NUM_UNITS)
+
+    # enable TLS and check if the cluster is still accessible
+    logger.info("Integrating TLS and client relations")
+    await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", TLS_NAME)
+    await ops_test.model.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
+    await ops_test.model.integrate(REQUIRER_NAME, TLS_NAME)
+    await ops_test.model.integrate(APP_NAME, REQUIRER_NAME)
+    await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME, TLS_NAME])
+
+
+@pytest.mark.abort_on_fail
+async def test_upgrade_to_latest(charm: str, ops_test: OpsTest) -> None:
+    """Refresh the charm and upgrade etcd, ensuring high availability while upgrading."""
+    etcd_application = ops_test.model.applications[APP_NAME]
+    endpoints = get_cluster_endpoints(ops_test, APP_NAME)
+    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
+    password = secret.get(f"{INTERNAL_USER}-password")
+
+    # start writing data to the cluster
+    start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+    # pre-refresh-check
+    for unit in etcd_application.units:
+        if await unit.is_leader_from_status():
+            leader_unit = unit
+    logger.info("Running `pre-refresh-check` action")
+    pre_refresh_action = await leader_unit.run_action("pre-refresh-check")
+    pre_refresh_response = await pre_refresh_action.wait()
+    assert pre_refresh_response.results.get("return-code") == 0, "action failed"
+
+    # Refresh always happens from highest to lowest unit number
+    refresh_order = sorted(
+        etcd_application.units,
+        key=lambda unit: int(unit.name.split("/")[1]),
+        reverse=True,
+    )
+
+    # initiate the upgrade
+    logger.info(f"Refresh etcd to v{WORKLOAD_VERSION['target']}")
+    await etcd_application.refresh(path=charm)
+
+    # versions will always be marked "incompatible" if refresh to a local version
+    # this will not be the case when the PR is released
+    # see: https://github.com/canonical/charm-refresh/blob/main/charm_refresh/_main.py#L182-L185
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], idle_period=30)
+    if "incompatible" in etcd_application.status_message:
+        logger.info("Upgrade is blocked due to incompatibility")
+
+        logger.info(f"Continue refresh on unit {refresh_order[0].name}")
+        logger.info("Running `force-refresh-start` action with check-compatibility=false")
+        force_refresh_action = await refresh_order[0].run_action(
+            "force-refresh-start", **{"check-compatibility": False}
+        )
+        force_refresh_response = await force_refresh_action.wait()
+        assert force_refresh_response.results.get("return-code") == 0, "action failed"
+
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+    await wait_until(ops_test, apps=[APP_NAME], apps_statuses=["blocked"])
+    assert "resume-refresh" in etcd_application.status_message, (
+        "Refresh should wait for user to continue with `resume-refresh` action"
+    )
+
+    logger.info("Continue refresh on all other units with `resume-refresh` action")
+    resume_refresh_action = await refresh_order[1].run_action("resume-refresh")
+    resume_refresh_response = await resume_refresh_action.wait()
+    assert resume_refresh_response.results.get("return-code") == 0, "action failed"
+
+    # wait for upgrade to complete
+    await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
+    assert_continuous_writes_increasing(endpoints=endpoints, user=INTERNAL_USER, password=password)
+
+    logger.info("Check etcd versions and cluster membership")
+    cluster_members = get_cluster_members(endpoints, user=INTERNAL_USER, password=password)
+    for unit in etcd_application.units:
+        unit_endpoint = get_unit_endpoint(ops_test, unit_name=unit.name, app_name=APP_NAME)
+        assert (
+            get_etcd_version(unit_endpoint, user=INTERNAL_USER, password=password)
+            == WORKLOAD_VERSION["target"]
+        ), f"unit {unit.name} was not upgraded"
+
+        assert any(unit.name.replace("/", "") == member["name"] for member in cluster_members), (
+            f"{unit.name} is not in {cluster_members}"
+        )
+
+    stop_continuous_writes()
+    assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)

--- a/tests/integration/ha/upgrades/test_stable_release_upgrade.py
+++ b/tests/integration/ha/upgrades/test_stable_release_upgrade.py
@@ -9,17 +9,8 @@ from platform import machine
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from literals import INTERNAL_USER, PEER_RELATION
 from tests.integration.ha.upgrades.literals import NUM_UNITS, WORKLOAD_VERSION
-from tests.integration.helpers import (
-    APP_NAME,
-    TLS_NAME,
-    get_cluster_endpoints,
-    get_cluster_members,
-    get_etcd_version,
-    get_secret_by_label,
-    get_unit_endpoint,
-)
+from tests.integration.helpers import APP_NAME, TLS_NAME
 from tests.integration.helpers_deployment import wait_until
 
 logger = logging.getLogger(__name__)
@@ -61,10 +52,11 @@ async def test_deploy_stable_revision(ops_test: OpsTest, requirer_charm: str) ->
         ops_test.model.deploy(
             requirer_charm,
             application_name=REQUIRER_NAME,
+            config={"data-interfaces-version": "0"},
         ),
         ops_test.model.deploy(TLS_NAME, channel="1/stable", config=tls_config),
         ops_test.model.deploy(
-            TLS_NAME, channel="1/edge", application_name=REQUIRER_TLS_NAME, config=tls_config
+            TLS_NAME, channel="1/stable", application_name=REQUIRER_TLS_NAME, config=tls_config
         ),
     )
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000, wait_for_exact_units=NUM_UNITS)
@@ -84,9 +76,6 @@ async def test_deploy_stable_revision(ops_test: OpsTest, requirer_charm: str) ->
 async def test_upgrade_to_latest(charm: str, ops_test: OpsTest) -> None:
     """Refresh the charm and upgrade etcd, ensuring high availability while upgrading."""
     etcd_application = ops_test.model.applications[APP_NAME]
-    endpoints = get_cluster_endpoints(ops_test, APP_NAME, tls_enabled=True)
-    secret = await get_secret_by_label(ops_test, label=f"{PEER_RELATION}.{APP_NAME}.app")
-    password = secret.get(f"{INTERNAL_USER}-password")
 
     # pre-refresh-check
     for unit in etcd_application.units:
@@ -135,22 +124,3 @@ async def test_upgrade_to_latest(charm: str, ops_test: OpsTest) -> None:
 
     # wait for upgrade to complete
     await wait_until(ops_test, apps=[APP_NAME], wait_for_exact_units=NUM_UNITS)
-
-    logger.info("Check etcd versions and cluster membership")
-    cluster_members = get_cluster_members(
-        endpoints, user=INTERNAL_USER, password=password, tls_enabled=True
-    )
-    for unit in etcd_application.units:
-        unit_endpoint = get_unit_endpoint(
-            ops_test, unit_name=unit.name, app_name=APP_NAME, tls_enabled=True
-        )
-        assert (
-            get_etcd_version(
-                unit_endpoint, user=INTERNAL_USER, password=password, tls_enabled=True
-            )
-            == WORKLOAD_VERSION["target"]
-        ), f"unit {unit.name} was not upgraded"
-
-        assert any(unit.name.replace("/", "") == member["name"] for member in cluster_members), (
-            f"{unit.name} is not in {cluster_members}"
-        )

--- a/tests/integration/ha/upgrades/test_stable_release_upgrade.py
+++ b/tests/integration/ha/upgrades/test_stable_release_upgrade.py
@@ -69,13 +69,15 @@ async def test_deploy_stable_revision(ops_test: OpsTest, requirer_charm: str) ->
     )
     await wait_until(ops_test, apps=[APP_NAME], timeout=1000, wait_for_exact_units=NUM_UNITS)
 
-    # enable TLS and check if the cluster is still accessible
-    logger.info("Integrating TLS and client relations")
+    logger.info("Enable TLS")
     await ops_test.model.integrate(f"{APP_NAME}:peer-certificates", TLS_NAME)
     await ops_test.model.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
     await ops_test.model.integrate(REQUIRER_NAME, REQUIRER_TLS_NAME)
-    await ops_test.model.integrate(APP_NAME, REQUIRER_NAME)
     await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME, TLS_NAME, REQUIRER_TLS_NAME])
+
+    logger.info("Integrate client application")
+    await ops_test.model.integrate(APP_NAME, REQUIRER_NAME)
+    await wait_until(ops_test, apps=[APP_NAME, REQUIRER_NAME])
 
 
 @pytest.mark.abort_on_fail

--- a/tests/spread/test_stable_release_upgrade.py/task.yaml
+++ b/tests/spread/test_stable_release_upgrade.py/task.yaml
@@ -1,0 +1,10 @@
+summary: test_stable_release_upgrade.py
+environment:
+  TEST_MODULE: ha/upgrades/test_stable_release_upgrade.py
+systems:
+  - self-hosted-linux-amd64-noble-large
+  - self-hosted-linux-arm64-noble-large
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results


### PR DESCRIPTION
## Description of issue or feature:
This PR adds an integration test to ensure we can upgrade the first `stable` version of `charmed-etcd` to the current version in a production-like setup with:
- TLS enabled
- persistent storage
- a client application (data-interfaces `v0`)

## Solution:
Ensure the upgrade runs without issues and doesn't break compatibility.

## How was this change tested?
- [X] Manually
- [ ] Unit tests
- [X] Integration tests