### PR TITLE
Add well sized icon.svg

### DIFF
--- a/icon.svg
+++ b/icon.svg
@@ -1,5 +1,80 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="-6.31 3.69 510.12 493.62" style="enable-background:new 0 0 100 100;" xml:space="preserve">
-<defs><style>.cls-1{fill:#419eda}</style></defs><path d="M228.175 224.684a31.994 31.994.0 11-32.007-31.986 32.011 32.011.0 0132.007 31.986zm41.37.0a32.007 32.007.0 1032.007-31.986 31.988 31.988.0 00-32.007 31.986z" class="cls-1"></path><path d="M487.371 259.399a87.82 87.82.0 01-7.07.267 92.362 92.362.0 01-40.621-9.455 377.209 377.209.0 005.47-71.86 371.808 371.808.0 00-46.507-55.11 92.396 92.396.0 0132.772-35.102l6.016-3.729-4.695-5.3a244.906 244.906.0 00-85.524-62.377l-6.507-2.828-1.654 6.862a92.144 92.144.0 01-23.19 42.096 371.928 371.928.0 00-67.006-27.602 370.624 370.624.0 00-66.908 27.558 91.915 91.915.0 01-23.098-42.003l-1.681-6.884-6.486 2.817A247.232 247.232.0 0065.164 79.104l-4.689 5.3 6.005 3.724a92.249 92.249.0 0132.695 34.917A374.63 374.63.0 0052.75 177.953a376.956 376.956.0 005.328 72.334 92.115 92.115.0 01-40.376 9.374 86.36 86.36.0 01-7.086-.268l-7.053-.551.655 7.042a243.413 243.413.0 0032.897 100.678l3.581 6.098 5.372-4.575a92.052 92.052.0 0143.592-20.406 373.97 373.97.0 0037.308 60.76 377.717 377.717.0 0070.69 17.382 91.87 91.87.0 01-5.885 48.232l-2.686 6.54 6.9 1.529a246.355 246.355.0 0052.966 5.857l52.954-5.857 6.906-1.529-2.675-6.54a91.755 91.755.0 01-5.869-48.286 377.784 377.784.0 0070.407-17.328 372.3 372.3.0 0037.335-60.815 92.233 92.233.0 0143.81 20.428l5.377 4.553 3.587-6.049a242.844 242.844.0 0032.859-100.672l.655-7.037zM324.644 345.45a285.884 285.884.0 01-151.628.0 290.124 290.124.0 01-46.141-143.385 288.675 288.675.0 0154.957-52.315 293.065 293.065.0 0167.028-36.462 293.976 293.976.0 0166.891 36.364 290.886 290.886.0 0155.198 52.675 292.253 292.253.0 01-13.817 74.682 293.726 293.726.0 01-32.488 68.441z" class="cls-1"></path>
-</svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="100px"
+   height="100px"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg18"
+   sodipodi:docname="icon.svg"
+   inkscape:version="1.4.3 (0d15f750, 2025-12-25)"
+   xml:space="preserve"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata
+     id="metadata22"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title>eclispe-che</dc:title></cc:Work></rdf:RDF></metadata><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1022"
+     id="namedview20"
+     showgrid="false"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="4.72"
+     inkscape:cx="59.427966"
+     inkscape:cy="32.097458"
+     inkscape:window-x="3712"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" /><!-- Generator: Sketch 45.2 (43514) - http://www.bohemiancoding.com/sketch --><title
+     id="title2">eclispe-che</title><desc
+     id="desc4">Created with Sketch.</desc><defs
+     id="defs7"><path
+       d="M50.0004412,4.04252804e-14 C22.3871247,4.04252804e-14 0,22.3848726 0,49.9995588 C0,77.6133626 22.3871247,100 50.0004412,100 C77.6137577,100 100,77.6133626 100,49.9995588 C100,22.3848726 77.6128753,3.55271368e-14 50.0004412,4.04252804e-14 Z"
+       id="path-1" /><style
+       id="style1">.cls-1{fill:#419eda}</style></defs><g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="BACKGROUND"><g
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="Page-1"><g
+         id="eclispe-che"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"><g
+           id="path3023-path"
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"><use
+             xlink:href="#path-1"
+             id="use9"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-opacity:1"
+             x="0"
+             y="0"
+             width="100%"
+             height="100%" /><path
+             d="M 50.000441,0.5 C 22.662621,0.5 0.5,22.661661 0.5,49.999559 0.5,77.337051 22.663098,99.5 50.000441,99.5 77.337613,99.5 99.5,77.337222 99.5,49.999559 99.5,22.661796 77.337514,0.5 50.000441,0.5 Z"
+             id="path11"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+             inkscape:connector-curvature="0" /></g></g></g></g><g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="PLACE LOGO HERE"><g
+       id="g1"
+       transform="matrix(0.17947428,0,0,0.17947428,5.3656623,6.055588)"><path
+         d="m 228.175,224.684 a 31.994,31.994 0 1 1 -32.007,-31.986 32.011,32.011 0 0 1 32.007,31.986 z m 41.37,0 a 32.007,32.007 0 1 0 32.007,-31.986 31.988,31.988 0 0 0 -32.007,31.986 z"
+         class="cls-1"
+         id="path1" /><path
+         d="m 487.371,259.399 a 87.82,87.82 0 0 1 -7.07,0.267 92.362,92.362 0 0 1 -40.621,-9.455 377.209,377.209 0 0 0 5.47,-71.86 371.808,371.808 0 0 0 -46.507,-55.11 92.396,92.396 0 0 1 32.772,-35.102 l 6.016,-3.729 -4.695,-5.3 A 244.906,244.906 0 0 0 347.212,16.733 l -6.507,-2.828 -1.654,6.862 A 92.144,92.144 0 0 1 315.861,62.863 371.928,371.928 0 0 0 248.855,35.261 370.624,370.624 0 0 0 181.947,62.819 91.915,91.915 0 0 1 158.849,20.816 l -1.681,-6.884 -6.486,2.817 A 247.232,247.232 0 0 0 65.164,79.104 l -4.689,5.3 6.005,3.724 a 92.249,92.249 0 0 1 32.695,34.917 374.63,374.63 0 0 0 -46.425,54.908 376.956,376.956 0 0 0 5.328,72.334 92.115,92.115 0 0 1 -40.376,9.374 86.36,86.36 0 0 1 -7.086,-0.268 l -7.053,-0.551 0.655,7.042 a 243.413,243.413 0 0 0 32.897,100.678 l 3.581,6.098 5.372,-4.575 a 92.052,92.052 0 0 1 43.592,-20.406 373.97,373.97 0 0 0 37.308,60.76 377.717,377.717 0 0 0 70.69,17.382 91.87,91.87 0 0 1 -5.885,48.232 l -2.686,6.54 6.9,1.529 a 246.355,246.355 0 0 0 52.966,5.857 l 52.954,-5.857 6.906,-1.529 -2.675,-6.54 a 91.755,91.755 0 0 1 -5.869,-48.286 377.784,377.784 0 0 0 70.407,-17.328 372.3,372.3 0 0 0 37.335,-60.815 92.233,92.233 0 0 1 43.81,20.428 l 5.377,4.553 3.587,-6.049 a 242.844,242.844 0 0 0 32.859,-100.672 l 0.655,-7.037 z M 324.644,345.45 a 285.884,285.884 0 0 1 -151.628,0 290.124,290.124 0 0 1 -46.141,-143.385 288.675,288.675 0 0 1 54.957,-52.315 293.065,293.065 0 0 1 67.028,-36.462 293.976,293.976 0 0 1 66.891,36.364 290.886,290.886 0 0 1 55.198,52.675 292.253,292.253 0 0 1 -13.817,74.682 293.726,293.726 0 0 1 -32.488,68.441 z"
+         class="cls-1"
+         id="path2" /></g></g></svg>


### PR DESCRIPTION
## Description of issue or feature:
The current icon of the charm is not well dimensioned, thus failing to be loaded by charmhub 

## Solution:
Add a well dimensioned and valid icon, as per the official template 

## How was this change tested?
- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
