### PR TITLE
Test with juju 4

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -119,7 +119,7 @@ path: /root/spread_project
 kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
-  CONCIERGE_JUJU_CHANNEL: 4/stable
+  CONCIERGE_JUJU_CHANNEL: 4.1/beta
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"

--- a/spread.yaml
+++ b/spread.yaml
@@ -119,7 +119,7 @@ path: /root/spread_project
 kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
-  CONCIERGE_JUJU_CHANNEL: 3.6/stable
+  CONCIERGE_JUJU_CHANNEL: 4/stable
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -145,6 +145,14 @@ def k8s_cloud(arch: str, lxd_controller: str, juju: Juju):
 
 @pytest.fixture(scope="module")
 def juju_vm_model(arch: str, lxd_cloud: str, lxd_controller: str, juju: Juju):
+    ssh_key_file = "id_rsa_jubilant"
+    subprocess.run(
+        ["ssh-keygen", "-t", "rsa", "-b", "4096", "-f", ssh_key_file, "-q", "-N", ""],
+        check=True,
+    )
+    with open(f"{ssh_key_file}.pub") as key_file:
+        ssh_key = key_file.read()
+
     # if concierge model ("testing") is found, such as on CI, continue with this. Else setup temp model.
     models = json.loads(juju.cli("models", "--format", "json", include_model=False))
     for model in models["models"]:
@@ -153,12 +161,14 @@ def juju_vm_model(arch: str, lxd_cloud: str, lxd_controller: str, juju: Juju):
                 model=f"{lxd_controller}:{CONCIERGE_MODEL_NAME}", wait_timeout=1000
             )
             juju_lxd.cli("set-model-constraints", f"arch={arch}")
+            juju_lxd.add_ssh_key(ssh_key)
             yield juju_lxd
             return
 
     with jubilant.temp_model(cloud=lxd_cloud, controller=lxd_controller) as juju_lxd:
         juju_lxd.wait_timeout = 1000
         juju_lxd.cli("set-model-constraints", f"arch={arch}")
+        juju_lxd.add_ssh_key(ssh_key)
         yield juju_lxd
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -34,6 +34,7 @@ LOKI_APP_NAME = "loki"
 PROMETHEUS_APP_NAME = "prometheus"
 GRAFANA_APP_NAME = "grafana"
 COS_RELATION_NAME = "cos-agent"
+SSH_KEY_FILE = "id_rsa_jubilant"
 
 
 class SecretNotFoundError(Exception):
@@ -308,7 +309,7 @@ def get_certificate_from_unit(
 ) -> str | None:
     """Retrieve a certificate from a unit."""
     command = f"cat {TLS_ROOT_DIR}/{cert_type.value}{'_ca' if is_ca else ''}.pem"
-    output = juju.ssh(target=unit, command=command)
+    output = juju.ssh(target=unit, command=command, ssh_options=['-i', SSH_KEY_FILE])
     if output.startswith("-----BEGIN CERTIFICATE-----"):
         return output
 
@@ -353,7 +354,7 @@ def download_client_certificate_from_unit(juju: Juju, app_name: str = APP_NAME) 
     tls_path = TLS_ROOT_DIR
 
     for file in ["client.pem", "client.key", "client_ca.pem"]:
-        juju.scp(f"{unit}:{tls_path}/{file}", file)
+        juju.scp(f"{unit}:{tls_path}/{file}", file, scp_options=['-i', SSH_KEY_FILE])
 
 
 def get_storage_id(juju: Juju, unit_name: str, storage_name: str) -> str | None:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -309,7 +309,7 @@ def get_certificate_from_unit(
 ) -> str | None:
     """Retrieve a certificate from a unit."""
     command = f"cat {TLS_ROOT_DIR}/{cert_type.value}{'_ca' if is_ca else ''}.pem"
-    output = juju.ssh(target=unit, command=command, ssh_options=['-i', SSH_KEY_FILE])
+    output = juju.ssh(target=unit, command=command, ssh_options=["-i", SSH_KEY_FILE])
     if output.startswith("-----BEGIN CERTIFICATE-----"):
         return output
 
@@ -354,7 +354,7 @@ def download_client_certificate_from_unit(juju: Juju, app_name: str = APP_NAME) 
     tls_path = TLS_ROOT_DIR
 
     for file in ["client.pem", "client.key", "client_ca.pem"]:
-        juju.scp(f"{unit}:{tls_path}/{file}", file, scp_options=['-i', SSH_KEY_FILE])
+        juju.scp(f"{unit}:{tls_path}/{file}", file, scp_options=["-i", SSH_KEY_FILE])
 
 
 def get_storage_id(juju: Juju, unit_name: str, storage_name: str) -> str | None:

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -222,7 +222,7 @@ def _prepare_units_for_ca_expiration_test(juju: Juju) -> None:
         juju.ssh(
             command=f"sudo sed -i 's|{search_expression}|{replace_expression}|' {file}",
             target=unit_name,
-            ssh_options=['-i', SSH_KEY_FILE],
+            ssh_options=["-i", SSH_KEY_FILE],
         )
 
 

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -33,6 +33,7 @@ NUM_UNITS = 3
 TEST_KEY = "test_key"
 TEST_VALUE = "42"
 CERTIFICATE_EXPIRY_TIME = 90
+SSH_KEY_FILE = "id_rsa_jubilant"
 
 
 def test_build_and_deploy_with_tls(charm: str, juju_vm_model: Juju) -> None:
@@ -221,6 +222,7 @@ def _prepare_units_for_ca_expiration_test(juju: Juju) -> None:
         juju.ssh(
             command=f"sudo sed -i 's|{search_expression}|{replace_expression}|' {file}",
             target=unit_name,
+            ssh_options=['-i', SSH_KEY_FILE],
         )
 
 

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -7,7 +7,6 @@ import subprocess
 from time import sleep
 
 from jubilant import Juju
-import pytest
 
 from literals import INTERNAL_USER, PEER_RELATION, TLSType
 from statuses import CharmStatuses, TLSStatuses

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -38,7 +38,6 @@ TEST_VALUE = "42"
 CERTIFICATE_EXPIRY_TIME = 250
 
 
-@pytest.mark.skip()
 def test_build_and_deploy_with_tls(charm: str, juju_vm_model: Juju) -> None:
     """Build the charm-under-test and deploy it with three units.
 

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -7,6 +7,7 @@ import subprocess
 from time import sleep
 
 from jubilant import Juju
+import pytest
 
 from literals import INTERNAL_USER, PEER_RELATION, TLSType
 from statuses import CharmStatuses, TLSStatuses
@@ -37,6 +38,7 @@ TEST_VALUE = "42"
 CERTIFICATE_EXPIRY_TIME = 250
 
 
+@pytest.mark.skip()
 def test_build_and_deploy_with_tls(charm: str, juju_vm_model: Juju) -> None:
     """Build the charm-under-test and deploy it with three units.
 


### PR DESCRIPTION
## Description of issue or feature:
The PR adds integration testing for Juju 4.

## Solution:
- Add integration test runs for Juju 4 to the existing runs for Juju 3
- Adjust integration test helpers to create a ssh key and use it for `ssh` and `scp` commands.

## How was this change tested?
- [X] Manually
- [ ] Unit tests
- [X] Integration tests