### PR TITLE
fix: pin charmcraft to fix charm build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v32.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v42.1.0
 
   unit-test:
     name: Unit test charm
@@ -70,7 +70,7 @@ jobs:
           - .
           - tests/integration/client_relations/requirer-charm
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v32.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v42.1.0
     with:
       path-to-charm-directory: ${{ matrix.path }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v42.1.0
     with:
       path-to-charm-directory: ${{ matrix.path }}
+      charmcraft-snap-revisions: '{"amd64": "7517", "arm64": "7519"}'
 
   integration-test:
     name: Integration test charm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   tag:
     name: Create charm refresh compatibility version git tag
-    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v32.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v42.1.0
     with:
       track: 3.6
     permissions:
@@ -52,7 +52,7 @@ jobs:
     needs:
       - tag
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v32.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v42.1.0
     with:
       track: ${{ needs.tag.outputs.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}


### PR DESCRIPTION
## Description of issue or feature:
charmcraft 4.2 build is broken, see https://github.com/canonical/charmcraft/issues/2620

## Solution:
- update data-platform-workflows to newer versions
- pin charmcraft snap revisions to install

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [X] Integration tests
