### PR TITLE
test: remove pytest-operator's abort_on_fail marker

### DIFF
--- a/tests/integration/backup/test_restore_verification_failed.py
+++ b/tests/integration/backup/test_restore_verification_failed.py
@@ -4,7 +4,6 @@
 
 import logging
 
-import pytest
 from jubilant import Juju
 
 from literals import INTERNAL_USER, PEER_RELATION
@@ -31,7 +30,6 @@ TEST_VALUE = "42"
 backup_id = ""
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_and_configure(
     charm: str, juju_vm_model: Juju, storage_credentials, storage_config
 ) -> None:
@@ -61,7 +59,6 @@ def test_deploy_and_configure(
     )
 
 
-@pytest.mark.abort_on_fail
 def test_s3_integration(juju_vm_model: Juju, s3_bucket) -> None:
     """Integrate charm and s3-integrator."""
     juju_vm_model.integrate(APP_NAME, S3_INTEGRATOR)
@@ -79,7 +76,6 @@ def test_s3_integration(juju_vm_model: Juju, s3_bucket) -> None:
     assert s3_bucket.meta.client.head_bucket(Bucket=s3_bucket.name)
 
 
-@pytest.mark.abort_on_fail
 def test_create_backup(juju_vm_model: Juju) -> None:
     """Create a backup and upload to s3-storage."""
     global backup_id
