### PR TITLE
Install pylint and deps inside venv

### DIFF
--- a/.github/workflows/tics_run_sh_ghaction_test.yaml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yaml
@@ -5,7 +5,7 @@ name: TICS run self-hosted test (github-action)
 
 on:
   schedule:
-    - cron: '0 2 * * 6' # Every Saturday 2:00 AM UTC
+    - cron: "0 2 * * 6" # Every Saturday 2:00 AM UTC
   workflow_dispatch: # Allows manual triggering
 
 jobs:
@@ -35,7 +35,7 @@ jobs:
           python3 -m venv .venv
           . .venv/bin/activate
           poetry install --all-groups
-          pipx install pylint flake8
+          pip install flake8 poetry pylint pytest tox
           echo "PATH=$PATH" >> "$GITHUB_PATH"
 
       - name: Run tox tests to create coverage.xml


### PR DESCRIPTION
This pull request makes minor updates to the GitHub Actions workflow for running self-hosted tests. The changes improve the installation step for Python tools and update the cron syntax for scheduled runs.

Python environment setup:

* Replaced `pipx install pylint flake8` with `pip install flake8 poetry pylint pytest tox` to install all required tools directly with pip, simplifying the setup and ensuring all dependencies are available in the environment.

Workflow configuration:

* Changed the cron schedule syntax from single to double quotes for consistency and YAML compatibility.