@@ -127,7 +123,6 @@ def test_create_backup(juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_restore_verification_failed(juju_vm_model: Juju):
     """Restore a backup with invalid admin password."""
     logger.info("Configure admin credentials in etcd")

--- a/tests/integration/backup/test_s3_backup_restore.py
+++ b/tests/integration/backup/test_s3_backup_restore.py
@@ -4,7 +4,6 @@
 
 import logging
 
-import pytest
 from jubilant import Juju
 
 from literals import INTERNAL_USER
@@ -29,7 +28,6 @@ PASSWORD = "some-password"
 backup_id = ""
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_and_configure(
     charm: str, juju_vm_model: Juju, storage_credentials, storage_config
 ) -> None:
@@ -65,7 +63,6 @@ def test_deploy_and_configure(
     )
 
 
-@pytest.mark.abort_on_fail
 def test_s3_integration(juju_vm_model: Juju, s3_bucket) -> None:
     """Integrate charm and s3-integrator."""
     juju_vm_model.integrate(APP_NAME, S3_INTEGRATOR)
@@ -83,7 +80,6 @@ def test_s3_integration(juju_vm_model: Juju, s3_bucket) -> None:
     assert s3_bucket.meta.client.head_bucket(Bucket=s3_bucket.name)
 
 
-@pytest.mark.abort_on_fail
 def test_create_backup(juju_vm_model: Juju) -> None:
     """Create a backup and upload to s3-storage."""
     global backup_id
@@ -125,7 +121,6 @@ def test_create_backup(juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_restore_backup_on_same_cluster(juju_vm_model: Juju) -> None:
     """Restore a backup and check if data is recovered."""
     leader_unit = get_leader_unit_name(juju_vm_model, APP_NAME)
@@ -146,7 +141,6 @@ def test_restore_backup_on_same_cluster(juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_restore_backup_on_different_cluster(charm: str, juju_vm_model: Juju):
     """Restore a backup and check if data is recovered."""
     logger.info("Remove existing etcd cluster and deploy a new one.")

--- a/tests/integration/client_relations/test_client_relations.py
+++ b/tests/integration/client_relations/test_client_relations.py
@@ -91,7 +91,6 @@ def get_requirer_mtls_certificates(juju: Juju) -> list[str] | None:
     return None
 
 
-@pytest.mark.abort_on_fail
 @pytest.mark.parametrize(
     "data_interfaces_version",
     [pytest.param("0", marks=pytest.mark.v0), pytest.param("1", marks=pytest.mark.v1)],
@@ -122,7 +121,6 @@ def test_build_and_deploy(
     )
 
 
-@pytest.mark.abort_on_fail
 @pytest.mark.v0
 @pytest.mark.v1
 def test_relate_client_charm(juju_vm_model: Juju) -> None:
@@ -172,7 +170,6 @@ def test_relate_client_charm(juju_vm_model: Juju) -> None:
             assert mtls_cert in client_cas, f"mtls cert not in trusted CAs for {unit_name}"
 
 
-@pytest.mark.abort_on_fail
 @pytest.mark.v0
 @pytest.mark.v1
 def test_write_read_with_requirer(juju_vm_model: Juju) -> None:
@@ -204,7 +201,6 @@ def test_write_read_with_requirer(juju_vm_model: Juju) -> None:
         )
 
 
-@pytest.mark.abort_on_fail
 @pytest.mark.v0
 @pytest.mark.v1
 def test_update_mtls_cert(juju_vm_model: Juju) -> None:
@@ -241,7 +237,6 @@ def test_update_mtls_cert(juju_vm_model: Juju) -> None:
             )
 
 
-@pytest.mark.abort_on_fail
 @pytest.mark.v0
 @pytest.mark.v1
 def test_etcd_updates_ca(juju_vm_model: Juju) -> None:
@@ -284,7 +279,6 @@ def test_etcd_updates_ca(juju_vm_model: Juju) -> None:
             assert mtls_cert in client_cas, f"new mtls cert not in trusted CAs for {unit_name}"
 
 
-@pytest.mark.abort_on_fail
 @pytest.mark.v0
 @pytest.mark.v1
 def test_remove_client_relation(juju_vm_model: Juju) -> None:
@@ -341,7 +335,6 @@ def test_remove_client_relation(juju_vm_model: Juju) -> None:
             )
 
 
-@pytest.mark.abort_on_fail
 @pytest.mark.v0
 @pytest.mark.v1
 def test_different_tls_providers(juju_vm_model: Juju) -> None:
@@ -398,7 +391,6 @@ def test_different_tls_providers(juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 @pytest.mark.v0
 @pytest.mark.v1
 def test_certificate_transfer(juju_vm_model: Juju) -> None:
@@ -426,7 +418,6 @@ def test_certificate_transfer(juju_vm_model: Juju) -> None:
         assert ca_cert in client_cas, f"CA chain not in trusted CAs for {unit_name}"
 
 
-@pytest.mark.abort_on_fail
 @pytest.mark.v0
 @pytest.mark.v1
 def test_requirer_sends_ca(juju_vm_model: Juju) -> None:

--- a/tests/integration/ha/test_disaster_recovery.py
+++ b/tests/integration/ha/test_disaster_recovery.py
@@ -33,7 +33,6 @@ logger = logging.getLogger(__name__)
 NUM_UNITS = 5
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(charm: str, juju_vm_model: Juju) -> None:
     """Build and deploy the charm."""
     juju_vm_model.deploy(charm, num_units=NUM_UNITS)
@@ -48,7 +47,6 @@ def test_build_and_deploy(charm: str, juju_vm_model: Juju) -> None:
     start_continuous_writes(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.abort_on_fail
 def test_membership_reconfiguration_after_unit_loss(juju_vm_model: Juju) -> None:
     """Make sure a forcefully removed unit is removed as cluster member."""
     units = list(juju_vm_model.status().get_units(APP_NAME))
@@ -95,7 +93,6 @@ def test_membership_reconfiguration_after_unit_loss(juju_vm_model: Juju) -> None
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.abort_on_fail
 def test_rebuild_on_healthy_cluster(juju_vm_model: Juju) -> None:
     """Users can run `rebuild-cluster` on a healthy cluster if they use the `force` parameter."""
     wait_until_apps_active_and_agents_idle(juju_vm_model, APP_NAME, NUM_UNITS - 1)
@@ -130,7 +127,6 @@ def test_rebuild_on_healthy_cluster(juju_vm_model: Juju) -> None:
         logger.info(f"{unit_name} in cluster members")
 
 
-@pytest.mark.abort_on_fail
 def test_recover_from_majority_failure(juju_vm_model: Juju) -> None:
     """When the majority of the cluster is lost, users can run `rebuild-cluster`."""
     wait_until_apps_active_and_agents_idle(juju_vm_model, APP_NAME, NUM_UNITS - 1)

--- a/tests/integration/ha/test_failover.py
+++ b/tests/integration/ha/test_failover.py
@@ -5,7 +5,6 @@
 import logging
 import time
 
-import pytest
 from jubilant import Juju
 
 from literals import INTERNAL_USER, PEER_RELATION
@@ -42,7 +41,6 @@ TEST_KEY = "test_key"
 TEST_VALUE = "42"
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(charm: str, juju_vm_model: Juju) -> None:
     """Build and deploy the charm, allowing for skipping if already deployed."""
     # it is possible for users to provide their own cluster for HA testing.
@@ -56,7 +54,6 @@ def test_build_and_deploy(charm: str, juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_kill_db_process_on_raft_leader(etcd_process: str, juju_vm_model: Juju) -> None:
     """Make sure the cluster can self-heal when the leader goes down."""
     app = existing_app(juju_vm_model) or APP_NAME
@@ -143,7 +140,6 @@ def test_kill_db_process_on_raft_leader(etcd_process: str, juju_vm_model: Juju) 
     )
 
 
-@pytest.mark.abort_on_fail
 def test_freeze_db_process_on_raft_leader(etcd_process: str, juju_vm_model: Juju) -> None:
     """Make sure the cluster can self-heal when the leader stops."""
     app = existing_app(juju_vm_model) or APP_NAME
@@ -236,7 +232,6 @@ def test_freeze_db_process_on_raft_leader(etcd_process: str, juju_vm_model: Juju
     )
 
 
-@pytest.mark.abort_on_fail
 def test_restart_db_process_on_raft_leader(etcd_process: str, juju_vm_model: Juju) -> None:
     """Make sure the cluster can self-heal when the leader goes down."""
     app = existing_app(juju_vm_model) or APP_NAME
@@ -322,7 +317,6 @@ def test_restart_db_process_on_raft_leader(etcd_process: str, juju_vm_model: Juj
     )
 
 
-@pytest.mark.abort_on_fail
 def test_full_cluster_restart(etcd_process: str, juju_vm_model: Juju) -> None:
     """Make sure the cluster can self-heal after all members went down."""
     app = existing_app(juju_vm_model) or APP_NAME
@@ -391,7 +385,6 @@ def test_full_cluster_restart(etcd_process: str, juju_vm_model: Juju) -> None:
         patch_restart_delay(juju_vm_model, unit_name=unit, delay=RESTART_DELAY_DEFAULT)
 
 
-@pytest.mark.abort_on_fail
 def test_full_cluster_crash(etcd_process: str, juju_vm_model: Juju) -> None:
     """Make sure the cluster can self-heal after all members went down."""
     app = existing_app(juju_vm_model) or APP_NAME
@@ -460,7 +453,6 @@ def test_full_cluster_crash(etcd_process: str, juju_vm_model: Juju) -> None:
         patch_restart_delay(juju_vm_model, unit_name=unit, delay=RESTART_DELAY_DEFAULT)
 
 
-@pytest.mark.abort_on_fail
 def test_restart_raft_leader_after_deleting_database_file(
     etcd_process: str, juju_vm_model: Juju
 ) -> None:
@@ -552,7 +544,6 @@ def test_restart_raft_leader_after_deleting_database_file(
     )
 
 
-@pytest.mark.abort_on_fail
 def test_reboot_raft_leader(etcd_process: str, juju_vm_model: Juju) -> None:
     """Make sure a unit comes back cleanly after rebooting the VM."""
     app = existing_app(juju_vm_model) or APP_NAME

--- a/tests/integration/ha/test_ha_on_rolling_restart.py
+++ b/tests/integration/ha/test_ha_on_rolling_restart.py
@@ -4,7 +4,6 @@
 
 import logging
 
-import pytest
 from jubilant import Juju
 
 from literals import INTERNAL_USER, PEER_RELATION, TuningOptions
@@ -30,7 +29,6 @@ TLS_NAME = "self-signed-certificates"
 NUM_UNITS = 3
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_with_peer_tls(charm: str, juju_vm_model: Juju) -> None:
     """Deploy a cluster with three units and peer-certificates."""
     # Deploy the TLS charm
@@ -45,7 +43,6 @@ def test_deploy_with_peer_tls(charm: str, juju_vm_model: Juju) -> None:
     juju_vm_model.deploy(charm, num_units=NUM_UNITS)
 
 
-@pytest.mark.abort_on_fail
 def test_disable_and_enable_peer_tls(juju_vm_model: Juju) -> None:
     """Disable and enable peer TLS on a running cluster.
 
@@ -84,7 +81,6 @@ def test_disable_and_enable_peer_tls(juju_vm_model: Juju) -> None:
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.abort_on_fail
 def test_tuning_config_options(juju_vm_model: Juju) -> None:
     """Tune the network latency parameters in etcd and ensure the cluster is available."""
     app_name = existing_app(juju_vm_model) or APP_NAME
@@ -117,7 +113,6 @@ def test_tuning_config_options(juju_vm_model: Juju) -> None:
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.abort_on_fail
 def test_invalid_tuning_config_options(juju_vm_model: Juju) -> None:
     """Ensure the cluster keeps running with invalid tuning options."""
     app_name = existing_app(juju_vm_model) or APP_NAME

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -47,7 +47,6 @@ NUM_UNITS = 3
 TLS_NAME = "self-signed-certificates"
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(charm: str, juju_vm_model: Juju) -> None:
     """Build and deploy the charm, allowing for skipping if already deployed."""
     # it is possible for users to provide their own cluster for HA testing.
@@ -63,7 +62,6 @@ def test_build_and_deploy(charm: str, juju_vm_model: Juju) -> None:
 # command fails because of wrong kernel version
 # details see: https://warthogs.atlassian.net/browse/ISD-3026
 @pytest.mark.skip()
-@pytest.mark.abort_on_fail
 def test_network_cut_on_raft_leader_without_ip_change(juju_vm_model: Juju) -> None:
     """Make sure the cluster can self-heal and the unit reconfigures after network disconnect."""
     app = existing_app(juju_vm_model) or APP_NAME
@@ -173,7 +171,6 @@ def test_network_cut_on_raft_leader_without_ip_change(juju_vm_model: Juju) -> No
     )
 
 
-@pytest.mark.abort_on_fail
 def test_network_cut_on_raft_leader_with_ip_change(juju_vm_model: Juju) -> None:
     """Make sure the cluster can self-heal and the unit reconfigures after network disconnect."""
     app = existing_app(juju_vm_model) or APP_NAME
@@ -312,7 +309,6 @@ def test_network_cut_on_raft_leader_with_ip_change(juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_ip_change_with_client_tls(juju_vm_model: Juju) -> None:
     """Ensure TLS communication with the cluster works after an ip change."""
     app = existing_app(juju_vm_model) or APP_NAME

--- a/tests/integration/ha/test_scaling.py
+++ b/tests/integration/ha/test_scaling.py
@@ -5,7 +5,6 @@
 import logging
 import time
 
-import pytest
 from jubilant import Juju
 
 from literals import INTERNAL_USER, PEER_RELATION
@@ -30,7 +29,6 @@ from .helpers import (
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(charm: str, juju_vm_model: Juju) -> None:
     """Build and deploy the charm, allowing for skipping if already deployed."""
     # it is possible for users to provide their own cluster for HA testing.
@@ -46,7 +44,6 @@ def test_build_and_deploy(charm: str, juju_vm_model: Juju) -> None:
     assert len(juju_vm_model.status().get_units(APP_NAME)) == 1
 
 
-@pytest.mark.abort_on_fail
 def test_scale_up(juju_vm_model: Juju) -> None:
     """Make sure new units are added to the etcd cluster without downtime."""
     app = existing_app(juju_vm_model) or APP_NAME
@@ -83,7 +80,6 @@ def test_scale_up(juju_vm_model: Juju) -> None:
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.abort_on_fail
 def test_scale_down(juju_vm_model: Juju) -> None:
     """Make sure a unit is removed from the etcd cluster without downtime."""
     app = existing_app(juju_vm_model) or APP_NAME
@@ -121,7 +117,6 @@ def test_scale_down(juju_vm_model: Juju) -> None:
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.abort_on_fail
 def test_remove_raft_leader(juju_vm_model: Juju) -> None:
     """Make sure the etcd cluster is still available when the Raft leader is removed."""
     app = existing_app(juju_vm_model) or APP_NAME
@@ -186,7 +181,6 @@ def test_remove_raft_leader(juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_remove_multiple_units(juju_vm_model: Juju) -> None:
     """Make sure multiple units can be removed from the etcd cluster without downtime."""
     app = existing_app(juju_vm_model) or APP_NAME
@@ -222,7 +216,6 @@ def test_remove_multiple_units(juju_vm_model: Juju) -> None:
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.abort_on_fail
 def test_scale_to_zero_and_back(juju_vm_model: Juju) -> None:
     """Make sure that removing all units and then adding them again works."""
     app = existing_app(juju_vm_model) or APP_NAME
@@ -256,7 +249,6 @@ def test_scale_to_zero_and_back(juju_vm_model: Juju) -> None:
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.abort_on_fail
 def test_remove_juju_leader(juju_vm_model: Juju) -> None:
     """Make sure that removing the juju leader unit works."""
     app = existing_app(juju_vm_model) or APP_NAME
@@ -296,7 +288,6 @@ def test_remove_juju_leader(juju_vm_model: Juju) -> None:
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.abort_on_fail
 def test_remove_application(juju_vm_model: Juju) -> None:
     """Make sure removing the application works."""
     app = existing_app(juju_vm_model) or APP_NAME

--- a/tests/integration/ha/test_storage_reuse.py
+++ b/tests/integration/ha/test_storage_reuse.py
@@ -5,7 +5,6 @@
 import logging
 import time
 
-import pytest
 from jubilant import Juju
 
 from literals import INTERNAL_USER, PEER_RELATION
@@ -41,7 +40,6 @@ TEST_KEY = "test_key"
 TEST_VALUE = "42"
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(charm: str, juju_vm_model: Juju) -> None:
     """Deploy the charm with storage volume for data, allowing for skipping if already deployed."""
     # create storage to be used in this test
@@ -66,7 +64,6 @@ def test_build_and_deploy(charm: str, juju_vm_model: Juju) -> None:
     assert len(juju_vm_model.status().get_units(APP_NAME)) == NUM_UNITS
 
 
-@pytest.mark.abort_on_fail
 def test_attach_storage_after_scale_down(juju_vm_model: Juju) -> None:
     """Make sure storage can be re-attached after removing a unit."""
     # this test should only be executed with the app we deployed
@@ -128,7 +125,6 @@ def test_attach_storage_after_scale_down(juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_attach_storage_after_scale_to_zero(juju_vm_model: Juju) -> None:
     """Make sure storage can be re-attached after removing all units."""
     # this test should only be executed with the app we deployed
@@ -187,7 +183,6 @@ def test_attach_storage_after_scale_to_zero(juju_vm_model: Juju) -> None:
     assert_continuous_writes_consistent(endpoints=endpoints, user=INTERNAL_USER, password=password)
 
 
-@pytest.mark.abort_on_fail
 def test_attach_storage_after_removing_application(charm: str, juju_vm_model: Juju) -> None:
     """Make sure storage can be re-attached to a completely new etcd application."""
     # this test should only be executed with the app we deployed

--- a/tests/integration/ha/upgrades/test_stable_release_upgrade.py
+++ b/tests/integration/ha/upgrades/test_stable_release_upgrade.py
@@ -62,8 +62,7 @@ def test_deploy_stable_revision(juju_vm_model: Juju, requirer_charm: str) -> Non
     juju_vm_model.deploy(TLS_NAME, channel="1/stable", app=REQUIRER_TLS_NAME, config=tls_config)
 
     juju_vm_model.wait(
-        lambda status: are_apps_active_and_agents_idle(status, APP_NAME, unit_count=NUM_UNITS),
-        timeout=60,
+        lambda status: are_apps_active_and_agents_idle(status, APP_NAME, unit_count=NUM_UNITS)
     )
 
     logger.info("Enable TLS")

--- a/tests/integration/ha/upgrades/test_stable_release_upgrade.py
+++ b/tests/integration/ha/upgrades/test_stable_release_upgrade.py
@@ -33,7 +33,6 @@ def requirer_charm(arch: str) -> str:
     return f"./tests/integration/client_relations/requirer-charm/requirer-charm_ubuntu@24.04-{arch}.charm"
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_stable_revision(juju_vm_model: Juju, requirer_charm: str) -> None:
     """Deploy the charm with the first stable release, in a production-like setup."""
     logger.info("Create storage pool for persistent storage")
@@ -63,7 +62,8 @@ def test_deploy_stable_revision(juju_vm_model: Juju, requirer_charm: str) -> Non
     juju_vm_model.deploy(TLS_NAME, channel="1/stable", app=REQUIRER_TLS_NAME, config=tls_config)
 
     juju_vm_model.wait(
-        lambda status: are_apps_active_and_agents_idle(status, APP_NAME, unit_count=NUM_UNITS)
+        lambda status: are_apps_active_and_agents_idle(status, APP_NAME, unit_count=NUM_UNITS),
+        timeout=60,
     )
 
     logger.info("Enable TLS")
@@ -83,7 +83,6 @@ def test_deploy_stable_revision(juju_vm_model: Juju, requirer_charm: str) -> Non
     )
 
 
-@pytest.mark.abort_on_fail
 def test_upgrade_to_latest(charm: str, juju_vm_model: Juju) -> None:
     """Refresh the charm and upgrade etcd, ensuring high availability while upgrading."""
     # pre-refresh-check

--- a/tests/integration/ha/upgrades/test_upgrade_and_rollback.py
+++ b/tests/integration/ha/upgrades/test_upgrade_and_rollback.py
@@ -5,7 +5,6 @@
 import logging
 from platform import machine
 
-import pytest
 from jubilant import Juju
 
 from literals import INTERNAL_USER, PEER_RELATION
@@ -42,7 +41,6 @@ from tests.integration.helpers_deployment import (
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.abort_on_fail
 def test_deploy(juju_vm_model: Juju) -> None:
     """Deploy the charm with the previously released workload version of etcd."""
     juju_vm_model.deploy(
@@ -57,7 +55,6 @@ def test_deploy(juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_fail_upgrade_and_rollback(charm: str, juju_vm_model: Juju) -> None:
     """Run a refresh, fail and roll back."""
     endpoints = get_cluster_endpoints(juju_vm_model, APP_NAME)
@@ -161,7 +158,6 @@ def test_fail_upgrade_and_rollback(charm: str, juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_upgrade_to_local(charm: str, juju_vm_model: Juju) -> None:
     """Refresh the charm and upgrade etcd, ensuring high availability while upgrading."""
     juju_vm_model.wait(

--- a/tests/integration/ha/upgrades/test_upgrade_cluster_size_related_tests.py
+++ b/tests/integration/ha/upgrades/test_upgrade_cluster_size_related_tests.py
@@ -5,7 +5,6 @@
 import logging
 from platform import machine
 
-import pytest
 from jubilant import Juju
 
 from literals import INTERNAL_USER, PEER_RELATION
@@ -39,7 +38,6 @@ from tests.integration.helpers_deployment import (
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.abort_on_fail
 def test_upgrade_single_unit_cluster(charm: str, juju_vm_model: Juju) -> None:
     """Deploy one unit of etcd and upgrade it - without HA."""
     juju_vm_model.deploy(
@@ -98,7 +96,6 @@ def test_upgrade_single_unit_cluster(charm: str, juju_vm_model: Juju) -> None:
     juju_vm_model.wait(lambda status: not juju_vm_model.status().get_units(APP_NAME))
 
 
-@pytest.mark.abort_on_fail
 def test_scale_up_during_upgrade(charm: str, juju_vm_model: Juju) -> None:
     """Add a unit to an etcd cluster during an upgrade."""
     juju_vm_model.deploy(
@@ -180,7 +177,6 @@ def test_scale_up_during_upgrade(charm: str, juju_vm_model: Juju) -> None:
     juju_vm_model.wait(lambda status: not juju_vm_model.status().get_units(APP_NAME))
 
 
-@pytest.mark.abort_on_fail
 def test_scale_down_during_upgrade(charm: str, juju_vm_model: Juju) -> None:
     """Remove a unit from an etcd cluster during an upgrade."""
     juju_vm_model.deploy(

--- a/tests/integration/ha/upgrades/test_upgrade_edge_cases.py
+++ b/tests/integration/ha/upgrades/test_upgrade_edge_cases.py
@@ -6,7 +6,6 @@ import logging
 from platform import machine
 from time import sleep
 
-import pytest
 from jubilant import Juju
 
 from literals import INTERNAL_USER, PEER_RELATION, TLSType
@@ -54,7 +53,6 @@ from tests.integration.helpers_deployment import (
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.abort_on_fail
 def test_disaster_recovery_during_upgrade(charm: str, juju_vm_model: Juju) -> None:
     """Recover a failed cluster of two units during an upgrade."""
     juju_vm_model.deploy(
@@ -150,7 +148,6 @@ def test_disaster_recovery_during_upgrade(charm: str, juju_vm_model: Juju) -> No
     juju_vm_model.wait(lambda status: not juju_vm_model.status().get_units(APP_NAME))
 
 
-@pytest.mark.abort_on_fail
 def test_ip_address_change_during_upgrade(charm: str, juju_vm_model: Juju) -> None:
     """Process an updated ip address during an upgrade."""
     juju_vm_model.deploy(
@@ -284,7 +281,6 @@ def test_ip_address_change_during_upgrade(charm: str, juju_vm_model: Juju) -> No
     juju_vm_model.wait(lambda status: not juju_vm_model.status().get_units(APP_NAME))
 
 
-@pytest.mark.abort_on_fail
 def test_tls_cert_rotation_during_upgrade(charm: str, juju_vm_model: Juju) -> None:
     """Process new TLS certificates during an upgrade."""
     juju_vm_model.deploy(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,7 +5,6 @@ import json
 import logging
 
 import jubilant
-import pytest
 import requests
 from jubilant import Juju
 
@@ -41,7 +40,6 @@ TEST_VALUE = "42"
 ADMIN = "admin"
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(charm: str, juju_vm_model: Juju) -> None:
     """Build the charm-under-test and deploy it with three units.
 
@@ -72,7 +70,6 @@ def test_build_and_deploy(charm: str, juju_vm_model: Juju) -> None:
     assert get_key(endpoints, user=INTERNAL_USER, password=password, key=TEST_KEY) == TEST_VALUE
 
 
-@pytest.mark.abort_on_fail
 def test_authentication(juju_vm_model: Juju) -> None:
     """Assert authentication is enabled by default."""
     endpoints = get_cluster_endpoints(juju_vm_model, APP_NAME)
@@ -82,7 +79,6 @@ def test_authentication(juju_vm_model: Juju) -> None:
     assert put_key(endpoints, key=TEST_KEY, value=TEST_VALUE) != "OK"
 
 
-@pytest.mark.abort_on_fail
 def test_update_admin_password(juju_vm_model: Juju) -> None:
     """Assert the admin password is updated when adding a user secret to the config."""
     endpoints = get_cluster_endpoints(juju_vm_model, APP_NAME)
@@ -111,7 +107,6 @@ def test_update_admin_password(juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_user_secret_permissions(juju_vm_model: Juju) -> None:
     """If a user secret is not granted, ensure we can process updated permissions."""
     endpoints = get_cluster_endpoints(juju_vm_model, APP_NAME)
@@ -152,7 +147,6 @@ def test_user_secret_permissions(juju_vm_model: Juju) -> None:
     logger.info("Password update successful after secret was granted")
 
 
-@pytest.mark.abort_on_fail
 def test_etcd_metrics_endpoint(juju_vm_model: Juju):
     # direct metrics scrape
     leader_unit_ip = get_leader_unit_ip(juju_vm_model, app=APP_NAME)
@@ -163,7 +157,6 @@ def test_etcd_metrics_endpoint(juju_vm_model: Juju):
     assert len(text.splitlines()) > 50
 
 
-@pytest.mark.abort_on_fail
 def test_etcd_integration_with_grafana_agent(juju_vm_model: Juju):
     # deploy grafana-agent and integrate
     juju_vm_model.deploy(GRAFANA_AGENT_APP_NAME, channel=COS_CHANNEL)
@@ -187,7 +180,6 @@ def test_etcd_integration_with_grafana_agent(juju_vm_model: Juju):
     assert scrape_job["static_configs"][0]["targets"][0].endswith(f":{METRICS_PORT}")
 
 
-@pytest.mark.abort_on_fail
 def test_etcd_metrics_on_cos(juju_vm_model: Juju, juju_k8s_model: Juju, lxd_controller: str):
     # further, verify integration with cos-lite bundle.
     # Some charms in this bundle are only supported by amd64, so this test will be run only on this arch

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -4,7 +4,6 @@
 import logging
 import time
 
-import pytest
 from jubilant import Juju
 
 from literals import INTERNAL_USER, PEER_RELATION, TLSType
@@ -36,7 +35,6 @@ TEST_VALUE = "42"
 CERTIFICATE_EXPIRY_TIME = 90
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy_with_tls(charm: str, juju_vm_model: Juju) -> None:
     """Build the charm-under-test and deploy it with three units.
 
@@ -97,7 +95,6 @@ def test_build_and_deploy_with_tls(charm: str, juju_vm_model: Juju) -> None:
     ), "Failed to read key"
 
 
-@pytest.mark.abort_on_fail
 def test_ca_rotation_by_config_change(juju_vm_model: Juju) -> None:
     """Test the CA rotation.
 
@@ -227,7 +224,6 @@ def _prepare_units_for_ca_expiration_test(juju: Juju) -> None:
         )
 
 
-@pytest.mark.abort_on_fail
 def test_ca_rotation_by_expiration(juju_vm_model: Juju) -> None:
     """Test the CA rotation.
 

--- a/tests/integration/tls/test_private_key_rotation.py
+++ b/tests/integration/tls/test_private_key_rotation.py
@@ -42,7 +42,6 @@ TEST_VALUE = "42"
 TLSLIBID = "afd8c2bccf834997afce12c2706d2ede"
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy_with_tls(charm: str, juju_vm_model: Juju) -> None:
     """Build the charm-under-test and deploy it with three units.
 
@@ -64,7 +63,6 @@ def test_build_and_deploy_with_tls(charm: str, juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_tls_enabled(juju_vm_model: Juju) -> None:
     """Check if the TLS has been enabled on app startup."""
     # check if all units have been added to the cluster
@@ -112,7 +110,6 @@ def test_tls_enabled(juju_vm_model: Juju) -> None:
     ), "Failed to read key"
 
 
-@pytest.mark.abort_on_fail
 def test_set_private_key(juju_vm_model: Juju) -> None:
     """Set a new private key and check if the cluster is still accessible."""
     secret = get_secret_by_label(juju_vm_model, label=f"{PEER_RELATION}.{APP_NAME}.app")

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -6,7 +6,6 @@ import logging
 import subprocess
 from time import sleep
 
-import pytest
 from jubilant import Juju
 
 from literals import INTERNAL_USER, PEER_RELATION, TLSType
@@ -38,7 +37,6 @@ TEST_VALUE = "42"
 CERTIFICATE_EXPIRY_TIME = 250
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy_with_tls(charm: str, juju_vm_model: Juju) -> None:
     """Build the charm-under-test and deploy it with three units.
 
@@ -61,7 +59,6 @@ def test_build_and_deploy_with_tls(charm: str, juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_tls_enabled(juju_vm_model: Juju) -> None:
     """Check if the TLS has been enabled on app startup."""
     # check if all units have been added to the cluster
@@ -109,7 +106,6 @@ def test_tls_enabled(juju_vm_model: Juju) -> None:
     ), "Failed to read key"
 
 
-@pytest.mark.abort_on_fail
 def test_disable_tls(juju_vm_model: Juju) -> None:
     """Disable TLS on a running cluster and check if it is still accessible."""
     logger.info("Removing peer-certificates and client-certificates relations")
@@ -162,7 +158,6 @@ def test_disable_tls(juju_vm_model: Juju) -> None:
     ), "Failed to read new key"
 
 
-@pytest.mark.abort_on_fail
 def test_enable_tls(juju_vm_model: Juju) -> None:
     """Enable TLS on a running cluster and check if it is still accessible."""
     logger.info("Integrating peer-certificates and client-certificates relations")
@@ -222,7 +217,6 @@ def test_enable_tls(juju_vm_model: Juju) -> None:
     ), "Failed to read new key"
 
 
-@pytest.mark.abort_on_fail
 def test_extra_sans_config_option(juju_vm_model: Juju) -> None:
     """Configure extra sans for the TLS certificates."""
     juju_vm_model.wait(lambda status: are_apps_active_and_agents_idle(status, APP_NAME, TLS_NAME))
@@ -286,7 +280,6 @@ def test_extra_sans_config_option(juju_vm_model: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_disable_and_enable_peer_tls(juju_vm_model: Juju) -> None:
     """Disable then enable peer TLS on a running cluster and check if it is still accessible."""
     leader_unit = get_leader_unit_name(juju_vm_model, APP_NAME)
@@ -411,7 +404,6 @@ def test_disable_and_enable_peer_tls(juju_vm_model: Juju) -> None:
     ), "Failed to read new key"
 
 
-@pytest.mark.abort_on_fail
 def test_disable_and_enable_client_tls(juju_vm_model: Juju) -> None:
     """Disable then enable client TLS on a running cluster and check if it is still accessible."""
     leader_unit = get_leader_unit_name(juju_vm_model, APP_NAME)
@@ -535,7 +527,6 @@ def test_disable_and_enable_client_tls(juju_vm_model: Juju) -> None:
     ), "Failed to read new key"
 
 
-@pytest.mark.abort_on_fail
 def test_certificate_expiration(juju_vm_model: Juju) -> None:
     """Test the TLS certificate expiration on a running cluster."""
     # disable TLS and check if the cluster is still accessible

--- a/tests/integration/tls/test_vault_intermediate_ca.py
+++ b/tests/integration/tls/test_vault_intermediate_ca.py
@@ -9,7 +9,6 @@ import subprocess
 from pathlib import Path
 
 import jubilant
-import pytest
 from jubilant import Juju
 
 from literals import INTERNAL_USER, PEER_RELATION
@@ -45,7 +44,6 @@ def _install_dependencies() -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy_with_tls(charm: str, juju_vm_model: Juju) -> None:
     """Set up the TLS provider charms and etcd."""
     _install_dependencies()
@@ -71,7 +69,6 @@ def test_build_and_deploy_with_tls(charm: str, juju_vm_model: Juju) -> None:
     juju_vm_model.wait(lambda status: jubilant.all_blocked(status, VAULT_NAME))
 
 
-@pytest.mark.abort_on_fail
 def test_initialize_vault(juju_vm_model: Juju) -> None:
     """Initialize Vault and wait for it to be ready."""
     vault_units = juju_vm_model.status().get_units(VAULT_NAME)
@@ -169,7 +166,6 @@ def test_initialize_vault(juju_vm_model: Juju) -> None:
     juju_vm_model.wait(lambda status: are_apps_active_and_agents_idle(status, VAULT_NAME))
 
 
-@pytest.mark.abort_on_fail
 def test_tls_enabled(juju_vm_model: Juju) -> None:
     """Check if the TLS has been enabled on app startup."""
     logger.info("Integrating peer-certificates and client-certificates relations")
@@ -225,7 +221,6 @@ def test_tls_enabled(juju_vm_model: Juju) -> None:
     ), "Failed to read key"
 
 
-@pytest.mark.abort_on_fail
 def test_restrict_certificate_domain(juju_vm_model: Juju) -> None:
     """Restrict the allowed domains and request new certificates."""
     logger.info("Restrict allowed certificate domains in Vault")
@@ -255,7 +250,6 @@ def test_restrict_certificate_domain(juju_vm_model: Juju) -> None:
     logger.info("Certificates in etcd updated with new domain")
 
 
-@pytest.mark.abort_on_fail
 def test_invalid_certificate_domain(juju_vm_model: Juju) -> None:
     """Ensure no new certificates are requested if invalid domain is configured."""
     logger.info("Set config in etcd to invalid value")

--- a/tox.ini
+++ b/tox.ini
@@ -92,4 +92,4 @@ commands_pre =
 commands =
     # https://github.com/canonical/data-platform-workflows/blob/main/python/pytest_plugins/pytest_operator_cache/deprecation_notice.md
     sh -c "if [ -z "$CI" ]; then charmcraft pack; fi;"
-    poetry run pytest -v --tb native --log-cli-level=INFO -s -x --ignore={[vars]tests_path}/unit/ {posargs}
+    poetry run pytest -v --tb native --log-cli-level=INFO -s --maxfail=1 --ignore={[vars]tests_path}/unit/ {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -92,4 +92,4 @@ commands_pre =
 commands =
     # https://github.com/canonical/data-platform-workflows/blob/main/python/pytest_plugins/pytest_operator_cache/deprecation_notice.md
     sh -c "if [ -z "$CI" ]; then charmcraft pack; fi;"
-    poetry run pytest -v --tb native --log-cli-level=INFO -s --maxfail=1 --ignore={[vars]tests_path}/unit/ {posargs}
+    poetry run pytest -v --tb native --log-cli-level=INFO -s -x --ignore={[vars]tests_path}/unit/ {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -92,4 +92,4 @@ commands_pre =
 commands =
     # https://github.com/canonical/data-platform-workflows/blob/main/python/pytest_plugins/pytest_operator_cache/deprecation_notice.md
     sh -c "if [ -z "$CI" ]; then charmcraft pack; fi;"
-    poetry run pytest -v --tb native --log-cli-level=INFO -s --ignore={[vars]tests_path}/unit/ {posargs}
+    poetry run pytest -v --tb native --log-cli-level=INFO -s -x --ignore={[vars]tests_path}/unit/ {posargs}


### PR DESCRIPTION
## Description of issue or feature:
Following recommended practices outlined in [this](https://github.com/canonical/chArmIng-recipes/blob/main/integration-testing/commands/migrate-jubilant.md) guide for jubilant rewrite of integration tests, this PR removes `pytest-operator`'s `abort_on_fail` markers left behind. It introduces the `-x` (exit upon first failure) option to the pytest command instead.

## Solution:
<!--- Please describe in detail what the solution implemented in this PR is. The changes made etc. -->

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [x] Integration tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
